### PR TITLE
[#38] schedule 이벤트 생성 및 exclude로 인해 신규로 생성시에 event_tag_id 잘못저장하는 이슈 수정

### DIFF
--- a/functions/controllers/scheduleEventController.js
+++ b/functions/controllers/scheduleEventController.js
@@ -52,7 +52,7 @@ class ScheduleEventController {
         const payload = {
             userId: userId, 
             name: body.name, 
-            evnet_tag_id: body.evnet_tag_id, 
+            event_tag_id: body.event_tag_id, 
             event_time: body.event_time,
             repeating: body.repeating, 
             notification_options: body.notification_options, 
@@ -123,7 +123,7 @@ class ScheduleEventController {
         const payload = {
             userId: userId, 
             name: newPayload.name, 
-            evnet_tag_id: newPayload.evnet_tag_id, 
+            event_tag_id: newPayload.event_tag_id, 
             event_time: newPayload.event_time,
             repeating: newPayload.repeating, 
             notification_options: newPayload.notification_options, 


### PR DESCRIPTION
- 오타 수정: evnet_tag_id -> event_tag_id