### PR TITLE
[#60] 반복 Schedule event 수정 - 분기시에 endCount가 존재하는 경우 endTime이 같이 저장될 수…

### DIFF
--- a/functions/services/scheduleEventService.js
+++ b/functions/services/scheduleEventService.js
@@ -70,8 +70,10 @@ class ScheduleEventService {
         if (!origin.repeating) {
             throw new Errors.Application({status: 400, message: 'origin event not repeating'});
         }
-        const updated = await this.scheduleEventRepository.updateEvent(
-            originEventId, { repeating: {...origin.repeating, end: endTime} }
+        origin.repeating.end = endTime
+        delete origin.repeating.end_count
+        const updated = await this.scheduleEventRepository.putEvent(
+            originEventId, origin
         )
         await this.#updateEventtime(userId, updated);
         const newEvent = await this.scheduleEventRepository.makeEvent(newPayload);


### PR DESCRIPTION
… 있는 부분 수정

- origin의 repeating end_count 필드를 먼저 삭제하고, put으로 저장