### PR TITLE
[#54] 기본태그 설정 수정 버그 수정

### DIFF
--- a/functions/controllers/appSettingController.js
+++ b/functions/controllers/appSettingController.js
@@ -23,8 +23,8 @@ class AppSetingController {
     }
 
     async patchUserDefaultEventTagColors(req, res) {
-        const { body } = req.body, userId = req.auth.uid;
-        if(!userId || !body.holiday || !body.default) {
+        const body  = req.body, userId = req.auth.uid;
+        if(!userId || (!body.holiday && !body.default)) {
             throw new Errors.BadRequest('user id, holiday or default tag color is missing.')
         }
 

--- a/functions/repositories/appSettingRepository.js
+++ b/functions/repositories/appSettingRepository.js
@@ -10,7 +10,7 @@ class AppSettingRepository {
         try {
             const ref = collectionRef.doc(userId)
             const snapShot = await ref.get();
-            return snapShot.data()?.defaultEventTagColors ?? { }
+            return snapShot.data()?.defaultTagColor ?? { }
         } catch (error) {
             throw { status: 500, message: error?.message || error }
         }
@@ -21,7 +21,7 @@ class AppSettingRepository {
             const ref = collectionRef.doc(userId)
             await ref.set({ defaultTagColor: payload }, {merge: true})
             const updated = await ref.get();
-            return updated.data().defaultEventTagColors
+            return updated.data().defaultTagColor
         } catch (error) {
             throw { status: 500, message: error?.message || error }
         }

--- a/functions/services/appSettingService.js
+++ b/functions/services/appSettingService.js
@@ -9,20 +9,22 @@ class AppSettingService {
     async userDefaultEventTagColors(userId) {
         try {
             const color = await this.appSettingRepository.userDefaultEventTagColors(userId);
-            if(!color.holiday) {
-                color.holiday = "#D6236A"
-            }
-            if(!color.default) {
-                color.default = "#088CDA"
-            }
-            return color
+            return this.#addDefaultValueIfNotExists(color)
         } catch (error) {
             throw error
         }
     }
 
     async updateUserDefaultEventTagColors(userId, payload) {
-        return this.appSettingRepository.updateUserDefaultEventTagColors(userId, payload)
+        const updatedColor = await this.appSettingRepository.updateUserDefaultEventTagColors(userId, payload)
+        return this.#addDefaultValueIfNotExists(updatedColor)
+    }
+
+    #addDefaultValueIfNotExists(color) {
+        return {
+            holiday: color.holiday ?? "#D6236A", 
+            default: color.default ?? "#088CDA"
+        }
     }
 }
 

--- a/functions/test/appSettingService.test.js
+++ b/functions/test/appSettingService.test.js
@@ -11,9 +11,12 @@ describe('AppSettingService', () => {
     beforeEach(() => {
         stubSettingRepository = new StubRepos.ApPSetting();
         stubSettingRepository.stubUserSetting('existing_user', { 
-            defaultEventTagColors: { holiday: '#holiday_value', default: '#default_value' } 
+            defaultTagColor: { holiday: '#holiday_value', default: '#default_value' } 
         })
         stubSettingRepository.stubUserSetting('empty_setting_user', { })
+        stubSettingRepository.stubUserSetting('partial_setting_user', { 
+            defaultTagColor: { holiday: '#holiday_value' } 
+        })
         service = new AppSettingService(stubSettingRepository);
     })
 
@@ -22,6 +25,18 @@ describe('AppSettingService', () => {
         it('and user setting not exists, provide fallback values', async () => {
             const color = await service.userDefaultEventTagColors('not_exists_user');
             assert.equal(color.holiday, '#D6236A');
+            assert.equal(color.default, '#088CDA');
+        });
+
+        it('and user setting is null, provide fallback values', async () => {
+            const color = await service.userDefaultEventTagColors('null_setting_user');
+            assert.equal(color.holiday, '#D6236A');
+            assert.equal(color.default, '#088CDA');
+        });
+
+        it('and user setting parital exists, provide fallback value', async () => {
+            const color = await service.userDefaultEventTagColors('partial_setting_user');
+            assert.equal(color.holiday, '#holiday_value');
             assert.equal(color.default, '#088CDA');
         });
 
@@ -42,6 +57,77 @@ describe('AppSettingService', () => {
 
             try {
                 const color = await service.userDefaultEventTagColors('existing_user');
+                assert.equal(color == null, true);
+            } catch (error) {
+                assert.equal(error.message, 'failed');
+            }
+        });
+    })
+
+    describe.only('update color setting', () => {
+
+        // 없는데 일부만 저장 -> 저장된 값과, 디폴트값 반환
+        it('and parital update to setting not exists, return partial updated and default value', async () => {
+            const updated = await service.updateUserDefaultEventTagColors(
+                'not_exists_user', { holiday: '#new_holiday' }
+            )
+            assert.equal(updated.holiday, '#new_holiday');
+            assert.equal(updated.default, '#088CDA');
+        })
+
+        // 없는데 전체 저장 -> 전체 저장된값 반환
+        it('to setting not exists, return partial updated values', async () => {
+            const updated = await service.updateUserDefaultEventTagColors(
+                'not_exists_user', { holiday: '#new_holiday', default: '#new_default' }
+            )
+            assert.equal(updated.holiday, '#new_holiday');
+            assert.equal(updated.default, '#new_default');
+        })
+
+        // 일부만 있는데 일부만 저장 -> 변경된 값이랑, 디폴트값 반환
+        it('and parital update to partial setting exists, return partial updated and default value', async () => {
+            const updated = await service.updateUserDefaultEventTagColors(
+                'partial_setting_user', { holiday: '#new_holiday' }
+            )
+            assert.equal(updated.holiday, '#new_holiday');
+            assert.equal(updated.default, '#088CDA');
+        })
+
+        // 일부만 있는데 없던 일부만 저장 -> 있던 일부랑, 새로 저장한 일부값 반환
+        it('and other parital update to partial setting exists, return updated values', async () => {
+            const updated = await service.updateUserDefaultEventTagColors(
+                'partial_setting_user', { default: '#new_default' }
+            )
+            assert.equal(updated.holiday, '#holiday_value');
+            assert.equal(updated.default, '#new_default');
+        })
+
+        // 전체 있는데 일부만 저장 -> 변경된 값만 반환
+        it('with parital value, return only partial updated', async () => {
+            const updated = await service.updateUserDefaultEventTagColors(
+                'existing_user', { default: '#new_default' }
+            )
+            assert.equal(updated.holiday, '#holiday_value');
+            assert.equal(updated.default, '#new_default');
+        })
+
+        // 전체 있는데 전체 저장 -> 전체 변경된 값 반환
+        it('return updated values', async () => {
+            const updated = await service.updateUserDefaultEventTagColors(
+                'existing_user', { holiday: '#new_holiday', default: '#new_default' }
+            )
+            assert.equal(updated.holiday, '#new_holiday');
+            assert.equal(updated.default, '#new_default');
+        })
+
+        it('fail', async () => {
+            stubSettingRepository.shouldFail = true
+
+            try {
+                const color = await service.updateUserDefaultEventTagColors(
+                    'existing_user', 
+                    { holiday: "some", default: 'some' }
+                );
                 assert.equal(color == null, true);
             } catch (error) {
                 assert.equal(error.message, 'failed');

--- a/functions/test/stubs/stubRepositories.js
+++ b/functions/test/stubs/stubRepositories.js
@@ -575,7 +575,7 @@ class StubAppSettingRepository {
             throw { message: 'failed' }
         }
         const setting = this.userSettingMap.get(userId)
-        return setting?.defaultEventTagColors ?? {}
+        return setting?.defaultTagColor ?? {}
     }
 
     async updateUserDefaultEventTagColors(userId, payload) {
@@ -583,9 +583,10 @@ class StubAppSettingRepository {
             throw { message: 'failed' }
         }
         const setting = this.userSettingMap.get(userId) ?? {}
-        setting.defaultEventTagColors = payload
+        const newColorSetting = {...setting.defaultTagColor, ...payload}
+        setting.defaultTagColor = newColorSetting
         this.userSettingMap.set(userId, setting)
-        return setting
+        return setting.defaultTagColor
     }
 }
 


### PR DESCRIPTION
- 일부만 업데이트 가능하도록 수정
- 조회시, 수정이후 결과 조회시, 일부만 설정값이 존재하는 경우에는 디폴트값을 채우도록 수정