### PR TITLE
[#104] Phase 5: Todo/Schedule CRUD

### DIFF
--- a/docs/web/plans/2026-04-01-phase5-crud.md
+++ b/docs/web/plans/2026-04-01-phase5-crud.md
@@ -1,0 +1,2620 @@
+# Phase 5: Todo/Schedule CRUD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Todo/Schedule 생성·수정·삭제·완료 기능 구현 (반복 이벤트 6종 + 3-scope 범위 선택 포함)
+
+**Architecture:** 비반복 이벤트는 낙관적 업데이트(addEvent/removeEvent/replaceEvent), 반복 이벤트는 scope 선택 후 refreshCurrentRange() 재조회. 모든 폼은 React Router background location 오버레이 패턴.
+
+**Tech Stack:** React 19, TypeScript, Zustand, Tailwind CSS, Vitest, React Testing Library
+
+---
+
+## File Map
+
+### 수정
+- `web/src/utils/eventTimeUtils.ts` — `eventTimeOverlapsRange` export 추가
+- `web/src/stores/calendarEventsStore.ts` — lastRange 보존 + addEvent/removeEvent/replaceEvent/refreshCurrentRange
+- `web/src/stores/currentTodosStore.ts` — addTodo/removeTodo/replaceTodo
+- `web/src/stores/eventTagStore.ts` — createTag/updateTag/deleteTag
+- `web/src/components/DayEventList.tsx` — 아이템 편집 메뉴 + Todo 완료 체크박스
+- `web/src/components/CurrentTodoList.tsx` — Todo 완료 체크박스
+- `web/src/pages/EventDetailPage.tsx` — 수정 버튼
+- `web/src/pages/MainPage.tsx` — FAB + TypeSelectorPopup
+- `web/src/App.tsx` — 신규 라우트 5개
+
+### 신규
+- `web/src/components/ConfirmDialog.tsx`
+- `web/src/components/RepeatingScopeDialog.tsx`
+- `web/src/components/TypeSelectorPopup.tsx`
+- `web/src/components/EventTimePicker.tsx`
+- `web/src/components/RepeatingPicker.tsx`
+- `web/src/components/TagSelector.tsx`
+- `web/src/pages/TagManagementPage.tsx`
+- `web/src/pages/TodoFormPage.tsx`
+- `web/src/pages/ScheduleFormPage.tsx`
+
+### 테스트 (추가/신규)
+- `web/tests/stores/calendarEventsStore.test.ts` — mutation 테스트 추가
+- `web/tests/stores/currentTodosStore.test.ts` — 신규
+- `web/tests/stores/eventTagStore.test.ts` — CRUD 테스트 추가
+- `web/tests/components/ConfirmDialog.test.tsx`
+- `web/tests/components/RepeatingScopeDialog.test.tsx`
+- `web/tests/components/TypeSelectorPopup.test.tsx`
+- `web/tests/components/EventTimePicker.test.tsx`
+- `web/tests/components/RepeatingPicker.test.tsx`
+- `web/tests/components/TagSelector.test.tsx`
+- `web/tests/pages/TagManagementPage.test.tsx`
+- `web/tests/pages/TodoFormPage.test.tsx`
+- `web/tests/pages/ScheduleFormPage.test.tsx`
+
+---
+
+## Task 1: eventTimeUtils — eventTimeOverlapsRange export
+
+**Files:**
+- Modify: `web/src/utils/eventTimeUtils.ts`
+
+- [ ] **Step 1: Write failing test**
+
+`web/tests/utils/eventTimeUtils.test.ts` 파일 하단에 추가:
+
+```ts
+import { eventTimeOverlapsRange } from '../../src/utils/eventTimeUtils'
+
+describe('eventTimeOverlapsRange', () => {
+  it('at 이벤트가 범위 안에 있으면 true를 반환한다', () => {
+    const et: EventTime = { time_type: 'at', timestamp: 1000 }
+    expect(eventTimeOverlapsRange(et, 900, 1100)).toBe(true)
+  })
+
+  it('at 이벤트가 범위 밖에 있으면 false를 반환한다', () => {
+    const et: EventTime = { time_type: 'at', timestamp: 500 }
+    expect(eventTimeOverlapsRange(et, 900, 1100)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/utils/eventTimeUtils.test.ts
+```
+Expected: FAIL — `eventTimeOverlapsRange is not exported`
+
+- [ ] **Step 3: export 추가**
+
+`web/src/utils/eventTimeUtils.ts` 59번째 줄 `function eventTimeOverlapsRange` 앞에 `export` 추가:
+
+```ts
+export function eventTimeOverlapsRange(eventTime: EventTime, lower: number, upper: number): boolean {
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/utils/eventTimeUtils.test.ts
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/utils/eventTimeUtils.ts web/tests/utils/eventTimeUtils.test.ts
+git commit -m "[#104] Phase 5-1: eventTimeOverlapsRange export"
+```
+
+---
+
+## Task 2: calendarEventsStore — mutation 메서드
+
+**Files:**
+- Modify: `web/src/stores/calendarEventsStore.ts`
+- Modify: `web/tests/stores/calendarEventsStore.test.ts`
+
+- [ ] **Step 1: 테스트 추가** (`web/tests/stores/calendarEventsStore.test.ts` 하단에 추가)
+
+```ts
+// 2025-03-31 00:00:00 UTC+9 = 2025-03-30 15:00:00 UTC
+const AT_TIMESTAMP = 1743375600  // 2025-03-31 UTC
+
+describe('calendarEventsStore — mutation', () => {
+  beforeEach(() => {
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+    vi.clearAllMocks()
+  })
+
+  it('addEvent를 호출하면 해당 이벤트를 날짜별 목록에서 조회할 수 있다', async () => {
+    // given: 범위 fetch 후 lastRange가 저장됨
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(todoApi.getTodos).mockResolvedValue([])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([])
+    await useCalendarEventsStore.getState().fetchEventsForRange(1743292800, 1743465600)
+
+    // when: 새 todo 이벤트 추가
+    const newTodo = { uuid: 'new-1', name: '새 할 일', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } }
+    useCalendarEventsStore.getState().addEvent({ type: 'todo', event: newTodo })
+
+    // then: 해당 날짜에서 조회 가능
+    const events = useCalendarEventsStore.getState().eventsByDate.get(MARCH31_KEY)
+    expect(events?.some(e => e.event.uuid === 'new-1')).toBe(true)
+  })
+
+  it('removeEvent를 호출하면 해당 이벤트를 더 이상 조회할 수 없다', async () => {
+    // given: 이벤트가 있는 상태
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(todoApi.getTodos).mockResolvedValue([
+      { uuid: 'todo-1', name: 'Task', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } },
+    ])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([])
+    await useCalendarEventsStore.getState().fetchEventsForRange(1743292800, 1743465600)
+
+    // when: 이벤트 제거
+    useCalendarEventsStore.getState().removeEvent('todo-1')
+
+    // then: 해당 날짜에서 조회 불가
+    const events = useCalendarEventsStore.getState().eventsByDate.get(MARCH31_KEY) ?? []
+    expect(events.some(e => e.event.uuid === 'todo-1')).toBe(false)
+  })
+
+  it('replaceEvent를 호출하면 기존 이벤트가 새 이벤트로 교체된다', async () => {
+    // given: 이벤트가 있는 상태
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(todoApi.getTodos).mockResolvedValue([
+      { uuid: 'todo-1', name: '원래 이름', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } },
+    ])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([])
+    await useCalendarEventsStore.getState().fetchEventsForRange(1743292800, 1743465600)
+
+    // when: 이벤트 교체
+    const updated = { uuid: 'todo-1', name: '수정된 이름', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } }
+    useCalendarEventsStore.getState().replaceEvent('todo-1', { type: 'todo', event: updated })
+
+    // then: 새 이름으로 조회됨
+    const events = useCalendarEventsStore.getState().eventsByDate.get(MARCH31_KEY) ?? []
+    expect(events.find(e => e.event.uuid === 'todo-1')?.event.name).toBe('수정된 이름')
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/stores/calendarEventsStore.test.ts
+```
+Expected: FAIL
+
+- [ ] **Step 3: 스토어 구현**
+
+`web/src/stores/calendarEventsStore.ts` 전체 교체:
+
+```ts
+import { create } from 'zustand'
+import { todoApi } from '../api/todoApi'
+import { scheduleApi } from '../api/scheduleApi'
+import { groupEventsByDate, eventTimeOverlapsRange, eventTimeToStartDate, eventTimeToEndDate, formatDateKey } from '../utils/eventTimeUtils'
+import type { CalendarEvent } from '../utils/eventTimeUtils'
+
+interface CalendarEventsState {
+  eventsByDate: Map<string, CalendarEvent[]>
+  loading: boolean
+  lastRange: { lower: number; upper: number } | null
+  fetchEventsForRange: (lower: number, upper: number) => Promise<void>
+  refreshCurrentRange: () => Promise<void>
+  addEvent: (event: CalendarEvent) => void
+  removeEvent: (uuid: string) => void
+  replaceEvent: (uuid: string, next: CalendarEvent) => void
+}
+
+export const useCalendarEventsStore = create<CalendarEventsState>((set, get) => ({
+  eventsByDate: new Map(),
+  loading: false,
+  lastRange: null,
+
+  fetchEventsForRange: async (lower: number, upper: number) => {
+    set({ loading: true, eventsByDate: new Map(), lastRange: { lower, upper } })
+    try {
+      const [todos, schedules] = await Promise.all([
+        todoApi.getTodos(lower, upper),
+        scheduleApi.getSchedules(lower, upper),
+      ])
+      const eventsByDate = groupEventsByDate(todos, schedules, lower, upper)
+      set({ eventsByDate, loading: false })
+    } catch (e) {
+      console.warn('이벤트 로드 실패:', e)
+      set({ loading: false })
+    }
+  },
+
+  refreshCurrentRange: async () => {
+    const { lastRange, fetchEventsForRange } = get()
+    if (!lastRange) return
+    await fetchEventsForRange(lastRange.lower, lastRange.upper)
+  },
+
+  addEvent: (event: CalendarEvent) => {
+    const { eventsByDate, lastRange } = get()
+    if (!lastRange) return
+    const eventTime = event.type === 'todo'
+      ? (event.event.event_time ?? null)
+      : event.event.event_time
+    if (!eventTime) return
+
+    if (!eventTimeOverlapsRange(eventTime, lastRange.lower, lastRange.upper)) return
+
+    const updated = new Map(eventsByDate)
+    const start = eventTimeToStartDate(eventTime)
+    const end = eventTimeToEndDate(eventTime)
+    const cur = new Date(start)
+    cur.setHours(0, 0, 0, 0)
+    const endDay = new Date(end)
+    endDay.setHours(0, 0, 0, 0)
+    while (cur <= endDay) {
+      const key = formatDateKey(cur)
+      updated.set(key, [...(updated.get(key) ?? []), event])
+      cur.setDate(cur.getDate() + 1)
+    }
+    set({ eventsByDate: updated })
+  },
+
+  removeEvent: (uuid: string) => {
+    const { eventsByDate } = get()
+    const updated = new Map<string, CalendarEvent[]>()
+    for (const [key, events] of eventsByDate) {
+      const filtered = events.filter(e => e.event.uuid !== uuid)
+      if (filtered.length > 0) updated.set(key, filtered)
+    }
+    set({ eventsByDate: updated })
+  },
+
+  replaceEvent: (uuid: string, next: CalendarEvent) => {
+    const { eventsByDate } = get()
+    const updated = new Map<string, CalendarEvent[]>()
+    for (const [key, events] of eventsByDate) {
+      updated.set(key, events.map(e => e.event.uuid === uuid ? next : e))
+    }
+    set({ eventsByDate: updated })
+  },
+}))
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/stores/calendarEventsStore.test.ts
+```
+Expected: PASS (기존 3개 + 신규 3개)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/stores/calendarEventsStore.ts web/tests/stores/calendarEventsStore.test.ts
+git commit -m "[#104] Phase 5-2: calendarEventsStore — lastRange + mutation 메서드"
+```
+
+---
+
+## Task 3: currentTodosStore + eventTagStore — mutation 메서드
+
+**Files:**
+- Modify: `web/src/stores/currentTodosStore.ts`
+- Modify: `web/src/stores/eventTagStore.ts`
+- Create: `web/tests/stores/currentTodosStore.test.ts`
+- Modify: `web/tests/stores/eventTagStore.test.ts`
+
+- [ ] **Step 1: currentTodosStore 테스트 작성**
+
+`web/tests/stores/currentTodosStore.test.ts` 신규 생성:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
+
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: { getCurrentTodos: vi.fn() },
+}))
+
+const makeTodo = (uuid: string, name: string) => ({
+  uuid, name, is_current: true as const,
+})
+
+describe('useCurrentTodosStore', () => {
+  beforeEach(() => {
+    useCurrentTodosStore.setState({ todos: [] })
+    vi.clearAllMocks()
+  })
+
+  it('addTodo를 호출하면 todos 목록에서 해당 todo를 찾을 수 있다', () => {
+    // given: 빈 스토어
+    // when: todo 추가
+    useCurrentTodosStore.getState().addTodo(makeTodo('t1', '할 일') as any)
+    // then: 목록에서 조회 가능
+    expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(true)
+  })
+
+  it('removeTodo를 호출하면 해당 todo를 더 이상 목록에서 찾을 수 없다', () => {
+    // given: todo가 있는 상태
+    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '할 일') as any] })
+    // when: 제거
+    useCurrentTodosStore.getState().removeTodo('t1')
+    // then: 목록에 없음
+    expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(false)
+  })
+
+  it('replaceTodo를 호출하면 기존 todo가 새 데이터로 교체된다', () => {
+    // given: todo가 있는 상태
+    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '원래') as any] })
+    // when: 교체
+    useCurrentTodosStore.getState().replaceTodo(makeTodo('t1', '수정됨') as any)
+    // then: 새 이름으로 조회됨
+    expect(useCurrentTodosStore.getState().todos.find(t => t.uuid === 't1')?.name).toBe('수정됨')
+  })
+})
+```
+
+- [ ] **Step 2: eventTagStore.test.ts 상단 `vi.mock` 블록 업데이트**
+
+파일 상단의 기존 `vi.mock` 블록을 다음으로 교체 (CRUD 메서드 추가):
+
+```ts
+vi.mock('../../src/api/eventTagApi', () => ({
+  eventTagApi: {
+    getAllTags: vi.fn(),
+    createTag: vi.fn(),
+    updateTag: vi.fn(),
+    deleteTag: vi.fn(),
+  },
+}))
+```
+
+그 다음 파일 하단에 CRUD 테스트 추가:
+
+```ts
+describe('eventTagStore — CRUD', () => {
+  beforeEach(() => {
+    useEventTagStore.setState({ tags: new Map() })
+    vi.clearAllMocks()
+  })
+
+  it('createTag를 호출하면 생성된 태그를 ID로 조회할 수 있다', async () => {
+    // given: API가 새 태그를 반환
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi.createTag).mockResolvedValue({ uuid: 'tag-new', name: '업무', color_hex: '#ff0000' })
+    // when: 태그 생성
+    await useEventTagStore.getState().createTag('업무', '#ff0000')
+    // then: 태그 조회 가능
+    expect(useEventTagStore.getState().getColorForTagId('tag-new')).toBe('#ff0000')
+  })
+
+  it('updateTag를 호출하면 변경된 색상으로 조회된다', async () => {
+    // given: 태그가 있는 상태
+    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]) })
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi as any).updateTag = vi.fn().mockResolvedValue({ uuid: 'tag-1', name: '업무', color_hex: '#0000ff' })
+    // when: 색상 수정
+    await useEventTagStore.getState().updateTag('tag-1', { name: '업무', color_hex: '#0000ff' })
+    // then: 새 색상으로 조회됨
+    expect(useEventTagStore.getState().getColorForTagId('tag-1')).toBe('#0000ff')
+  })
+
+  it('deleteTag를 호출하면 해당 태그를 더 이상 조회할 수 없다', async () => {
+    // given: 태그가 있는 상태
+    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]) })
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi as any).deleteTag = vi.fn().mockResolvedValue({ status: 'ok' })
+    // when: 삭제
+    await useEventTagStore.getState().deleteTag('tag-1')
+    // then: 조회 불가
+    expect(useEventTagStore.getState().getColorForTagId('tag-1')).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/stores/currentTodosStore.test.ts tests/stores/eventTagStore.test.ts
+```
+Expected: FAIL
+
+- [ ] **Step 4: currentTodosStore 구현**
+
+`web/src/stores/currentTodosStore.ts` 전체 교체:
+
+```ts
+import { create } from 'zustand'
+import { todoApi } from '../api/todoApi'
+import type { Todo } from '../models'
+
+interface CurrentTodosState {
+  todos: Todo[]
+  fetch: () => Promise<void>
+  addTodo: (todo: Todo) => void
+  removeTodo: (uuid: string) => void
+  replaceTodo: (todo: Todo) => void
+}
+
+export const useCurrentTodosStore = create<CurrentTodosState>((set, get) => ({
+  todos: [],
+
+  fetch: async () => {
+    try {
+      const todos = await todoApi.getCurrentTodos()
+      set({ todos })
+    } catch (e) {
+      console.warn('Current todo 로드 실패:', e)
+    }
+  },
+
+  addTodo: (todo: Todo) => set(s => ({ todos: [...s.todos, todo] })),
+  removeTodo: (uuid: string) => set(s => ({ todos: s.todos.filter(t => t.uuid !== uuid) })),
+  replaceTodo: (todo: Todo) => set(s => ({ todos: s.todos.map(t => t.uuid === todo.uuid ? todo : t) })),
+}))
+```
+
+- [ ] **Step 5: eventTagStore 구현**
+
+`web/src/stores/eventTagStore.ts` 전체 교체:
+
+```ts
+import { create } from 'zustand'
+import { eventTagApi } from '../api/eventTagApi'
+import type { EventTag } from '../models'
+
+interface EventTagState {
+  tags: Map<string, EventTag>
+  fetchAll: () => Promise<void>
+  getColorForTagId: (id: string) => string | null | undefined
+  createTag: (name: string, color_hex?: string) => Promise<EventTag>
+  updateTag: (id: string, updates: { name?: string; color_hex?: string }) => Promise<EventTag>
+  deleteTag: (id: string) => Promise<void>
+}
+
+export const useEventTagStore = create<EventTagState>((set, get) => ({
+  tags: new Map(),
+
+  fetchAll: async () => {
+    try {
+      const list = await eventTagApi.getAllTags()
+      const map = new Map<string, EventTag>()
+      for (const tag of list) map.set(tag.uuid, tag)
+      set({ tags: map })
+    } catch (e) {
+      console.warn('태그 로드 실패:', e)
+    }
+  },
+
+  getColorForTagId: (id: string) => get().tags.get(id)?.color_hex,
+
+  createTag: async (name: string, color_hex?: string) => {
+    const tag = await eventTagApi.createTag({ name, color_hex })
+    set(s => { const tags = new Map(s.tags); tags.set(tag.uuid, tag); return { tags } })
+    return tag
+  },
+
+  updateTag: async (id: string, updates: { name?: string; color_hex?: string }) => {
+    const tag = await eventTagApi.updateTag(id, { name: updates.name ?? '', color_hex: updates.color_hex })
+    set(s => { const tags = new Map(s.tags); tags.set(tag.uuid, tag); return { tags } })
+    return tag
+  },
+
+  deleteTag: async (id: string) => {
+    await eventTagApi.deleteTag(id)
+    set(s => { const tags = new Map(s.tags); tags.delete(id); return { tags } })
+  },
+}))
+```
+
+- [ ] **Step 6: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/stores/currentTodosStore.test.ts tests/stores/eventTagStore.test.ts
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/stores/currentTodosStore.ts web/src/stores/eventTagStore.ts \
+  web/tests/stores/currentTodosStore.test.ts web/tests/stores/eventTagStore.test.ts
+git commit -m "[#104] Phase 5-3: currentTodosStore + eventTagStore mutation 메서드"
+```
+
+---
+
+## Task 4: 다이얼로그 컴포넌트 3종
+
+**Files:**
+- Create: `web/src/components/ConfirmDialog.tsx`
+- Create: `web/src/components/RepeatingScopeDialog.tsx`
+- Create: `web/src/components/TypeSelectorPopup.tsx`
+- Create: `web/tests/components/ConfirmDialog.test.tsx`
+- Create: `web/tests/components/RepeatingScopeDialog.test.tsx`
+- Create: `web/tests/components/TypeSelectorPopup.test.tsx`
+
+- [ ] **Step 1: ConfirmDialog 테스트**
+
+```ts
+// web/tests/components/ConfirmDialog.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConfirmDialog } from '../../src/components/ConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  it('제목과 메시지를 표시한다', () => {
+    render(<ConfirmDialog title="삭제 확인" message="정말 삭제할까요?" onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('삭제 확인')).toBeInTheDocument()
+    expect(screen.getByText('정말 삭제할까요?')).toBeInTheDocument()
+  })
+
+  it('확인 버튼을 클릭하면 onConfirm이 호출된다', async () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDialog title="삭제" message="삭제?" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('취소 버튼을 클릭하면 onCancel이 호출된다', async () => {
+    const onCancel = vi.fn()
+    render(<ConfirmDialog title="삭제" message="삭제?" onConfirm={vi.fn()} onCancel={onCancel} />)
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: RepeatingScopeDialog 테스트**
+
+```ts
+// web/tests/components/RepeatingScopeDialog.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RepeatingScopeDialog } from '../../src/components/RepeatingScopeDialog'
+
+describe('RepeatingScopeDialog', () => {
+  it('삭제 모드에서는 "반복 일정 삭제" 제목을 표시한다', () => {
+    render(<RepeatingScopeDialog mode="delete" onSelect={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('반복 일정 삭제')).toBeInTheDocument()
+  })
+
+  it('"이 이벤트만" 선택 시 scope "this"로 onSelect가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<RepeatingScopeDialog mode="delete" onSelect={onSelect} onCancel={vi.fn()} />)
+    await userEvent.click(screen.getByText('이 이벤트만'))
+    expect(onSelect).toHaveBeenCalledWith('this')
+  })
+
+  it('"모든 이벤트" 선택 시 scope "all"로 onSelect가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<RepeatingScopeDialog mode="edit" onSelect={onSelect} onCancel={vi.fn()} />)
+    await userEvent.click(screen.getByText('모든 이벤트'))
+    expect(onSelect).toHaveBeenCalledWith('all')
+  })
+})
+```
+
+- [ ] **Step 3: TypeSelectorPopup 테스트**
+
+```ts
+// web/tests/components/TypeSelectorPopup.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TypeSelectorPopup } from '../../src/components/TypeSelectorPopup'
+
+describe('TypeSelectorPopup', () => {
+  it('Todo와 Schedule 선택지를 표시한다', () => {
+    render(<TypeSelectorPopup onSelect={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByText('Todo')).toBeInTheDocument()
+    expect(screen.getByText('Schedule')).toBeInTheDocument()
+  })
+
+  it('Todo 클릭 시 onSelect("todo")가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<TypeSelectorPopup onSelect={onSelect} onClose={vi.fn()} />)
+    await userEvent.click(screen.getByText('Todo'))
+    expect(onSelect).toHaveBeenCalledWith('todo')
+  })
+
+  it('배경 클릭 시 onClose가 호출된다', async () => {
+    const onClose = vi.fn()
+    render(<TypeSelectorPopup onSelect={vi.fn()} onClose={onClose} />)
+    await userEvent.click(screen.getByTestId('popup-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 4: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/components/ConfirmDialog.test.tsx tests/components/RepeatingScopeDialog.test.tsx tests/components/TypeSelectorPopup.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 5: ConfirmDialog 구현**
+
+```tsx
+// web/src/components/ConfirmDialog.tsx
+interface ConfirmDialogProps {
+  title: string
+  message: string
+  confirmLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({ title, message, confirmLabel = '삭제', onConfirm, onCancel }: ConfirmDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="text-base font-semibold text-gray-900">{title}</h2>
+        <p className="mt-2 text-sm text-gray-600">{message}</p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100" onClick={onCancel}>
+            취소
+          </button>
+          <button className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700" onClick={onConfirm}>
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: RepeatingScopeDialog 구현**
+
+```tsx
+// web/src/components/RepeatingScopeDialog.tsx
+export type RepeatScope = 'this' | 'future' | 'all'
+
+interface RepeatingScopeDialogProps {
+  mode: 'edit' | 'delete'
+  onSelect: (scope: RepeatScope) => void
+  onCancel: () => void
+}
+
+export function RepeatingScopeDialog({ mode, onSelect, onCancel }: RepeatingScopeDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="text-base font-semibold text-gray-900">
+          {mode === 'delete' ? '반복 일정 삭제' : '반복 일정 수정'}
+        </h2>
+        <div className="mt-4 flex flex-col divide-y divide-gray-100">
+          {(['this', 'future', 'all'] as RepeatScope[]).map((scope) => (
+            <button
+              key={scope}
+              className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+              onClick={() => onSelect(scope)}
+            >
+              {scope === 'this' ? '이 이벤트만' : scope === 'future' ? '이 이벤트 및 이후 이벤트' : '모든 이벤트'}
+            </button>
+          ))}
+        </div>
+        <button className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100" onClick={onCancel}>
+          취소
+        </button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 7: TypeSelectorPopup 구현**
+
+```tsx
+// web/src/components/TypeSelectorPopup.tsx
+interface TypeSelectorPopupProps {
+  onSelect: (type: 'todo' | 'schedule') => void
+  onClose: () => void
+}
+
+export function TypeSelectorPopup({ onSelect, onClose }: TypeSelectorPopupProps) {
+  return (
+    <>
+      <div data-testid="popup-backdrop" className="fixed inset-0 z-40" onClick={onClose} />
+      <div className="fixed bottom-20 right-4 z-50 overflow-hidden rounded-xl bg-white shadow-xl">
+        <button className="flex w-full px-6 py-4 text-left text-sm font-medium hover:bg-gray-50" onClick={() => onSelect('todo')}>
+          Todo
+        </button>
+        <div className="border-t border-gray-100" />
+        <button className="flex w-full px-6 py-4 text-left text-sm font-medium hover:bg-gray-50" onClick={() => onSelect('schedule')}>
+          Schedule
+        </button>
+      </div>
+    </>
+  )
+}
+```
+
+- [ ] **Step 8: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/components/ConfirmDialog.test.tsx tests/components/RepeatingScopeDialog.test.tsx tests/components/TypeSelectorPopup.test.tsx
+```
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/components/ConfirmDialog.tsx web/src/components/RepeatingScopeDialog.tsx \
+  web/src/components/TypeSelectorPopup.tsx \
+  web/tests/components/ConfirmDialog.test.tsx web/tests/components/RepeatingScopeDialog.test.tsx \
+  web/tests/components/TypeSelectorPopup.test.tsx
+git commit -m "[#104] Phase 5-4: ConfirmDialog + RepeatingScopeDialog + TypeSelectorPopup"
+```
+
+---
+
+## Task 5: EventTimePicker
+
+**Files:**
+- Create: `web/src/components/EventTimePicker.tsx`
+- Create: `web/tests/components/EventTimePicker.test.tsx`
+
+날짜/시간 input 변환 헬퍼 (컴포넌트 내부에 정의):
+- `tsToDatetimeLocal(ts)` → `"YYYY-MM-DDTHH:mm"` (로컬 시간)
+- `datetimeLocalToTs(str)` → UTC timestamp
+- `tsToDateInput(ts)` → `"YYYY-MM-DD"` (로컬 날짜)
+- `dateInputToTs(str)` → UTC timestamp (로컬 자정)
+
+- [ ] **Step 1: 테스트 작성**
+
+```tsx
+// web/tests/components/EventTimePicker.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EventTimePicker } from '../../src/components/EventTimePicker'
+
+describe('EventTimePicker', () => {
+  it('required=false이면 "시간 없음" 옵션이 기본 선택된다', () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} required={false} />)
+    expect(screen.getByRole('radio', { name: '시간 없음' })).toBeChecked()
+  })
+
+  it('"at" 탭을 선택하면 단일 datetime 입력 필드가 표시된다', async () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('radio', { name: '특정 시각' }))
+    expect(screen.getByLabelText('시각')).toBeInTheDocument()
+  })
+
+  it('"period" 탭을 선택하면 시작/종료 datetime 필드가 표시된다', async () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('radio', { name: '기간' }))
+    expect(screen.getByLabelText('시작')).toBeInTheDocument()
+    expect(screen.getByLabelText('종료')).toBeInTheDocument()
+  })
+
+  it('"allday" 탭을 선택하면 날짜만 있는 시작/종료 필드가 표시된다', async () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('radio', { name: '종일' }))
+    expect(screen.getByLabelText('시작일')).toBeInTheDocument()
+    expect(screen.getByLabelText('종료일')).toBeInTheDocument()
+  })
+
+  it('기존 at 값이 있으면 해당 타입으로 초기화된다', () => {
+    const value = { time_type: 'at' as const, timestamp: 1743375600 }
+    render(<EventTimePicker value={value} onChange={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: '특정 시각' })).toBeChecked()
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/components/EventTimePicker.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// web/src/components/EventTimePicker.tsx
+import { useState } from 'react'
+import type { EventTime } from '../models'
+
+type TimeType = 'none' | 'at' | 'period' | 'allday'
+
+function tsToDatetimeLocal(ts: number): string {
+  const d = new Date(ts * 1000)
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`
+}
+
+function datetimeLocalToTs(v: string): number {
+  return Math.floor(new Date(v).getTime() / 1000)
+}
+
+function tsToDateInput(ts: number): string {
+  const d = new Date(ts * 1000)
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())}`
+}
+
+function dateInputToTs(v: string): number {
+  return Math.floor(new Date(v + 'T00:00:00').getTime() / 1000)
+}
+
+function localSecondsFromGmt(): number {
+  return -(new Date().getTimezoneOffset() * 60)
+}
+
+interface EventTimePickerProps {
+  value: EventTime | null
+  onChange: (value: EventTime | null) => void
+  required?: boolean
+}
+
+export function EventTimePicker({ value, onChange, required = false }: EventTimePickerProps) {
+  const initType = (): TimeType => {
+    if (!value) return required ? 'at' : 'none'
+    return value.time_type
+  }
+
+  const [type, setType] = useState<TimeType>(initType)
+
+  const now = Math.floor(Date.now() / 1000)
+
+  function handleTypeChange(t: TimeType) {
+    setType(t)
+    if (t === 'none') { onChange(null); return }
+    if (t === 'at') onChange({ time_type: 'at', timestamp: now })
+    else if (t === 'period') onChange({ time_type: 'period', period_start: now, period_end: now + 3600 })
+    else onChange({ time_type: 'allday', period_start: now, period_end: now, seconds_from_gmt: localSecondsFromGmt() })
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-3">
+        {!required && (
+          <label className="flex items-center gap-1 text-sm">
+            <input type="radio" name="time-type" checked={type === 'none'} onChange={() => handleTypeChange('none')} />
+            시간 없음
+          </label>
+        )}
+        <label className="flex items-center gap-1 text-sm">
+          <input type="radio" name="time-type" checked={type === 'at'} onChange={() => handleTypeChange('at')} />
+          특정 시각
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          <input type="radio" name="time-type" checked={type === 'period'} onChange={() => handleTypeChange('period')} />
+          기간
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          <input type="radio" name="time-type" checked={type === 'allday'} onChange={() => handleTypeChange('allday')} />
+          종일
+        </label>
+      </div>
+
+      {type === 'at' && value?.time_type === 'at' && (
+        <div>
+          <label className="block text-xs text-gray-500">시각</label>
+          <input
+            aria-label="시각"
+            type="datetime-local"
+            className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+            value={tsToDatetimeLocal(value.timestamp)}
+            onChange={e => onChange({ time_type: 'at', timestamp: datetimeLocalToTs(e.target.value) })}
+          />
+        </div>
+      )}
+
+      {type === 'period' && value?.time_type === 'period' && (
+        <div className="flex gap-3">
+          <div>
+            <label className="block text-xs text-gray-500">시작</label>
+            <input
+              aria-label="시작"
+              type="datetime-local"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDatetimeLocal(value.period_start)}
+              onChange={e => onChange({ ...value, period_start: datetimeLocalToTs(e.target.value) })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500">종료</label>
+            <input
+              aria-label="종료"
+              type="datetime-local"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDatetimeLocal(value.period_end)}
+              onChange={e => onChange({ ...value, period_end: datetimeLocalToTs(e.target.value) })}
+            />
+          </div>
+        </div>
+      )}
+
+      {type === 'allday' && value?.time_type === 'allday' && (
+        <div className="flex gap-3">
+          <div>
+            <label className="block text-xs text-gray-500">시작일</label>
+            <input
+              aria-label="시작일"
+              type="date"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDateInput(value.period_start + value.seconds_from_gmt)}
+              onChange={e => onChange({ ...value, period_start: dateInputToTs(e.target.value) - value.seconds_from_gmt })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500">종료일</label>
+            <input
+              aria-label="종료일"
+              type="date"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDateInput(value.period_end + value.seconds_from_gmt)}
+              onChange={e => onChange({ ...value, period_end: dateInputToTs(e.target.value) - value.seconds_from_gmt })}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/components/EventTimePicker.test.tsx
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/EventTimePicker.tsx web/tests/components/EventTimePicker.test.tsx
+git commit -m "[#104] Phase 5-5: EventTimePicker"
+```
+
+---
+
+## Task 6: RepeatingPicker
+
+**Files:**
+- Create: `web/src/components/RepeatingPicker.tsx`
+- Create: `web/tests/components/RepeatingPicker.test.tsx`
+
+- [ ] **Step 1: 테스트 작성**
+
+```tsx
+// web/tests/components/RepeatingPicker.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RepeatingPicker } from '../../src/components/RepeatingPicker'
+
+describe('RepeatingPicker', () => {
+  it('기본값은 반복 없음이다', () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    expect(screen.getByRole('checkbox', { name: '반복' })).not.toBeChecked()
+  })
+
+  it('반복 토글 ON 시 기본 타입 "매일" 옵션이 표시된다', async () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    expect(screen.getByRole('combobox', { name: '반복 유형' })).toBeInTheDocument()
+  })
+
+  it('"매주" 선택 시 요일 체크박스가 표시된다', async () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '반복 유형' }), 'every_week')
+    expect(screen.getByText('월')).toBeInTheDocument()
+  })
+
+  it('"매월" 선택 시 날짜/요일 선택 라디오가 표시된다', async () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '반복 유형' }), 'every_month')
+    expect(screen.getByRole('radio', { name: '날짜 지정' })).toBeInTheDocument()
+  })
+
+  it('기존 반복 값이 있으면 반복 토글이 ON 상태로 초기화된다', () => {
+    const value = { start: 1743375600, option: { optionType: 'every_day' as const, interval: 1 } }
+    render(<RepeatingPicker value={value} onChange={vi.fn()} startTimestamp={1743375600} />)
+    expect(screen.getByRole('checkbox', { name: '반복' })).toBeChecked()
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/components/RepeatingPicker.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// web/src/components/RepeatingPicker.tsx
+import { useState } from 'react'
+import type { Repeating, RepeatingOption } from '../models'
+
+const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+const DAYS = ['일', '월', '화', '수', '목', '금', '토']
+
+function defaultOption(type: string, startTs: number): RepeatingOption {
+  const d = new Date(startTs * 1000)
+  switch (type) {
+    case 'every_day': return { optionType: 'every_day', interval: 1 }
+    case 'every_week': return { optionType: 'every_week', interval: 1, dayOfWeek: [d.getDay()], timeZone: TZ }
+    case 'every_month': return { optionType: 'every_month', interval: 1, monthDaySelection: { days: [d.getDate()] }, timeZone: TZ }
+    case 'every_year': return { optionType: 'every_year', interval: 1, months: [d.getMonth()+1], weekOrdinals: [], dayOfWeek: [d.getDay()], timeZone: TZ }
+    case 'every_year_some_day': return { optionType: 'every_year_some_day', interval: 1, month: d.getMonth()+1, day: d.getDate(), timeZone: TZ }
+    case 'lunar_calendar_every_year': return { optionType: 'lunar_calendar_every_year', month: d.getMonth()+1, day: d.getDate(), timeZone: TZ }
+    default: return { optionType: 'every_day', interval: 1 }
+  }
+}
+
+interface RepeatingPickerProps {
+  value: Repeating | null
+  onChange: (value: Repeating | null) => void
+  startTimestamp: number
+}
+
+export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPickerProps) {
+  const [enabled, setEnabled] = useState(!!value)
+  const [option, setOption] = useState<RepeatingOption>(value?.option ?? defaultOption('every_day', startTimestamp))
+  const [endType, setEndType] = useState<'none' | 'date' | 'count'>('none')
+  const [endDate, setEndDate] = useState('')
+  const [endCount, setEndCount] = useState(10)
+  const [monthMode, setMonthMode] = useState<'days' | 'week'>('days')
+
+  function emit(opt: RepeatingOption) {
+    const end = endType === 'date' && endDate ? Math.floor(new Date(endDate + 'T00:00:00').getTime() / 1000) : undefined
+    const endCnt = endType === 'count' ? endCount : undefined
+    onChange({ start: startTimestamp, option: opt, end, end_count: endCnt })
+  }
+
+  function handleToggle() {
+    const next = !enabled
+    setEnabled(next)
+    if (!next) onChange(null)
+    else emit(option)
+  }
+
+  function handleTypeChange(type: string) {
+    const opt = defaultOption(type, startTimestamp)
+    setOption(opt)
+    emit(opt)
+  }
+
+  return (
+    <div className="space-y-3">
+      <label className="flex items-center gap-2 text-sm font-medium">
+        <input type="checkbox" aria-label="반복" checked={enabled} onChange={handleToggle} />
+        반복
+      </label>
+
+      {enabled && (
+        <div className="space-y-3 pl-4">
+          <div>
+            <label className="block text-xs text-gray-500">반복 유형</label>
+            <select
+              aria-label="반복 유형"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={option.optionType}
+              onChange={e => handleTypeChange(e.target.value)}
+            >
+              <option value="every_day">매일</option>
+              <option value="every_week">매주</option>
+              <option value="every_month">매월</option>
+              <option value="every_year">매년</option>
+              <option value="every_year_some_day">매년 (특정일)</option>
+              <option value="lunar_calendar_every_year">매년 (음력)</option>
+            </select>
+          </div>
+
+          {option.optionType !== 'lunar_calendar_every_year' && (
+            <div>
+              <label className="block text-xs text-gray-500">간격</label>
+              <input
+                type="number" min={1}
+                className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={'interval' in option ? option.interval : 1}
+                onChange={e => {
+                  const opt = { ...option, interval: Number(e.target.value) } as RepeatingOption
+                  setOption(opt); emit(opt)
+                }}
+              />
+            </div>
+          )}
+
+          {option.optionType === 'every_week' && (
+            <div>
+              <p className="text-xs text-gray-500">요일</p>
+              <div className="mt-1 flex gap-1">
+                {DAYS.map((d, i) => (
+                  <label key={i} className="flex flex-col items-center text-xs">
+                    <input
+                      type="checkbox"
+                      checked={option.dayOfWeek.includes(i)}
+                      onChange={() => {
+                        const days = option.dayOfWeek.includes(i)
+                          ? option.dayOfWeek.filter(x => x !== i)
+                          : [...option.dayOfWeek, i]
+                        const opt = { ...option, dayOfWeek: days }
+                        setOption(opt); emit(opt)
+                      }}
+                    />
+                    {d}
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {option.optionType === 'every_month' && (
+            <div className="space-y-2">
+              <div className="flex gap-4">
+                <label className="flex items-center gap-1 text-sm">
+                  <input type="radio" name="month-mode" checked={monthMode === 'days'} onChange={() => setMonthMode('days')} />
+                  날짜 지정
+                </label>
+                <label className="flex items-center gap-1 text-sm">
+                  <input type="radio" name="month-mode" checked={monthMode === 'week'} onChange={() => setMonthMode('week')} />
+                  요일 지정
+                </label>
+              </div>
+              {monthMode === 'days' && (
+                <div>
+                  <label className="block text-xs text-gray-500">날짜</label>
+                  <input
+                    type="number" min={1} max={31}
+                    className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                    value={'monthDaySelection' in option && 'days' in option.monthDaySelection ? option.monthDaySelection.days[0] : 1}
+                    onChange={e => {
+                      const opt = { ...option, monthDaySelection: { days: [Number(e.target.value)] } } as RepeatingOption
+                      setOption(opt); emit(opt)
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {(option.optionType === 'every_year_some_day' || option.optionType === 'lunar_calendar_every_year') && (
+            <div className="flex gap-3">
+              <div>
+                <label className="block text-xs text-gray-500">월</label>
+                <input
+                  type="number" min={1} max={12}
+                  className="mt-1 w-16 rounded border border-gray-300 px-2 py-1 text-sm"
+                  value={option.month}
+                  onChange={e => { const opt = { ...option, month: Number(e.target.value) } as RepeatingOption; setOption(opt); emit(opt) }}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500">일</label>
+                <input
+                  type="number" min={1} max={31}
+                  className="mt-1 w-16 rounded border border-gray-300 px-2 py-1 text-sm"
+                  value={option.day}
+                  onChange={e => { const opt = { ...option, day: Number(e.target.value) } as RepeatingOption; setOption(opt); emit(opt) }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* 종료 조건 */}
+          <div>
+            <label className="block text-xs text-gray-500">종료 조건</label>
+            <div className="mt-1 flex gap-3">
+              {(['none', 'date', 'count'] as const).map(t => (
+                <label key={t} className="flex items-center gap-1 text-sm">
+                  <input type="radio" name="end-type" checked={endType === t} onChange={() => setEndType(t)} />
+                  {t === 'none' ? '없음' : t === 'date' ? '날짜' : '횟수'}
+                </label>
+              ))}
+            </div>
+            {endType === 'date' && (
+              <input
+                type="date"
+                className="mt-2 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+              />
+            )}
+            {endType === 'count' && (
+              <input
+                type="number" min={1}
+                className="mt-2 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={endCount}
+                onChange={e => setEndCount(Number(e.target.value))}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/components/RepeatingPicker.test.tsx
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/RepeatingPicker.tsx web/tests/components/RepeatingPicker.test.tsx
+git commit -m "[#104] Phase 5-6: RepeatingPicker — 반복 설정 컴포넌트"
+```
+
+---
+
+## Task 7: TagSelector + TagManagementPage
+
+**Files:**
+- Create: `web/src/components/TagSelector.tsx`
+- Create: `web/src/pages/TagManagementPage.tsx`
+- Create: `web/tests/components/TagSelector.test.tsx`
+- Create: `web/tests/pages/TagManagementPage.test.tsx`
+
+- [ ] **Step 1: TagSelector 테스트**
+
+```tsx
+// web/tests/components/TagSelector.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { TagSelector } from '../../src/components/TagSelector'
+import { useEventTagStore } from '../../src/stores/eventTagStore'
+
+vi.mock('../../src/stores/eventTagStore', () => ({ useEventTagStore: vi.fn() }))
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function mockTags(tags: Array<{ uuid: string; name: string; color_hex?: string }>) {
+  vi.mocked(useEventTagStore).mockImplementation((sel: any) => sel({ tags: new Map(tags.map(t => [t.uuid, t])), getColorForTagId: (id: string) => tags.find(t => t.uuid === id)?.color_hex }))
+}
+
+describe('TagSelector', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('태그 목록을 표시한다', () => {
+    mockTags([{ uuid: 't1', name: '업무', color_hex: '#ff0000' }])
+    render(<MemoryRouter><TagSelector value={null} onChange={vi.fn()} /></MemoryRouter>)
+    expect(screen.getByText('업무')).toBeInTheDocument()
+  })
+
+  it('태그를 선택하면 onChange가 해당 uuid로 호출된다', async () => {
+    const onChange = vi.fn()
+    mockTags([{ uuid: 't1', name: '업무', color_hex: '#ff0000' }])
+    render(<MemoryRouter><TagSelector value={null} onChange={onChange} /></MemoryRouter>)
+    await userEvent.click(screen.getByText('업무'))
+    expect(onChange).toHaveBeenCalledWith('t1')
+  })
+
+  it('"태그 관리" 버튼 클릭 시 /tags로 이동한다', async () => {
+    mockTags([])
+    render(<MemoryRouter><TagSelector value={null} onChange={vi.fn()} /></MemoryRouter>)
+    await userEvent.click(screen.getByRole('button', { name: '태그 관리' }))
+    expect(mockNavigate).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: TagManagementPage 테스트**
+
+```tsx
+// web/tests/pages/TagManagementPage.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { TagManagementPage } from '../../src/pages/TagManagementPage'
+
+vi.mock('../../src/api/eventTagApi', () => ({
+  eventTagApi: {
+    getAllTags: vi.fn().mockResolvedValue([]),
+    createTag: vi.fn(),
+    updateTag: vi.fn(),
+    deleteTag: vi.fn(),
+  },
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function renderPage() {
+  return render(<MemoryRouter><TagManagementPage /></MemoryRouter>)
+}
+
+describe('TagManagementPage', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('"태그 관리" 제목을 표시한다', () => {
+    renderPage()
+    expect(screen.getByText('태그 관리')).toBeInTheDocument()
+  })
+
+  it('새 태그 이름 입력 후 추가하면 createTag API가 호출된다', async () => {
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi.createTag).mockResolvedValue({ uuid: 'new', name: '새 태그' })
+    renderPage()
+    await userEvent.type(screen.getByPlaceholderText('새 태그 이름'), '새 태그')
+    await userEvent.click(screen.getByRole('button', { name: '추가' }))
+    expect(eventTagApi.createTag).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/components/TagSelector.test.tsx tests/pages/TagManagementPage.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 4: TagSelector 구현**
+
+```tsx
+// web/src/components/TagSelector.tsx
+import { useNavigate, useLocation } from 'react-router-dom'
+import { useEventTagStore } from '../stores/eventTagStore'
+
+interface TagSelectorProps {
+  value: string | null | undefined
+  onChange: (tagId: string | null) => void
+}
+
+export function TagSelector({ value, onChange }: TagSelectorProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const tags = useEventTagStore(s => s.tags)
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        <button
+          className={`rounded-full border px-3 py-1 text-xs ${!value ? 'border-gray-700 bg-gray-700 text-white' : 'border-gray-300 text-gray-600'}`}
+          onClick={() => onChange(null)}
+        >
+          없음
+        </button>
+        {Array.from(tags.values()).map(tag => (
+          <button
+            key={tag.uuid}
+            className={`flex items-center gap-1 rounded-full border px-3 py-1 text-xs ${value === tag.uuid ? 'border-gray-700 font-semibold' : 'border-gray-300'}`}
+            onClick={() => onChange(tag.uuid)}
+          >
+            {tag.color_hex && <span className="h-2 w-2 rounded-full" style={{ backgroundColor: tag.color_hex }} />}
+            {tag.name}
+          </button>
+        ))}
+      </div>
+      <button
+        className="text-xs text-blue-500 hover:underline"
+        onClick={() => navigate('/tags', { state: { background: location } })}
+      >
+        태그 관리
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: TagManagementPage 구현**
+
+```tsx
+// web/src/pages/TagManagementPage.tsx
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useEventTagStore } from '../stores/eventTagStore'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import type { EventTag } from '../models'
+
+export function TagManagementPage() {
+  const navigate = useNavigate()
+  const { tags, createTag, updateTag, deleteTag } = useEventTagStore()
+  const [newName, setNewName] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editColor, setEditColor] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<EventTag | null>(null)
+
+  async function handleCreate() {
+    if (!newName.trim()) return
+    await createTag(newName.trim())
+    setNewName('')
+  }
+
+  async function handleUpdate(id: string) {
+    await updateTag(id, { name: editName, color_hex: editColor || undefined })
+    setEditingId(null)
+  }
+
+  function startEdit(tag: EventTag) {
+    setEditingId(tag.uuid)
+    setEditName(tag.name)
+    setEditColor(tag.color_hex ?? '')
+  }
+
+  return (
+    <div className="mx-auto max-w-sm px-4 py-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-lg font-bold">태그 관리</h1>
+        <button className="text-sm text-gray-500" onClick={() => navigate(-1)}>닫기</button>
+      </div>
+
+      {/* Create */}
+      <div className="mb-4 flex gap-2">
+        <input
+          className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm"
+          placeholder="새 태그 이름"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+        />
+        <button
+          className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          onClick={handleCreate}
+        >
+          추가
+        </button>
+      </div>
+
+      {/* List */}
+      <ul className="divide-y divide-gray-100">
+        {Array.from(tags.values()).map(tag => (
+          <li key={tag.uuid} className="py-3">
+            {editingId === tag.uuid ? (
+              <div className="flex gap-2">
+                <input className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm" value={editName} onChange={e => setEditName(e.target.value)} />
+                <input type="color" className="h-8 w-8 rounded border" value={editColor || '#000000'} onChange={e => setEditColor(e.target.value)} />
+                <button className="text-xs text-blue-500" onClick={() => handleUpdate(tag.uuid)}>저장</button>
+                <button className="text-xs text-gray-400" onClick={() => setEditingId(null)}>취소</button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  {tag.color_hex && <span className="h-3 w-3 rounded-full" style={{ backgroundColor: tag.color_hex }} />}
+                  <span className="text-sm">{tag.name}</span>
+                </div>
+                <div className="flex gap-2">
+                  <button className="text-xs text-gray-500" onClick={() => startEdit(tag)}>수정</button>
+                  <button className="text-xs text-red-500" onClick={() => setDeleteTarget(tag)}>삭제</button>
+                </div>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {deleteTarget && (
+        <ConfirmDialog
+          title="태그 삭제"
+          message={`"${deleteTarget.name}" 태그를 삭제할까요?`}
+          onConfirm={async () => { await deleteTag(deleteTarget.uuid); setDeleteTarget(null) }}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/components/TagSelector.test.tsx tests/pages/TagManagementPage.test.tsx
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/components/TagSelector.tsx web/src/pages/TagManagementPage.tsx \
+  web/tests/components/TagSelector.test.tsx web/tests/pages/TagManagementPage.test.tsx
+git commit -m "[#104] Phase 5-7: TagSelector + TagManagementPage"
+```
+
+---
+
+## Task 8: TodoFormPage
+
+**Files:**
+- Create: `web/src/pages/TodoFormPage.tsx`
+- Create: `web/tests/pages/TodoFormPage.test.tsx`
+
+**create 모드:** `/todos/new` (id param 없음). `selectedDate`를 uiStore에서 읽어 event_time 기본값으로 사용.
+**edit 모드:** `/todos/:id/edit`. mount 시 `todoApi.getTodo(id)` 호출, 폼 초기화.
+
+**CRUD 로직:**
+- 생성: `todoApi.createTodo` → 성공 시 `addEvent`(event_time 있을 때) + `addTodo`(is_current) → `navigate(-1)`
+- 수정: `todoApi.updateTodo` → 성공 시 `replaceEvent` + `replaceTodo` → `navigate(-1)`
+- 삭제(비반복): ConfirmDialog → `todoApi.deleteTodo` → `removeEvent` + `removeTodo` → `navigate(-1)`
+- 삭제(반복): ConfirmDialog → `todoApi.deleteTodo` (항상 전체 삭제) → `refreshCurrentRange` → `navigate(-1)`
+
+- [ ] **Step 1: 테스트 작성**
+
+```tsx
+// web/tests/pages/TodoFormPage.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { TodoFormPage } from '../../src/pages/TodoFormPage'
+import { useCalendarEventsStore } from '../../src/stores/calendarEventsStore'
+import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
+
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: {
+    getTodo: vi.fn(),
+    createTodo: vi.fn(),
+    updateTodo: vi.fn(),
+    deleteTodo: vi.fn(),
+  },
+}))
+vi.mock('../../src/stores/eventTagStore', () => ({ useEventTagStore: vi.fn() }))
+vi.mock('../../src/stores/uiStore', () => ({ useUiStore: vi.fn() }))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+import { useEventTagStore } from '../../src/stores/eventTagStore'
+import { useUiStore } from '../../src/stores/uiStore'
+
+function setupMocks() {
+  vi.mocked(useEventTagStore).mockImplementation((sel: any) => sel({ tags: new Map(), getColorForTagId: () => null }))
+  vi.mocked(useUiStore).mockImplementation((sel: any) => sel({ selectedDate: null }))
+}
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/todos/new']}>
+      <Routes><Route path="/todos/new" element={<TodoFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+function renderEdit(id: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/todos/${id}/edit`]}>
+      <Routes><Route path="/todos/:id/edit" element={<TodoFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('TodoFormPage — create', () => {
+  beforeEach(() => {
+    setupMocks()
+    vi.clearAllMocks()
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+    useCurrentTodosStore.setState({ todos: [] })
+  })
+
+  it('"새 Todo" 제목을 표시한다', () => {
+    renderCreate()
+    expect(screen.getByText('새 Todo')).toBeInTheDocument()
+  })
+
+  it('이름을 입력하고 저장하면 createTodo가 호출되고 화면을 닫는다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.createTodo).mockResolvedValue({ uuid: 'new-1', name: '테스트', is_current: false })
+    renderCreate()
+    await userEvent.type(screen.getByLabelText('이름'), '테스트')
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+  })
+
+  it('이름이 비어 있으면 저장 버튼을 클릭해도 API가 호출되지 않는다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    renderCreate()
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    expect(todoApi.createTodo).not.toHaveBeenCalled()
+  })
+})
+
+describe('TodoFormPage — edit', () => {
+  beforeEach(() => {
+    setupMocks()
+    vi.clearAllMocks()
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+    useCurrentTodosStore.setState({ todos: [] })
+  })
+
+  it('기존 todo를 불러와 이름 필드에 표시한다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.getTodo).mockResolvedValue({ uuid: 'todo-1', name: '기존 이름', is_current: false })
+    renderEdit('todo-1')
+    await waitFor(() => expect(screen.getByDisplayValue('기존 이름')).toBeInTheDocument())
+  })
+
+  it('삭제 버튼 클릭 시 확인 다이얼로그가 표시된다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.getTodo).mockResolvedValue({ uuid: 'todo-1', name: '할 일', is_current: false })
+    renderEdit('todo-1')
+    await waitFor(() => screen.getByRole('button', { name: '삭제' }))
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    expect(screen.getByText(/정말 삭제/)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/pages/TodoFormPage.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// web/src/pages/TodoFormPage.tsx
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { todoApi } from '../api/todoApi'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
+import { useCurrentTodosStore } from '../stores/currentTodosStore'
+import { useUiStore } from '../stores/uiStore'
+import { EventTimePicker } from '../components/EventTimePicker'
+import { RepeatingPicker } from '../components/RepeatingPicker'
+import { TagSelector } from '../components/TagSelector'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import type { Todo, EventTime, Repeating } from '../models'
+
+export function TodoFormPage() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const selectedDate = useUiStore(s => s.selectedDate)
+
+  const { addEvent, removeEvent, replaceEvent, refreshCurrentRange } = useCalendarEventsStore()
+  const { addTodo, removeTodo, replaceTodo } = useCurrentTodosStore()
+
+  const [loading, setLoading] = useState(!!id)
+  const [original, setOriginal] = useState<Todo | null>(null)
+  const [name, setName] = useState('')
+  const [tagId, setTagId] = useState<string | null>(null)
+  const [eventTime, setEventTime] = useState<EventTime | null>(() =>
+    selectedDate ? { time_type: 'at', timestamp: Math.floor(selectedDate.getTime() / 1000) } : null
+  )
+  const [repeating, setRepeating] = useState<Repeating | null>(null)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    todoApi.getTodo(id).then(todo => {
+      setOriginal(todo)
+      setName(todo.name)
+      setTagId(todo.event_tag_id ?? null)
+      setEventTime(todo.event_time ?? null)
+      setRepeating(todo.repeating ?? null)
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [id])
+
+  async function handleSave() {
+    if (!name.trim()) return
+    setSaving(true)
+    try {
+      if (id && original) {
+        const updated = await todoApi.updateTodo(id, { name: name.trim(), event_tag_id: tagId, event_time: eventTime, repeating })
+        replaceEvent(id, { type: 'todo', event: updated })
+        if (updated.is_current) replaceTodo(updated)
+      } else {
+        const created = await todoApi.createTodo({ name: name.trim(), event_tag_id: tagId ?? undefined, event_time: eventTime ?? undefined, repeating: repeating ?? undefined })
+        if (created.event_time) addEvent({ type: 'todo', event: created })
+        if (created.is_current) addTodo(created)
+      }
+      navigate(-1)
+    } catch (e) {
+      console.warn('저장 실패:', e)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!id) return
+    await todoApi.deleteTodo(id)
+    if (original?.repeating) {
+      await refreshCurrentRange()
+    } else {
+      removeEvent(id)
+      removeTodo(id)
+    }
+    navigate(-1)
+  }
+
+  if (loading) return <div className="flex min-h-screen items-center justify-center"><div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" /></div>
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-lg font-bold">{id ? 'Todo 수정' : '새 Todo'}</h1>
+        <button className="text-sm text-gray-500" onClick={() => navigate(-1)}>취소</button>
+      </div>
+
+      <div className="space-y-5 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">이름</label>
+          <input
+            aria-label="이름"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">태그</label>
+          <div className="mt-1"><TagSelector value={tagId} onChange={setTagId} /></div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">시간</label>
+          <div className="mt-1"><EventTimePicker value={eventTime} onChange={setEventTime} required={false} /></div>
+        </div>
+
+        {eventTime && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700">반복</label>
+            <div className="mt-1">
+              <RepeatingPicker
+                value={repeating}
+                onChange={setRepeating}
+                startTimestamp={eventTime.time_type === 'at' ? eventTime.timestamp : eventTime.period_start}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <button
+            className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            저장
+          </button>
+          {id && (
+            <button
+              className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50"
+              onClick={() => setShowConfirm(true)}
+            >
+              삭제
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showConfirm && (
+        <ConfirmDialog
+          title="Todo 삭제"
+          message={`"${name}" 을 정말 삭제할까요?${original?.repeating ? '\n반복 Todo는 전체 시리즈가 삭제됩니다.' : ''}`}
+          onConfirm={handleDelete}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/pages/TodoFormPage.test.tsx
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/TodoFormPage.tsx web/tests/pages/TodoFormPage.test.tsx
+git commit -m "[#104] Phase 5-8: TodoFormPage — Todo 생성/수정/삭제"
+```
+
+---
+
+## Task 9: ScheduleFormPage
+
+**Files:**
+- Create: `web/src/pages/ScheduleFormPage.tsx`
+- Create: `web/tests/pages/ScheduleFormPage.test.tsx`
+
+**반복 Schedule 수정/삭제 scope 처리:**
+
+| scope | 수정 | 삭제 |
+|-------|------|------|
+| `this` | `excludeRepeating(id, { exclude_repeatings: [...(schedule.exclude_repeatings ?? []), turn] })` + 단건 생성 | `excludeRepeating(id, { exclude_repeatings: [...(schedule.exclude_repeatings ?? []), turn] })` |
+| `future` | `updateSchedule(id, { repeating: { ...repeating, end: occStart - 1 } })` + 새 시리즈 생성 | `updateSchedule(id, { repeating: { ...repeating, end: occStart - 1 } })` |
+| `all` | `updateSchedule(id, body)` | `deleteSchedule(id)` |
+
+`turn` = `schedule.show_turns?.[0] ?? 0`
+`occStart` = `schedule.event_time.time_type === 'at' ? schedule.event_time.timestamp : schedule.event_time.period_start`
+
+범위 처리 후 → `refreshCurrentRange()`
+
+- [ ] **Step 1: 테스트 작성**
+
+```tsx
+// web/tests/pages/ScheduleFormPage.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { ScheduleFormPage } from '../../src/pages/ScheduleFormPage'
+import { useCalendarEventsStore } from '../../src/stores/calendarEventsStore'
+
+vi.mock('../../src/api/scheduleApi', () => ({
+  scheduleApi: {
+    getSchedule: vi.fn(),
+    createSchedule: vi.fn(),
+    updateSchedule: vi.fn(),
+    excludeRepeating: vi.fn(),
+    deleteSchedule: vi.fn(),
+  },
+}))
+vi.mock('../../src/stores/eventTagStore', () => ({ useEventTagStore: vi.fn() }))
+vi.mock('../../src/stores/uiStore', () => ({ useUiStore: vi.fn() }))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+import { useEventTagStore } from '../../src/stores/eventTagStore'
+import { useUiStore } from '../../src/stores/uiStore'
+
+function setupMocks() {
+  vi.mocked(useEventTagStore).mockImplementation((sel: any) => sel({ tags: new Map(), getColorForTagId: () => null }))
+  vi.mocked(useUiStore).mockImplementation((sel: any) => sel({ selectedDate: new Date('2025-03-31') }))
+}
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/schedules/new']}>
+      <Routes><Route path="/schedules/new" element={<ScheduleFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+function renderEdit(id: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/schedules/${id}/edit`]}>
+      <Routes><Route path="/schedules/:id/edit" element={<ScheduleFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('ScheduleFormPage — create', () => {
+  beforeEach(() => {
+    setupMocks()
+    vi.clearAllMocks()
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+  })
+
+  it('"새 Schedule" 제목을 표시한다', () => {
+    renderCreate()
+    expect(screen.getByText('새 Schedule')).toBeInTheDocument()
+  })
+
+  it('이름 입력 후 저장하면 createSchedule이 호출되고 화면을 닫는다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(scheduleApi.createSchedule).mockResolvedValue({
+      uuid: 'new-1', name: '회의', event_time: { time_type: 'at', timestamp: 1743375600 },
+    })
+    renderCreate()
+    await userEvent.type(screen.getByLabelText('이름'), '회의')
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+  })
+})
+
+describe('ScheduleFormPage — edit (반복)', () => {
+  const repeatingSch = {
+    uuid: 'sch-1',
+    name: '주간 미팅',
+    event_time: { time_type: 'at' as const, timestamp: 1743375600 },
+    repeating: { start: 1743375600, option: { optionType: 'every_week' as const, interval: 1, dayOfWeek: [1], timeZone: 'Asia/Seoul' } },
+    show_turns: [3],
+  }
+
+  beforeEach(() => {
+    setupMocks()
+    vi.clearAllMocks()
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: { lower: 0, upper: 9999999999 } })
+  })
+
+  it('반복 Schedule 수정 시 scope 선택 다이얼로그가 표시된다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(scheduleApi.getSchedule).mockResolvedValue(repeatingSch as any)
+    renderEdit('sch-1')
+    await waitFor(() => screen.getByDisplayValue('주간 미팅'))
+    await userEvent.type(screen.getByLabelText('이름'), ' 수정')
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    expect(screen.getByText('반복 일정 수정')).toBeInTheDocument()
+  })
+
+  it('반복 Schedule 삭제 시 scope 선택 다이얼로그가 표시된다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(scheduleApi.getSchedule).mockResolvedValue(repeatingSch as any)
+    renderEdit('sch-1')
+    await waitFor(() => screen.getByRole('button', { name: '삭제' }))
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    expect(screen.getByText('반복 일정 삭제')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/pages/ScheduleFormPage.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// web/src/pages/ScheduleFormPage.tsx
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { scheduleApi } from '../api/scheduleApi'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
+import { useUiStore } from '../stores/uiStore'
+import { EventTimePicker } from '../components/EventTimePicker'
+import { RepeatingPicker } from '../components/RepeatingPicker'
+import { TagSelector } from '../components/TagSelector'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import { RepeatingScopeDialog, type RepeatScope } from '../components/RepeatingScopeDialog'
+import type { Schedule, EventTime, Repeating } from '../models'
+
+export function ScheduleFormPage() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const selectedDate = useUiStore(s => s.selectedDate)
+
+  const { addEvent, removeEvent, replaceEvent, refreshCurrentRange } = useCalendarEventsStore()
+
+  const defaultEventTime = (): EventTime => {
+    const base = selectedDate ?? new Date()
+    return { time_type: 'at', timestamp: Math.floor(base.getTime() / 1000) }
+  }
+
+  const [loading, setLoading] = useState(!!id)
+  const [original, setOriginal] = useState<Schedule | null>(null)
+  const [name, setName] = useState('')
+  const [tagId, setTagId] = useState<string | null>(null)
+  const [eventTime, setEventTime] = useState<EventTime>(defaultEventTime)
+  const [repeating, setRepeating] = useState<Repeating | null>(null)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showSaveScope, setShowSaveScope] = useState(false)
+  const [showDeleteScope, setShowDeleteScope] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    scheduleApi.getSchedule(id).then(sch => {
+      setOriginal(sch)
+      setName(sch.name)
+      setTagId(sch.event_tag_id ?? null)
+      setEventTime(sch.event_time)
+      setRepeating(sch.repeating ?? null)
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [id])
+
+  function occurrenceStart(sch: Schedule): number {
+    const et = sch.event_time
+    return et.time_type === 'at' ? et.timestamp : et.period_start
+  }
+
+  async function applyCreate() {
+    const created = await scheduleApi.createSchedule({ name: name.trim(), event_tag_id: tagId ?? undefined, event_time: eventTime, repeating: repeating ?? undefined })
+    addEvent({ type: 'schedule', event: created })
+  }
+
+  async function applyUpdate(scope: RepeatScope) {
+    if (!id || !original) return
+    if (!original.repeating || scope === 'all') {
+      const updated = await scheduleApi.updateSchedule(id, { name: name.trim(), event_tag_id: tagId, event_time: eventTime, repeating: repeating ?? undefined })
+      replaceEvent(id, { type: 'schedule', event: updated })
+    } else if (scope === 'this') {
+      const turn = original.show_turns?.[0] ?? 0
+      await scheduleApi.excludeRepeating(id, { exclude_repeatings: [...(original.exclude_repeatings ?? []), turn] })
+      await scheduleApi.createSchedule({ name: name.trim(), event_tag_id: tagId ?? undefined, event_time: eventTime, repeating: undefined })
+      await refreshCurrentRange()
+    } else {
+      const cutoff = occurrenceStart(original) - 1
+      await scheduleApi.updateSchedule(id, { repeating: { ...original.repeating, end: cutoff } })
+      await scheduleApi.createSchedule({ name: name.trim(), event_tag_id: tagId ?? undefined, event_time: eventTime, repeating: repeating ?? undefined })
+      await refreshCurrentRange()
+    }
+  }
+
+  async function applyDelete(scope: RepeatScope) {
+    if (!id || !original) return
+    if (!original.repeating || scope === 'all') {
+      await scheduleApi.deleteSchedule(id)
+      removeEvent(id)
+    } else if (scope === 'this') {
+      const turn = original.show_turns?.[0] ?? 0
+      await scheduleApi.excludeRepeating(id, { exclude_repeatings: [...(original.exclude_repeatings ?? []), turn] })
+      await refreshCurrentRange()
+    } else {
+      const cutoff = occurrenceStart(original) - 1
+      await scheduleApi.updateSchedule(id, { repeating: { ...original.repeating, end: cutoff } })
+      await refreshCurrentRange()
+    }
+    navigate(-1)
+  }
+
+  async function handleSave() {
+    if (!name.trim()) return
+    if (id && original?.repeating) { setShowSaveScope(true); return }
+    setSaving(true)
+    try {
+      if (id) await applyUpdate('all')
+      else await applyCreate()
+      navigate(-1)
+    } catch (e) { console.warn('저장 실패:', e) }
+    finally { setSaving(false) }
+  }
+
+  async function handleSaveWithScope(scope: RepeatScope) {
+    setShowSaveScope(false)
+    setSaving(true)
+    try { await applyUpdate(scope); navigate(-1) }
+    catch (e) { console.warn('저장 실패:', e) }
+    finally { setSaving(false) }
+  }
+
+  if (loading) return <div className="flex min-h-screen items-center justify-center"><div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" /></div>
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-lg font-bold">{id ? 'Schedule 수정' : '새 Schedule'}</h1>
+        <button className="text-sm text-gray-500" onClick={() => navigate(-1)}>취소</button>
+      </div>
+
+      <div className="space-y-5 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">이름</label>
+          <input aria-label="이름" className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm" value={name} onChange={e => setName(e.target.value)} />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">태그</label>
+          <div className="mt-1"><TagSelector value={tagId} onChange={setTagId} /></div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">시간</label>
+          <div className="mt-1"><EventTimePicker value={eventTime} onChange={v => v && setEventTime(v)} required={true} /></div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">반복</label>
+          <div className="mt-1">
+            <RepeatingPicker
+              value={repeating}
+              onChange={setRepeating}
+              startTimestamp={eventTime.time_type === 'at' ? eventTime.timestamp : eventTime.period_start}
+            />
+          </div>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50" onClick={handleSave} disabled={saving}>
+            저장
+          </button>
+          {id && (
+            <button className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50" onClick={() => original?.repeating ? setShowDeleteScope(true) : setShowDeleteConfirm(true)}>
+              삭제
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showDeleteConfirm && (
+        <ConfirmDialog title="Schedule 삭제" message={`"${name}"을 삭제할까요?`}
+          onConfirm={async () => { setShowDeleteConfirm(false); await applyDelete('all') }}
+          onCancel={() => setShowDeleteConfirm(false)} />
+      )}
+      {showSaveScope && (
+        <RepeatingScopeDialog mode="edit" onSelect={handleSaveWithScope} onCancel={() => setShowSaveScope(false)} />
+      )}
+      {showDeleteScope && (
+        <RepeatingScopeDialog mode="delete" onSelect={async scope => { setShowDeleteScope(false); await applyDelete(scope) }} onCancel={() => setShowDeleteScope(false)} />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/pages/ScheduleFormPage.test.tsx
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/ScheduleFormPage.tsx web/tests/pages/ScheduleFormPage.test.tsx
+git commit -m "[#104] Phase 5-9: ScheduleFormPage — Schedule 생성/수정/삭제 + scope 선택"
+```
+
+---
+
+## Task 10: DayEventList 편집 메뉴 + EventDetailPage 버튼 + MainPage FAB + App 라우팅
+
+**Files:**
+- Modify: `web/src/components/DayEventList.tsx`
+- Modify: `web/src/pages/EventDetailPage.tsx`
+- Modify: `web/src/pages/MainPage.tsx`
+- Modify: `web/src/App.tsx`
+- Modify: `web/tests/components/DayEventList.test.tsx`
+
+- [ ] **Step 1: DayEventList 테스트 추가** (기존 `web/tests/components/DayEventList.test.tsx` 하단에 추가)
+
+```tsx
+describe('DayEventList — 편집 메뉴', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEventTagStore()
+  })
+
+  it('이벤트 아이템에 "···" 메뉴 버튼이 표시된다', () => {
+    const todo = { uuid: 't1', name: '할 일', is_current: false, event_time: null }
+    mockCalendarEventsStore(new Map([['2024-03-15', [{ type: 'todo' as const, event: todo }]]]))
+    renderComponent(new Date(2024, 2, 15))
+    expect(screen.getByRole('button', { name: '메뉴' })).toBeInTheDocument()
+  })
+
+  it('"···" 메뉴 클릭 시 수정/삭제 옵션이 표시된다', async () => {
+    const todo = { uuid: 't1', name: '할 일', is_current: false, event_time: null }
+    mockCalendarEventsStore(new Map([['2024-03-15', [{ type: 'todo' as const, event: todo }]]]))
+    renderComponent(new Date(2024, 2, 15))
+    await userEvent.click(screen.getByRole('button', { name: '메뉴' }))
+    expect(screen.getByText('수정')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/components/DayEventList.test.tsx
+```
+Expected: FAIL (새 테스트)
+
+- [ ] **Step 3: DayEventList 수정**
+
+`web/src/components/DayEventList.tsx`의 `EventItem` 컴포넌트를 다음으로 교체:
+
+```tsx
+function EventItem({ calEvent, onNavigate }: { calEvent: CalendarEvent; onNavigate: () => void }) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  const { uuid, name, event_tag_id, event_time } = calEvent.type === 'todo'
+    ? { ...calEvent.event, event_time: calEvent.event.event_time ?? undefined }
+    : { ...calEvent.event, event_time: calEvent.event.event_time }
+
+  const color = event_tag_id ? (getColorForTagId(event_tag_id) ?? '#9ca3af') : '#9ca3af'
+  const editPath = calEvent.type === 'todo' ? `/todos/${uuid}/edit` : `/schedules/${uuid}/edit`
+
+  return (
+    <div className="relative flex w-full items-start gap-3 rounded-lg px-3 py-2 hover:bg-gray-50">
+      <button className="flex flex-1 items-start gap-3 text-left" onClick={onNavigate}>
+        <span className="mt-1 h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-gray-900">{name}</p>
+          {event_time && <p className="text-xs text-gray-500"><EventTimeDisplay eventTime={event_time} /></p>}
+        </div>
+      </button>
+      <button
+        aria-label="메뉴"
+        className="shrink-0 rounded p-1 text-gray-400 hover:bg-gray-100"
+        onClick={e => { e.stopPropagation(); setMenuOpen(o => !o) }}
+      >
+        ···
+      </button>
+      {menuOpen && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+          <div className="absolute right-0 top-8 z-20 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+            <button
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-50"
+              onClick={() => { setMenuOpen(false); navigate(editPath, { state: { background: location } }) }}
+            >
+              수정
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+```
+
+`import { useState } from 'react'`를 DayEventList.tsx 상단에 추가.
+
+- [ ] **Step 4: EventDetailPage 수정 버튼 추가**
+
+`web/src/pages/EventDetailPage.tsx`에서 뒤로 버튼 옆에 수정 버튼 추가. `navigate` 및 `location` import가 이미 있음.
+
+뒤로 버튼 블록을 다음으로 교체:
+
+```tsx
+      <div className="mb-4 flex items-center justify-between">
+        <button
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+          onClick={() => navigate(-1)}
+        >
+          ← 뒤로
+        </button>
+        {event && (
+          <button
+            className="text-sm text-blue-500 hover:text-blue-700"
+            onClick={() => {
+              const eventType = (location.state as { eventType?: string } | null)?.eventType
+              const path = eventType === 'schedule' ? `/schedules/${id}/edit` : `/todos/${id}/edit`
+              navigate(path, { state: { background: location } })
+            }}
+          >
+            수정
+          </button>
+        )}
+      </div>
+```
+
+- [ ] **Step 5: MainPage FAB 추가**
+
+`web/src/pages/MainPage.tsx` 전체 교체:
+
+```tsx
+import { useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import MonthCalendar from '../calendar/MonthCalendar'
+import { DayEventList } from '../components/DayEventList'
+import { CurrentTodoList } from '../components/CurrentTodoList'
+import { ForemostEventBanner } from '../components/ForemostEventBanner'
+import { TypeSelectorPopup } from '../components/TypeSelectorPopup'
+import { useUiStore } from '../stores/uiStore'
+import { useForemostEventStore } from '../stores/foremostEventStore'
+
+export function MainPage() {
+  const selectedDate = useUiStore(s => s.selectedDate)
+  const foremostEvent = useForemostEventStore(s => s.foremostEvent)
+  const [showTypeSelector, setShowTypeSelector] = useState(false)
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  function handleTypeSelect(type: 'todo' | 'schedule') {
+    setShowTypeSelector(false)
+    navigate(type === 'todo' ? '/todos/new' : '/schedules/new', { state: { background: location } })
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-50 md:flex-row">
+      <div className="w-full shrink-0 bg-white shadow-sm md:w-80 md:min-h-screen">
+        <MonthCalendar />
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4 md:px-6">
+        {foremostEvent && <div className="mb-4"><ForemostEventBanner /></div>}
+        <CurrentTodoList />
+        {selectedDate && (
+          <section className="mt-4">
+            <h2 className="mb-2 px-3 text-sm font-semibold text-gray-700">
+              {selectedDate.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric', weekday: 'short' })}
+            </h2>
+            <DayEventList selectedDate={selectedDate} />
+          </section>
+        )}
+      </div>
+
+      {/* FAB */}
+      <button
+        className="fixed bottom-6 right-6 z-30 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-2xl text-white shadow-lg hover:bg-blue-700"
+        onClick={() => setShowTypeSelector(o => !o)}
+        aria-label="새 이벤트 추가"
+      >
+        +
+      </button>
+
+      {showTypeSelector && (
+        <TypeSelectorPopup onSelect={handleTypeSelect} onClose={() => setShowTypeSelector(false)} />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: App.tsx 라우팅 추가**
+
+`web/src/App.tsx` 전체 교체:
+
+```tsx
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { AuthGuard } from './components/AuthGuard'
+import { LoginPage } from './pages/LoginPage'
+import { MainPage } from './pages/MainPage'
+import { EventDetailPage } from './pages/EventDetailPage'
+import { TodoFormPage } from './pages/TodoFormPage'
+import { ScheduleFormPage } from './pages/ScheduleFormPage'
+import { TagManagementPage } from './pages/TagManagementPage'
+
+function AppRoutes() {
+  const location = useLocation()
+  const background = (location.state as { background?: typeof location } | null)?.background
+
+  return (
+    <>
+      <Routes location={background ?? location}>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/*"
+          element={
+            <AuthGuard>
+              <Routes>
+                <Route path="/" element={<MainPage />} />
+                <Route path="/events/:id" element={<EventDetailPage />} />
+                <Route path="/todos/new" element={<TodoFormPage />} />
+                <Route path="/todos/:id/edit" element={<TodoFormPage />} />
+                <Route path="/schedules/new" element={<ScheduleFormPage />} />
+                <Route path="/schedules/:id/edit" element={<ScheduleFormPage />} />
+                <Route path="/tags" element={<TagManagementPage />} />
+              </Routes>
+            </AuthGuard>
+          }
+        />
+      </Routes>
+
+      {background && (
+        <Routes>
+          {[
+            ['/events/:id', <EventDetailPage />],
+            ['/todos/new', <TodoFormPage />],
+            ['/todos/:id/edit', <TodoFormPage />],
+            ['/schedules/new', <ScheduleFormPage />],
+            ['/schedules/:id/edit', <ScheduleFormPage />],
+            ['/tags', <TagManagementPage />],
+          ].map(([path, element]) => (
+            <Route key={path as string} path={path as string} element={<AuthGuard>{element as React.ReactElement}</AuthGuard>} />
+          ))}
+        </Routes>
+      )}
+    </>
+  )
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  )
+}
+
+export default App
+```
+
+- [ ] **Step 7: 전체 테스트 통과 확인**
+
+```bash
+cd web && npm test
+```
+Expected: 전체 PASS (기존 102개 + 신규 테스트)
+
+- [ ] **Step 8: 빌드 확인**
+
+```bash
+cd web && npx tsc -b && npm run build
+```
+Expected: 타입 에러 없음, 빌드 성공
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/components/DayEventList.tsx web/src/pages/EventDetailPage.tsx \
+  web/src/pages/MainPage.tsx web/src/App.tsx \
+  web/tests/components/DayEventList.test.tsx
+git commit -m "[#104] Phase 5-10: FAB + 라우팅 + DayEventList 편집 메뉴 + EventDetailPage 수정 버튼"
+```
+
+---
+
+## Task 11: Todo 완료 체크박스 (CurrentTodoList + DayEventList)
+
+**Files:**
+- Modify: `web/src/components/CurrentTodoList.tsx`
+- Modify: `web/src/components/DayEventList.tsx`
+- Modify: `web/tests/components/CurrentTodoList.test.tsx`
+
+**완료 로직:**
+- 비반복 Todo: `todoApi.completeTodo(id, { origin: todo })` → `removeEvent(id)` + `removeTodo(id)`
+- 반복 Todo: `todoApi.completeTodo(id, { origin: todo })` → `refreshCurrentRange()`
+
+- [ ] **Step 1: CurrentTodoList 완료 테스트 추가** (`web/tests/components/CurrentTodoList.test.tsx` 하단에 추가)
+
+기존 파일의 `vi.mock` 블록에 `completeTodo` 추가:
+
+```ts
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: {
+    getCurrentTodos: vi.fn(),
+    completeTodo: vi.fn(),
+  },
+}))
+```
+
+테스트 추가:
+
+```tsx
+describe('CurrentTodoList — 완료', () => {
+  it('체크박스 클릭 시 completeTodo API가 호출된다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
+    const todo = { uuid: 't1', name: '완료 할 일', is_current: true, event_time: null }
+    useCurrentTodosStore.setState({ todos: [todo as any] })
+
+    render(
+      <MemoryRouter>
+        <CurrentTodoList />
+      </MemoryRouter>
+    )
+
+    await userEvent.click(screen.getByRole('checkbox', { name: '완료 할 일' }))
+    expect(todoApi.completeTodo).toHaveBeenCalled()
+  })
+
+  it('완료 후 해당 Todo가 목록에서 사라진다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
+    const todo = { uuid: 't1', name: '완료 할 일', is_current: true, event_time: null }
+    useCurrentTodosStore.setState({ todos: [todo as any] })
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+
+    render(<MemoryRouter><CurrentTodoList /></MemoryRouter>)
+    await userEvent.click(screen.getByRole('checkbox', { name: '완료 할 일' }))
+
+    await waitFor(() => {
+      expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(false)
+    })
+  })
+})
+```
+
+필요한 import 추가:
+
+```tsx
+import { waitFor } from '@testing-library/react'
+import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
+import { useCalendarEventsStore } from '../../src/stores/calendarEventsStore'
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd web && npx vitest run tests/components/CurrentTodoList.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 3: CurrentTodoList 수정**
+
+`web/src/components/CurrentTodoList.tsx` 전체 교체:
+
+```tsx
+import { useNavigate, useLocation } from 'react-router-dom'
+import { todoApi } from '../api/todoApi'
+import { useCurrentTodosStore } from '../stores/currentTodosStore'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
+import { useEventTagStore } from '../stores/eventTagStore'
+import type { Todo } from '../models'
+
+async function completeTodo(todo: Todo) {
+  const { removeTodo } = useCurrentTodosStore.getState()
+  const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
+  await todoApi.completeTodo(todo.uuid, { origin: todo })
+  if (todo.repeating) {
+    await refreshCurrentRange()
+  } else {
+    removeEvent(todo.uuid)
+    removeTodo(todo.uuid)
+  }
+}
+
+export function CurrentTodoList() {
+  const todos = useCurrentTodosStore(s => s.todos)
+  const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  if (todos.length === 0) return null
+
+  return (
+    <section>
+      <h3 className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+        Current
+      </h3>
+      <ul className="divide-y divide-gray-100">
+        {todos.map(todo => {
+          const color = todo.event_tag_id
+            ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
+            : '#9ca3af'
+          return (
+            <li key={todo.uuid} className="flex items-center gap-2 px-3 py-2">
+              <input
+                type="checkbox"
+                aria-label={todo.name}
+                className="h-4 w-4 rounded border-gray-300"
+                onChange={() => completeTodo(todo)}
+              />
+              <button
+                className="flex flex-1 items-center gap-2 rounded text-left hover:bg-gray-50"
+                onClick={() => navigate(`/events/${todo.uuid}`, {
+                  state: { background: location, eventType: 'todo' },
+                })}
+              >
+                <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                <span className="truncate text-sm text-gray-900">{todo.name}</span>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd web && npx vitest run tests/components/CurrentTodoList.test.tsx
+```
+Expected: PASS
+
+- [ ] **Step 5: 전체 테스트 + 빌드 최종 확인**
+
+```bash
+cd web && npm test && npx tsc -b && npm run build
+```
+Expected: 전체 PASS, 빌드 성공
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/CurrentTodoList.tsx web/tests/components/CurrentTodoList.test.tsx
+git commit -m "[#104] Phase 5-11: CurrentTodoList — Todo 완료 체크박스"
+```

--- a/docs/web/specs/2026-04-01-phase5-crud-design.md
+++ b/docs/web/specs/2026-04-01-phase5-crud-design.md
@@ -1,0 +1,208 @@
+# Phase 5: Todo/Schedule CRUD — 설계 문서
+
+> 작성일: 2026-04-01
+
+---
+
+## 1. 목표
+
+이벤트 조회만 가능했던 앱에 Todo/Schedule 생성·수정·삭제·완료 기능을 추가한다.
+태그 CRUD, 반복 이벤트 전체 지원(6가지 옵션), 반복 범위 선택(이 항목만/이후 전체/모든 이벤트)을 포함한다.
+
+---
+
+## 2. 라우팅 추가
+
+```
+/todos/new           → TodoFormPage 모달 (background: 현재 위치 유지)
+/todos/:id/edit      → TodoFormPage 모달
+/schedules/new       → ScheduleFormPage 모달
+/schedules/:id/edit  → ScheduleFormPage 모달
+/tags                → TagManagementPage 모달 (background: TodoForm or ScheduleForm)
+```
+
+모든 폼 라우트는 Phase 4에서 확립한 **React Router background location 오버레이 패턴**을 동일하게 적용한다.
+
+### FAB 진입 흐름
+
+```
+MainPage
+  └── FAB "+" (우하단 고정, position: fixed)
+        └── TypeSelectorPopup
+              ├── "Todo" → navigate('/todos/new', { state: { background: location } })
+              └── "Schedule" → navigate('/schedules/new', { state: { background: location } })
+```
+
+### 수정 진입점
+
+- `DayEventList` 아이템 우측 "···" 메뉴 → 수정 / 삭제
+- `EventDetailPage` 우상단 "수정" 버튼
+
+### 태그 관리 진입점
+
+TodoForm / ScheduleForm 내 TagSelector → "태그 관리 >" 버튼 → `/tags` (background: form 위치)
+
+---
+
+## 3. 스토어 확장
+
+### 3-1. calendarEventsStore
+
+낙관적 업데이트 메서드 4개 추가. 기존 `fetchEventsForRange` / `loading` 변경 없음.
+
+```ts
+addEvent(event: CalendarEvent): void
+// eventsByDate에서 이벤트 시간에 해당하는 날짜 키에 추가
+
+removeEvent(uuid: string): void
+// eventsByDate 전체를 순회하여 해당 uuid 제거
+
+replaceEvent(uuid: string, next: CalendarEvent): void
+// eventsByDate 전체를 순회하여 해당 uuid를 next로 교체
+// 반복 이벤트가 여러 날짜에 걸쳐 있는 경우도 처리
+
+refreshCurrentRange(): Promise<void>
+// 마지막으로 fetch한 lower/upper 범위를 재조회
+// 반복 이벤트 변경(excludeRepeating, scope 수정/삭제) 후 호출
+```
+
+`lower` / `upper` 는 스토어 내부에 보존해 `refreshCurrentRange`에서 재사용한다.
+
+### 3-2. eventTagStore
+
+```ts
+createTag(name: string, color_hex?: string): Promise<EventTag>
+updateTag(id: string, updates: { name?: string; color_hex?: string }): Promise<EventTag>
+deleteTag(id: string): Promise<void>
+```
+
+성공 시 즉시 `tags` Map 갱신 (낙관적).
+
+### 3-3. currentTodosStore
+
+```ts
+addTodo(todo: Todo): void       // is_current Todo 생성 시
+removeTodo(uuid: string): void  // 완료/삭제 시
+replaceTodo(todo: Todo): void   // 수정 시
+```
+
+---
+
+## 4. 컴포넌트 구성
+
+### 4-1. 폼 컴포넌트 계층
+
+```
+TodoFormPage / ScheduleFormPage   (라우트 컴포넌트, 모달 래퍼)
+└── TodoForm / ScheduleForm       (폼 로직 + 레이아웃)
+    ├── 이름 <input>
+    ├── TagSelector
+    │   └── "태그 관리 >" → /tags
+    ├── EventTimePicker            (Todo: 선택, Schedule: 필수)
+    │   ├── 타입 탭: at / period / allday
+    │   ├── at    : 날짜 + 시간 단일 picker
+    │   ├── period: 시작(날짜+시간) / 종료(날짜+시간)
+    │   └── allday: 시작 날짜 / 종료 날짜
+    └── RepeatingPicker            (선택, EventTime 설정 시에만 활성)
+        ├── 토글: 반복 없음(기본) / 반복 ON
+        └── 반복 ON:
+            ├── 타입: 매일 / 매주 / 매월 / 매년(날짜) / 매년(특정일) / 음력매년
+            ├── interval (공통)
+            ├── 매주       : 요일 체크박스 (월~일), timeZone
+            ├── 매월       : [날짜 선택 | 주차+요일 선택], timeZone
+            ├── 매년(날짜) : 월 + 일, timeZone
+            ├── 매년(특정일): 월 + 주차 + 요일, timeZone
+            ├── 음력매년   : 월 + 일, timeZone
+            └── 종료 조건: 없음 / 날짜(end) / 횟수(end_count)
+```
+
+### 4-2. 다이얼로그
+
+| 컴포넌트 | 역할 |
+|----------|------|
+| `TypeSelectorPopup` | FAB 클릭 시 Todo / Schedule 선택 |
+| `ConfirmDialog` | 삭제 확인 (제목 + 메시지 prop) |
+| `RepeatingScopeDialog` | 반복 이벤트 수정/삭제 범위: 이 이벤트만 / 이후 전체 / 모든 이벤트 |
+
+### 4-3. 파일 구조
+
+```
+src/
+  components/
+    EventTimePicker.tsx
+    RepeatingPicker.tsx
+    TagSelector.tsx
+    ConfirmDialog.tsx
+    RepeatingScopeDialog.tsx
+    TypeSelectorPopup.tsx
+  pages/
+    TodoFormPage.tsx        (모달 라우트)
+    ScheduleFormPage.tsx
+    TagManagementPage.tsx
+```
+
+---
+
+## 5. CRUD 로직
+
+### 5-1. 비반복 이벤트
+
+| 동작 | API | 스토어 |
+|------|-----|--------|
+| 생성 | `createTodo` / `createSchedule` | `addEvent` + `addTodo`(is_current) |
+| 수정 | `updateTodo` / `updateSchedule` → 응답으로 교체 | `replaceEvent` + `replaceTodo` |
+| 삭제 | `deleteTodo` / `deleteSchedule` | 즉시 `removeEvent` + `removeTodo` (낙관적), 실패 시 rollback |
+| 완료(Todo) | `completeTodo` | `removeEvent` + `removeTodo` |
+
+### 5-2. 반복 Schedule
+
+수정 또는 삭제 시 `RepeatingScopeDialog`를 먼저 표시한 뒤 아래 흐름으로 처리:
+
+| scope | 수정 | 삭제 |
+|-------|------|------|
+| 이 이벤트만 | `excludeRepeating(id, { exclude_repeatings: [turn] })` 후 단건 생성 | `excludeRepeating(id, { exclude_repeatings: [turn] })` |
+| 이후 전체 | 기존 시리즈 `end` 잘라내기 + 새 시리즈 생성 | 기존 시리즈 `end` 잘라내기 |
+| 모든 이벤트 | `updateSchedule(id, body)` | `deleteSchedule(id)` |
+
+반복 scope 처리 완료 후 → `refreshCurrentRange()` 호출.
+
+### 5-3. 반복 Todo 삭제
+
+`todoApi`에 `excludeRepeating`이 없으므로 단건 제거 API가 존재하지 않는다.
+
+- **삭제**: scope dialog 없이 항상 전체 시리즈 삭제 (`deleteTodo`) + `ConfirmDialog`로 확인
+- **단건 제거가 필요한 경우**: "완료"(체크박스)로 처리 — `completeTodo`가 해당 turn만 완료하고 다음 반복을 이어감
+
+### 5-4. 반복 Todo 완료
+
+```ts
+completeTodo(id, { origin: todo, next_event_time?, next_repeating_turn? })
+```
+
+성공 후 `refreshCurrentRange()`.
+
+---
+
+## 6. 태그 관리
+
+`TagManagementPage` (`/tags`):
+- 기존 태그 목록 표시 (색상 + 이름)
+- 태그 생성 인라인 입력
+- 태그 수정 인라인 (이름 + 컬러 피커)
+- 태그 삭제 → `ConfirmDialog`
+
+---
+
+## 7. 테스트 전략
+
+`web/CLAUDE.md` 원칙 준수:
+
+- **스토어 테스트**: API 경계에서 모킹, 공개 접근자(`getState()`) 반환값 검증
+  - `addEvent` / `removeEvent` / `replaceEvent` 후 `eventsByDate` 반환값 확인
+  - `createTag` 후 `tags` Map 반영 확인
+- **컴포넌트 테스트**: 사용자 관점 행동 검증
+  - FAB 클릭 → TypeSelectorPopup 표시
+  - "Todo" 선택 → 폼 모달 표시
+  - 삭제 버튼 → ConfirmDialog 표시
+  - 반복 이벤트 수정 → RepeatingScopeDialog 표시
+- **RepeatingPicker**: 타입별 옵션 노출 행동 테스트

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,12 @@
+import React from 'react'
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { AuthGuard } from './components/AuthGuard'
 import { LoginPage } from './pages/LoginPage'
 import { MainPage } from './pages/MainPage'
 import { EventDetailPage } from './pages/EventDetailPage'
+import { TodoFormPage } from './pages/TodoFormPage'
+import { ScheduleFormPage } from './pages/ScheduleFormPage'
+import { TagManagementPage } from './pages/TagManagementPage'
 
 function AppRoutes() {
   const location = useLocation()
@@ -20,23 +24,30 @@ function AppRoutes() {
               <Routes>
                 <Route path="/" element={<MainPage />} />
                 <Route path="/events/:id" element={<EventDetailPage />} />
+                <Route path="/todos/new" element={<TodoFormPage />} />
+                <Route path="/todos/:id/edit" element={<TodoFormPage />} />
+                <Route path="/schedules/new" element={<ScheduleFormPage />} />
+                <Route path="/schedules/:id/edit" element={<ScheduleFormPage />} />
+                <Route path="/tags" element={<TagManagementPage />} />
               </Routes>
             </AuthGuard>
           }
         />
       </Routes>
 
-      {/* background location이 있을 때 EventDetail을 오버레이로 렌더 */}
+      {/* background location이 있을 때 오버레이로 렌더 */}
       {background && (
         <Routes>
-          <Route
-            path="/events/:id"
-            element={
-              <AuthGuard>
-                <EventDetailPage />
-              </AuthGuard>
-            }
-          />
+          {[
+            ['/events/:id', <EventDetailPage />],
+            ['/todos/new', <TodoFormPage />],
+            ['/todos/:id/edit', <TodoFormPage />],
+            ['/schedules/new', <ScheduleFormPage />],
+            ['/schedules/:id/edit', <ScheduleFormPage />],
+            ['/tags', <TagManagementPage />],
+          ].map(([path, element]) => (
+            <Route key={path as string} path={path as string} element={<AuthGuard>{element as React.ReactElement}</AuthGuard>} />
+          ))}
         </Routes>
       )}
     </>

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,32 @@
+interface ConfirmDialogProps {
+  title: string
+  message: string
+  confirmLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({ title, message, confirmLabel = '삭제', onConfirm, onCancel }: ConfirmDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="text-base font-semibold text-gray-900">{title}</h2>
+        <p className="mt-2 text-sm text-gray-600">{message}</p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            onClick={onCancel}
+          >
+            취소
+          </button>
+          <button
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -5,6 +5,8 @@ import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import type { Todo } from '../models'
 
+// 이벤트 핸들러로 전달되므로 렌더 사이클 밖에서 실행됨.
+// React 훅 규칙 위반 없이 스토어 상태를 읽으려면 getState()를 직접 호출해야 한다.
 async function completeTodo(todo: Todo) {
   const { removeTodo } = useCurrentTodosStore.getState()
   const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -1,6 +1,21 @@
 import { useNavigate, useLocation } from 'react-router-dom'
+import { todoApi } from '../api/todoApi'
 import { useCurrentTodosStore } from '../stores/currentTodosStore'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
+import type { Todo } from '../models'
+
+async function completeTodo(todo: Todo) {
+  const { removeTodo } = useCurrentTodosStore.getState()
+  const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
+  await todoApi.completeTodo(todo.uuid, { origin: todo })
+  if (todo.repeating) {
+    await refreshCurrentRange()
+  } else {
+    removeEvent(todo.uuid)
+    removeTodo(todo.uuid)
+  }
+}
 
 export function CurrentTodoList() {
   const todos = useCurrentTodosStore(s => s.todos)
@@ -21,17 +36,20 @@ export function CurrentTodoList() {
             ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
             : '#9ca3af'
           return (
-            <li key={todo.uuid}>
+            <li key={todo.uuid} className="flex items-center gap-2 px-3 py-2">
+              <input
+                type="checkbox"
+                aria-label={todo.name}
+                className="h-4 w-4 rounded border-gray-300"
+                onChange={() => completeTodo(todo)}
+              />
               <button
-                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-gray-50"
+                className="flex flex-1 items-center gap-2 rounded text-left hover:bg-gray-50"
                 onClick={() => navigate(`/events/${todo.uuid}`, {
                   state: { background: location, eventType: 'todo' },
                 })}
               >
-                <span
-                  className="h-3 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: color }}
-                />
+                <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
                 <span className="truncate text-sm text-gray-900">{todo.name}</span>
               </button>
             </li>

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -8,12 +8,16 @@ import type { Todo } from '../models'
 async function completeTodo(todo: Todo) {
   const { removeTodo } = useCurrentTodosStore.getState()
   const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
-  await todoApi.completeTodo(todo.uuid, { origin: todo })
-  if (todo.repeating) {
-    await refreshCurrentRange()
-  } else {
-    removeEvent(todo.uuid)
-    removeTodo(todo.uuid)
+  try {
+    await todoApi.completeTodo(todo.uuid, { origin: todo })
+    if (todo.repeating) {
+      await refreshCurrentRange()
+    } else {
+      removeEvent(todo.uuid)
+      removeTodo(todo.uuid)
+    }
+  } catch (e) {
+    console.warn('완료 처리 실패:', e)
   }
 }
 

--- a/web/src/components/DayEventList.tsx
+++ b/web/src/components/DayEventList.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
@@ -6,32 +7,55 @@ import { EventTimeDisplay } from './EventTimeDisplay'
 import type { CalendarEvent } from '../utils/eventTimeUtils'
 
 function EventItem({ calEvent, onNavigate }: { calEvent: CalendarEvent; onNavigate: () => void }) {
+  const navigate = useNavigate()
+  const location = useLocation()
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const { uuid, name, event_tag_id, event_time } = calEvent.type === 'todo'
     ? { ...calEvent.event, event_time: calEvent.event.event_time ?? undefined }
     : { ...calEvent.event, event_time: calEvent.event.event_time }
 
   const color = event_tag_id ? (getColorForTagId(event_tag_id) ?? '#9ca3af') : '#9ca3af'
+  const editPath = calEvent.type === 'todo' ? `/todos/${uuid}/edit` : `/schedules/${uuid}/edit`
 
   return (
-    <button
-      className="flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left hover:bg-gray-50"
-      onClick={onNavigate}
-    >
-      <span
-        className="mt-1 h-3 w-3 shrink-0 rounded-full"
-        style={{ backgroundColor: color }}
-      />
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-gray-900">{name}</p>
-        {event_time && (
-          <p className="text-xs text-gray-500">
-            <EventTimeDisplay eventTime={event_time} />
-          </p>
-        )}
-      </div>
-    </button>
+    <div className="relative flex w-full items-start gap-3 rounded-lg px-3 py-2 hover:bg-gray-50">
+      <button className="flex flex-1 items-start gap-3 text-left" onClick={onNavigate}>
+        <span
+          className="mt-1 h-3 w-3 shrink-0 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-gray-900">{name}</p>
+          {event_time && (
+            <p className="text-xs text-gray-500">
+              <EventTimeDisplay eventTime={event_time} />
+            </p>
+          )}
+        </div>
+      </button>
+      <button
+        aria-label="메뉴"
+        className="shrink-0 rounded p-1 text-gray-400 hover:bg-gray-100"
+        onClick={e => { e.stopPropagation(); setMenuOpen(o => !o) }}
+      >
+        ···
+      </button>
+      {menuOpen && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+          <div className="absolute right-0 top-8 z-20 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+            <button
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-50"
+              onClick={() => { setMenuOpen(false); navigate(editPath, { state: { background: location } }) }}
+            >
+              수정
+            </button>
+          </div>
+        </>
+      )}
+    </div>
   )
 }
 

--- a/web/src/components/EventTimePicker.tsx
+++ b/web/src/components/EventTimePicker.tsx
@@ -108,29 +108,34 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
       )}
 
       {type === 'period' && internal?.time_type === 'period' && (
-        <div className="flex gap-3">
-          <div>
-            <label className="block text-xs text-gray-500" htmlFor="period-start">시작</label>
-            <input
-              id="period-start"
-              aria-label="시작"
-              type="datetime-local"
-              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
-              value={tsToDatetimeLocal(internal.period_start)}
-              onChange={e => handleValueChange({ ...internal, period_start: datetimeLocalToTs(e.target.value) })}
-            />
+        <div className="space-y-1">
+          <div className="flex gap-3">
+            <div>
+              <label className="block text-xs text-gray-500" htmlFor="period-start">시작</label>
+              <input
+                id="period-start"
+                aria-label="시작"
+                type="datetime-local"
+                className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={tsToDatetimeLocal(internal.period_start)}
+                onChange={e => handleValueChange({ ...internal, period_start: datetimeLocalToTs(e.target.value) })}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500" htmlFor="period-end">종료</label>
+              <input
+                id="period-end"
+                aria-label="종료"
+                type="datetime-local"
+                className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={tsToDatetimeLocal(internal.period_end)}
+                onChange={e => handleValueChange({ ...internal, period_end: datetimeLocalToTs(e.target.value) })}
+              />
+            </div>
           </div>
-          <div>
-            <label className="block text-xs text-gray-500" htmlFor="period-end">종료</label>
-            <input
-              id="period-end"
-              aria-label="종료"
-              type="datetime-local"
-              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
-              value={tsToDatetimeLocal(internal.period_end)}
-              onChange={e => handleValueChange({ ...internal, period_end: datetimeLocalToTs(e.target.value) })}
-            />
-          </div>
+          {internal.period_end < internal.period_start && (
+            <p className="text-xs text-red-500">종료 시각이 시작 시각보다 앞에 있습니다.</p>
+          )}
         </div>
       )}
 

--- a/web/src/components/EventTimePicker.tsx
+++ b/web/src/components/EventTimePicker.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react'
+import type { EventTime } from '../models'
+
+type TimeType = 'none' | 'at' | 'period' | 'allday'
+
+function tsToDatetimeLocal(ts: number): string {
+  const d = new Date(ts * 1000)
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`
+}
+
+function datetimeLocalToTs(v: string): number {
+  return Math.floor(new Date(v).getTime() / 1000)
+}
+
+function tsToDateInput(ts: number): string {
+  const d = new Date(ts * 1000)
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`
+}
+
+function dateInputToTs(v: string): number {
+  return Math.floor(new Date(v + 'T00:00:00').getTime() / 1000)
+}
+
+function localSecondsFromGmt(): number {
+  return -(new Date().getTimezoneOffset() * 60)
+}
+
+interface EventTimePickerProps {
+  value: EventTime | null
+  onChange: (value: EventTime | null) => void
+  required?: boolean
+}
+
+export function EventTimePicker({ value, onChange, required = false }: EventTimePickerProps) {
+  const now = Math.floor(Date.now() / 1000)
+
+  const initType = (): TimeType => {
+    if (!value) return required ? 'at' : 'none'
+    return value.time_type
+  }
+
+  const initInternal = (): EventTime | null => {
+    if (value) return value
+    if (required) return { time_type: 'at', timestamp: now }
+    return null
+  }
+
+  const [type, setType] = useState<TimeType>(initType)
+  const [internal, setInternal] = useState<EventTime | null>(initInternal)
+
+  function handleTypeChange(t: TimeType) {
+    setType(t)
+    if (t === 'none') {
+      setInternal(null)
+      onChange(null)
+      return
+    }
+    let next: EventTime
+    if (t === 'at') next = { time_type: 'at', timestamp: now }
+    else if (t === 'period') next = { time_type: 'period', period_start: now, period_end: now + 3600 }
+    else next = { time_type: 'allday', period_start: now, period_end: now, seconds_from_gmt: localSecondsFromGmt() }
+    setInternal(next)
+    onChange(next)
+  }
+
+  function handleValueChange(next: EventTime) {
+    setInternal(next)
+    onChange(next)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-3">
+        {!required && (
+          <label className="flex items-center gap-1 text-sm">
+            <input type="radio" name="time-type" checked={type === 'none'} onChange={() => handleTypeChange('none')} />
+            시간 없음
+          </label>
+        )}
+        <label className="flex items-center gap-1 text-sm">
+          <input type="radio" name="time-type" checked={type === 'at'} onChange={() => handleTypeChange('at')} />
+          특정 시각
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          <input type="radio" name="time-type" checked={type === 'period'} onChange={() => handleTypeChange('period')} />
+          기간
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          <input type="radio" name="time-type" checked={type === 'allday'} onChange={() => handleTypeChange('allday')} />
+          종일
+        </label>
+      </div>
+
+      {type === 'at' && internal?.time_type === 'at' && (
+        <div>
+          <label className="block text-xs text-gray-500" htmlFor="at-input">시각</label>
+          <input
+            id="at-input"
+            aria-label="시각"
+            type="datetime-local"
+            className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+            value={tsToDatetimeLocal(internal.timestamp)}
+            onChange={e => handleValueChange({ time_type: 'at', timestamp: datetimeLocalToTs(e.target.value) })}
+          />
+        </div>
+      )}
+
+      {type === 'period' && internal?.time_type === 'period' && (
+        <div className="flex gap-3">
+          <div>
+            <label className="block text-xs text-gray-500" htmlFor="period-start">시작</label>
+            <input
+              id="period-start"
+              aria-label="시작"
+              type="datetime-local"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDatetimeLocal(internal.period_start)}
+              onChange={e => handleValueChange({ ...internal, period_start: datetimeLocalToTs(e.target.value) })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500" htmlFor="period-end">종료</label>
+            <input
+              id="period-end"
+              aria-label="종료"
+              type="datetime-local"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDatetimeLocal(internal.period_end)}
+              onChange={e => handleValueChange({ ...internal, period_end: datetimeLocalToTs(e.target.value) })}
+            />
+          </div>
+        </div>
+      )}
+
+      {type === 'allday' && internal?.time_type === 'allday' && (
+        <div className="flex gap-3">
+          <div>
+            <label className="block text-xs text-gray-500" htmlFor="allday-start">시작일</label>
+            <input
+              id="allday-start"
+              aria-label="시작일"
+              type="date"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDateInput(internal.period_start + internal.seconds_from_gmt)}
+              onChange={e => handleValueChange({ ...internal, period_start: dateInputToTs(e.target.value) - internal.seconds_from_gmt })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500" htmlFor="allday-end">종료일</label>
+            <input
+              id="allday-end"
+              aria-label="종료일"
+              type="date"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={tsToDateInput(internal.period_end + internal.seconds_from_gmt)}
+              onChange={e => handleValueChange({ ...internal, period_end: dateInputToTs(e.target.value) - internal.seconds_from_gmt })}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/RepeatingPicker.tsx
+++ b/web/src/components/RepeatingPicker.tsx
@@ -38,10 +38,26 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
   const [option, setOption] = useState<RepeatingOption>(
     value?.option ?? defaultOption('every_day', startTimestamp)
   )
-  const [endType, setEndType] = useState<'none' | 'date' | 'count'>('none')
-  const [endDate, setEndDate] = useState('')
-  const [endCount, setEndCount] = useState(10)
-  const [monthMode, setMonthMode] = useState<'days' | 'week'>('days')
+  const [endType, setEndType] = useState<'none' | 'date' | 'count'>(() => {
+    if (value?.end_count != null) return 'count'
+    if (value?.end != null) return 'date'
+    return 'none'
+  })
+  const [endDate, setEndDate] = useState(() => {
+    if (value?.end != null) {
+      const d = new Date(value.end * 1000)
+      const p = (n: number) => String(n).padStart(2, '0')
+      return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())}`
+    }
+    return ''
+  })
+  const [endCount, setEndCount] = useState(() => value?.end_count ?? 10)
+  const [monthMode, setMonthMode] = useState<'days' | 'week'>(() => {
+    if (value?.option.optionType === 'every_month') {
+      return 'weekOrdinals' in value.option.monthDaySelection ? 'week' : 'days'
+    }
+    return 'days'
+  })
 
   function emitWithEnd(opt: RepeatingOption, et: 'none' | 'date' | 'count', ed: string, ec: number) {
     const end = et === 'date' && ed ? Math.floor(new Date(ed + 'T00:00:00').getTime() / 1000) : undefined
@@ -59,7 +75,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
     if (!next) {
       onChange(null)
     } else {
-      emit(option)
+      emitWithEnd(option, endType, endDate, endCount)
     }
   }
 

--- a/web/src/components/RepeatingPicker.tsx
+++ b/web/src/components/RepeatingPicker.tsx
@@ -1,0 +1,277 @@
+import { useState } from 'react'
+import type { Repeating, RepeatingOption } from '../models'
+
+const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+const DAYS = ['일', '월', '화', '수', '목', '금', '토']
+
+function defaultOption(type: string, startTs: number): RepeatingOption {
+  const d = new Date(startTs * 1000)
+  switch (type) {
+    case 'every_day':
+      return { optionType: 'every_day', interval: 1 }
+    case 'every_week':
+      return { optionType: 'every_week', interval: 1, dayOfWeek: [d.getDay()], timeZone: TZ }
+    case 'every_month':
+      return { optionType: 'every_month', interval: 1, monthDaySelection: { days: [d.getDate()] }, timeZone: TZ }
+    case 'every_year':
+      return { optionType: 'every_year', interval: 1, months: [d.getMonth() + 1], weekOrdinals: [], dayOfWeek: [d.getDay()], timeZone: TZ }
+    case 'every_year_some_day':
+      return { optionType: 'every_year_some_day', interval: 1, month: d.getMonth() + 1, day: d.getDate(), timeZone: TZ }
+    case 'lunar_calendar_every_year':
+      return { optionType: 'lunar_calendar_every_year', month: d.getMonth() + 1, day: d.getDate(), timeZone: TZ }
+    default:
+      return { optionType: 'every_day', interval: 1 }
+  }
+}
+
+interface RepeatingPickerProps {
+  value: Repeating | null
+  onChange: (value: Repeating | null) => void
+  startTimestamp: number
+}
+
+export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPickerProps) {
+  const [enabled, setEnabled] = useState(!!value)
+  const [option, setOption] = useState<RepeatingOption>(
+    value?.option ?? defaultOption('every_day', startTimestamp)
+  )
+  const [endType, setEndType] = useState<'none' | 'date' | 'count'>('none')
+  const [endDate, setEndDate] = useState('')
+  const [endCount, setEndCount] = useState(10)
+  const [monthMode, setMonthMode] = useState<'days' | 'week'>('days')
+
+  function buildRepeating(opt: RepeatingOption): Repeating {
+    const end =
+      endType === 'date' && endDate
+        ? Math.floor(new Date(endDate + 'T00:00:00').getTime() / 1000)
+        : undefined
+    const end_count = endType === 'count' ? endCount : undefined
+    return { start: startTimestamp, option: opt, end, end_count }
+  }
+
+  function emit(opt: RepeatingOption) {
+    onChange(buildRepeating(opt))
+  }
+
+  function handleToggle() {
+    const next = !enabled
+    setEnabled(next)
+    if (!next) {
+      onChange(null)
+    } else {
+      emit(option)
+    }
+  }
+
+  function handleTypeChange(type: string) {
+    const opt = defaultOption(type, startTimestamp)
+    setOption(opt)
+    emit(opt)
+  }
+
+  // Type-narrowed helpers to avoid TS narrowing issues in JSX
+  const weekOption = option.optionType === 'every_week' ? option : null
+  const monthOption = option.optionType === 'every_month' ? option : null
+  const yearSomeDayOption = option.optionType === 'every_year_some_day' ? option : null
+  const lunarOption = option.optionType === 'lunar_calendar_every_year' ? option : null
+  const specificDayOption = yearSomeDayOption ?? lunarOption
+
+  const interval = option.optionType !== 'lunar_calendar_every_year' ? option.interval : null
+
+  return (
+    <div className="space-y-3">
+      <label className="flex items-center gap-2 text-sm font-medium">
+        <input type="checkbox" aria-label="반복" checked={enabled} onChange={handleToggle} />
+        반복
+      </label>
+
+      {enabled && (
+        <div className="space-y-3 pl-4">
+          {/* 반복 유형 선택 */}
+          <div>
+            <label className="block text-xs text-gray-500">반복 유형</label>
+            <select
+              aria-label="반복 유형"
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={option.optionType}
+              onChange={e => handleTypeChange(e.target.value)}
+            >
+              <option value="every_day">매일</option>
+              <option value="every_week">매주</option>
+              <option value="every_month">매월</option>
+              <option value="every_year">매년</option>
+              <option value="every_year_some_day">매년 (특정일)</option>
+              <option value="lunar_calendar_every_year">매년 (음력)</option>
+            </select>
+          </div>
+
+          {/* 간격 (음력 제외) */}
+          {interval !== null && (
+            <div>
+              <label className="block text-xs text-gray-500">간격</label>
+              <input
+                type="number"
+                min={1}
+                className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={interval}
+                onChange={e => {
+                  const opt = { ...option, interval: Number(e.target.value) } as RepeatingOption
+                  setOption(opt)
+                  emit(opt)
+                }}
+              />
+            </div>
+          )}
+
+          {/* 매주: 요일 체크박스 */}
+          {weekOption && (
+            <div>
+              <p className="text-xs text-gray-500">요일</p>
+              <div className="mt-1 flex gap-1">
+                {DAYS.map((d, i) => (
+                  <label key={i} className="flex flex-col items-center text-xs">
+                    <input
+                      type="checkbox"
+                      checked={weekOption.dayOfWeek.includes(i)}
+                      onChange={() => {
+                        const days = weekOption.dayOfWeek.includes(i)
+                          ? weekOption.dayOfWeek.filter(x => x !== i)
+                          : [...weekOption.dayOfWeek, i]
+                        const opt: RepeatingOption = { ...weekOption, dayOfWeek: days }
+                        setOption(opt)
+                        emit(opt)
+                      }}
+                    />
+                    {d}
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* 매월: 날짜/요일 모드 선택 */}
+          {monthOption && (
+            <div className="space-y-2">
+              <div className="flex gap-4">
+                <label className="flex items-center gap-1 text-sm">
+                  <input
+                    type="radio"
+                    name="month-mode"
+                    checked={monthMode === 'days'}
+                    onChange={() => setMonthMode('days')}
+                  />
+                  날짜 지정
+                </label>
+                <label className="flex items-center gap-1 text-sm">
+                  <input
+                    type="radio"
+                    name="month-mode"
+                    checked={monthMode === 'week'}
+                    onChange={() => setMonthMode('week')}
+                  />
+                  요일 지정
+                </label>
+              </div>
+              {monthMode === 'days' && (
+                <div>
+                  <label className="block text-xs text-gray-500">날짜</label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={31}
+                    className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                    value={
+                      'days' in monthOption.monthDaySelection
+                        ? monthOption.monthDaySelection.days[0]
+                        : 1
+                    }
+                    onChange={e => {
+                      const opt: RepeatingOption = {
+                        ...monthOption,
+                        monthDaySelection: { days: [Number(e.target.value)] },
+                      }
+                      setOption(opt)
+                      emit(opt)
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* 매년 특정일 / 음력: 월+일 입력 */}
+          {specificDayOption && (
+            <div className="flex gap-3">
+              <div>
+                <label className="block text-xs text-gray-500">월</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={12}
+                  className="mt-1 w-16 rounded border border-gray-300 px-2 py-1 text-sm"
+                  value={specificDayOption.month}
+                  onChange={e => {
+                    const opt = { ...specificDayOption, month: Number(e.target.value) } as RepeatingOption
+                    setOption(opt)
+                    emit(opt)
+                  }}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500">일</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={31}
+                  className="mt-1 w-16 rounded border border-gray-300 px-2 py-1 text-sm"
+                  value={specificDayOption.day}
+                  onChange={e => {
+                    const opt = { ...specificDayOption, day: Number(e.target.value) } as RepeatingOption
+                    setOption(opt)
+                    emit(opt)
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* 종료 조건 */}
+          <div>
+            <label className="block text-xs text-gray-500">종료 조건</label>
+            <div className="mt-1 flex gap-3">
+              {(['none', 'date', 'count'] as const).map(t => (
+                <label key={t} className="flex items-center gap-1 text-sm">
+                  <input
+                    type="radio"
+                    name="end-type"
+                    checked={endType === t}
+                    onChange={() => setEndType(t)}
+                  />
+                  {t === 'none' ? '없음' : t === 'date' ? '날짜' : '횟수'}
+                </label>
+              ))}
+            </div>
+            {endType === 'date' && (
+              <input
+                type="date"
+                className="mt-2 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+              />
+            )}
+            {endType === 'count' && (
+              <input
+                type="number"
+                min={1}
+                className="mt-2 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                value={endCount}
+                onChange={e => setEndCount(Number(e.target.value))}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/RepeatingPicker.tsx
+++ b/web/src/components/RepeatingPicker.tsx
@@ -3,7 +3,9 @@ import type { Repeating, RepeatingOption } from '../models'
 
 const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
 
-const DAYS = ['일', '월', '화', '수', '목', '금', '토']
+const DAY_ORDER = [1, 2, 3, 4, 5, 6, 0] // 월~일 display order
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토']
+const DAY_FULL_LABELS = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
 
 function defaultOption(type: string, startTs: number): RepeatingOption {
   const d = new Date(startTs * 1000)
@@ -41,17 +43,14 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
   const [endCount, setEndCount] = useState(10)
   const [monthMode, setMonthMode] = useState<'days' | 'week'>('days')
 
-  function buildRepeating(opt: RepeatingOption): Repeating {
-    const end =
-      endType === 'date' && endDate
-        ? Math.floor(new Date(endDate + 'T00:00:00').getTime() / 1000)
-        : undefined
-    const end_count = endType === 'count' ? endCount : undefined
-    return { start: startTimestamp, option: opt, end, end_count }
+  function emitWithEnd(opt: RepeatingOption, et: 'none' | 'date' | 'count', ed: string, ec: number) {
+    const end = et === 'date' && ed ? Math.floor(new Date(ed + 'T00:00:00').getTime() / 1000) : undefined
+    const end_count = et === 'count' ? ec : undefined
+    onChange({ start: startTimestamp, option: opt, end, end_count })
   }
 
   function emit(opt: RepeatingOption) {
-    onChange(buildRepeating(opt))
+    emitWithEnd(opt, endType, endDate, endCount)
   }
 
   function handleToggle() {
@@ -73,6 +72,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
   // Type-narrowed helpers to avoid TS narrowing issues in JSX
   const weekOption = option.optionType === 'every_week' ? option : null
   const monthOption = option.optionType === 'every_month' ? option : null
+  const yearOption = option.optionType === 'every_year' ? option : null
   const yearSomeDayOption = option.optionType === 'every_year_some_day' ? option : null
   const lunarOption = option.optionType === 'lunar_calendar_every_year' ? option : null
   const specificDayOption = yearSomeDayOption ?? lunarOption
@@ -124,15 +124,16 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
             </div>
           )}
 
-          {/* 매주: 요일 체크박스 */}
+          {/* 매주: 요일 체크박스 (월~일 순서) */}
           {weekOption && (
             <div>
               <p className="text-xs text-gray-500">요일</p>
               <div className="mt-1 flex gap-1">
-                {DAYS.map((d, i) => (
-                  <label key={i} className="flex flex-col items-center text-xs">
+                {DAY_ORDER.map(i => (
+                  <div key={i} className="flex flex-col items-center text-xs">
                     <input
                       type="checkbox"
+                      aria-label={DAY_FULL_LABELS[i]}
                       checked={weekOption.dayOfWeek.includes(i)}
                       onChange={() => {
                         const days = weekOption.dayOfWeek.includes(i)
@@ -143,8 +144,8 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                         emit(opt)
                       }}
                     />
-                    {d}
-                  </label>
+                    <span aria-hidden="true">{DAY_LABELS[i]}</span>
+                  </div>
                 ))}
               </div>
             </div>
@@ -197,6 +198,153 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                   />
                 </div>
               )}
+              {monthMode === 'week' && (
+                <div className="space-y-2">
+                  <div>
+                    <label className="block text-xs text-gray-500" htmlFor="month-week-seq">주차</label>
+                    <input
+                      id="month-week-seq"
+                      type="number"
+                      min={1}
+                      max={5}
+                      aria-label="주차"
+                      className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                      value={
+                        'weekOrdinals' in monthOption.monthDaySelection &&
+                        monthOption.monthDaySelection.weekOrdinals.length > 0
+                          ? (monthOption.monthDaySelection.weekOrdinals[0].seq ?? 1)
+                          : 1
+                      }
+                      onChange={e => {
+                        const seq = Number(e.target.value)
+                        const prevDays =
+                          'weekDays' in monthOption.monthDaySelection
+                            ? monthOption.monthDaySelection.weekDays
+                            : []
+                        const opt: RepeatingOption = {
+                          ...monthOption,
+                          monthDaySelection: {
+                            weekOrdinals: [{ isLast: false, seq }],
+                            weekDays: prevDays,
+                          },
+                        }
+                        setOption(opt)
+                        emit(opt)
+                      }}
+                    />
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500">요일</p>
+                    <div className="mt-1 flex gap-1">
+                      {DAY_ORDER.map(i => {
+                        const currentDays =
+                          'weekDays' in monthOption.monthDaySelection
+                            ? monthOption.monthDaySelection.weekDays
+                            : []
+                        return (
+                          <div key={i} className="flex flex-col items-center text-xs">
+                            <input
+                              type="checkbox"
+                              aria-label={DAY_FULL_LABELS[i]}
+                              checked={currentDays.includes(i)}
+                              onChange={() => {
+                                const days = currentDays.includes(i)
+                                  ? currentDays.filter(x => x !== i)
+                                  : [...currentDays, i]
+                                const currentOrdinals =
+                                  'weekOrdinals' in monthOption.monthDaySelection
+                                    ? monthOption.monthDaySelection.weekOrdinals
+                                    : [{ isLast: false, seq: 1 }]
+                                const opt: RepeatingOption = {
+                                  ...monthOption,
+                                  monthDaySelection: {
+                                    weekOrdinals: currentOrdinals,
+                                    weekDays: days,
+                                  },
+                                }
+                                setOption(opt)
+                                emit(opt)
+                              }}
+                            />
+                            <span aria-hidden="true">{DAY_LABELS[i]}</span>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* 매년: 월 + 주차 + 요일 입력 */}
+          {yearOption && (
+            <div className="space-y-2">
+              <div>
+                <label className="block text-xs text-gray-500" htmlFor="year-month">월</label>
+                <input
+                  id="year-month"
+                  type="number"
+                  min={1}
+                  max={12}
+                  aria-label="월"
+                  className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                  value={yearOption.months[0] ?? 1}
+                  onChange={e => {
+                    const opt: RepeatingOption = { ...yearOption, months: [Number(e.target.value)] }
+                    setOption(opt)
+                    emit(opt)
+                  }}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500" htmlFor="year-week-seq">주차</label>
+                <input
+                  id="year-week-seq"
+                  type="number"
+                  min={1}
+                  max={5}
+                  aria-label="주차"
+                  className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+                  value={
+                    yearOption.weekOrdinals.length > 0
+                      ? (yearOption.weekOrdinals[0].seq ?? 1)
+                      : 1
+                  }
+                  onChange={e => {
+                    const seq = Number(e.target.value)
+                    const opt: RepeatingOption = {
+                      ...yearOption,
+                      weekOrdinals: [{ isLast: false, seq }],
+                    }
+                    setOption(opt)
+                    emit(opt)
+                  }}
+                />
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">요일</p>
+                <div className="mt-1 flex gap-1">
+                  {DAY_ORDER.map(i => (
+                    <div key={i} className="flex flex-col items-center text-xs">
+                      <input
+                        type="checkbox"
+                        aria-label={DAY_FULL_LABELS[i]}
+                        checked={yearOption.dayOfWeek.includes(i)}
+                        onChange={() => {
+                          const days = yearOption.dayOfWeek.includes(i)
+                            ? yearOption.dayOfWeek.filter(x => x !== i)
+                            : [...yearOption.dayOfWeek, i]
+                          const opt: RepeatingOption = { ...yearOption, dayOfWeek: days }
+                          setOption(opt)
+                          emit(opt)
+                        }}
+                      />
+                      <span aria-hidden="true">{DAY_LABELS[i]}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
           )}
 
@@ -246,7 +394,10 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                     type="radio"
                     name="end-type"
                     checked={endType === t}
-                    onChange={() => setEndType(t)}
+                    onChange={() => {
+                      setEndType(t)
+                      emitWithEnd(option, t, endDate, endCount)
+                    }}
                   />
                   {t === 'none' ? '없음' : t === 'date' ? '날짜' : '횟수'}
                 </label>
@@ -257,7 +408,10 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                 type="date"
                 className="mt-2 rounded border border-gray-300 px-2 py-1 text-sm"
                 value={endDate}
-                onChange={e => setEndDate(e.target.value)}
+                onChange={e => {
+                  setEndDate(e.target.value)
+                  emitWithEnd(option, endType, e.target.value, endCount)
+                }}
               />
             )}
             {endType === 'count' && (
@@ -266,7 +420,10 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                 min={1}
                 className="mt-2 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
                 value={endCount}
-                onChange={e => setEndCount(Number(e.target.value))}
+                onChange={e => {
+                  setEndCount(Number(e.target.value))
+                  emitWithEnd(option, endType, endDate, Number(e.target.value))
+                }}
               />
             )}
           </div>

--- a/web/src/components/RepeatingScopeDialog.tsx
+++ b/web/src/components/RepeatingScopeDialog.tsx
@@ -1,0 +1,45 @@
+export type RepeatScope = 'this' | 'future' | 'all'
+
+interface RepeatingScopeDialogProps {
+  mode: 'edit' | 'delete'
+  onSelect: (scope: RepeatScope) => void
+  onCancel: () => void
+}
+
+export function RepeatingScopeDialog({ mode, onSelect, onCancel }: RepeatingScopeDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="text-base font-semibold text-gray-900">
+          {mode === 'delete' ? '반복 일정 삭제' : '반복 일정 수정'}
+        </h2>
+        <div className="mt-4 flex flex-col divide-y divide-gray-100">
+          <button
+            className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+            onClick={() => onSelect('this')}
+          >
+            이 이벤트만
+          </button>
+          <button
+            className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+            onClick={() => onSelect('future')}
+          >
+            이 이벤트 및 이후 이벤트
+          </button>
+          <button
+            className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+            onClick={() => onSelect('all')}
+          >
+            모든 이벤트
+          </button>
+        </div>
+        <button
+          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100"
+          onClick={onCancel}
+        >
+          취소
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/TagSelector.tsx
+++ b/web/src/components/TagSelector.tsx
@@ -1,0 +1,42 @@
+import { useNavigate, useLocation } from 'react-router-dom'
+import { useEventTagStore } from '../stores/eventTagStore'
+
+interface TagSelectorProps {
+  value: string | null | undefined
+  onChange: (tagId: string | null) => void
+}
+
+export function TagSelector({ value, onChange }: TagSelectorProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const tags = useEventTagStore(s => s.tags)
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        <button
+          className={`rounded-full border px-3 py-1 text-xs ${!value ? 'border-gray-700 bg-gray-700 text-white' : 'border-gray-300 text-gray-600'}`}
+          onClick={() => onChange(null)}
+        >
+          없음
+        </button>
+        {Array.from(tags.values()).map(tag => (
+          <button
+            key={tag.uuid}
+            className={`flex items-center gap-1 rounded-full border px-3 py-1 text-xs ${value === tag.uuid ? 'border-gray-700 font-semibold' : 'border-gray-300'}`}
+            onClick={() => onChange(tag.uuid)}
+          >
+            {tag.color_hex && <span className="h-2 w-2 rounded-full" style={{ backgroundColor: tag.color_hex }} />}
+            {tag.name}
+          </button>
+        ))}
+      </div>
+      <button
+        className="text-xs text-blue-500 hover:underline"
+        onClick={() => navigate('/tags', { state: { background: location } })}
+      >
+        태그 관리
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/TagSelector.tsx
+++ b/web/src/components/TagSelector.tsx
@@ -35,7 +35,7 @@ export function TagSelector({ value, onChange }: TagSelectorProps) {
         className="text-xs text-blue-500 hover:underline"
         onClick={() => navigate('/tags', { state: { background: location } })}
       >
-        태그 관리
+        태그 관리 &gt;
       </button>
     </div>
   )

--- a/web/src/components/TypeSelectorPopup.tsx
+++ b/web/src/components/TypeSelectorPopup.tsx
@@ -1,0 +1,27 @@
+interface TypeSelectorPopupProps {
+  onSelect: (type: 'todo' | 'schedule') => void
+  onClose: () => void
+}
+
+export function TypeSelectorPopup({ onSelect, onClose }: TypeSelectorPopupProps) {
+  return (
+    <>
+      <div data-testid="popup-backdrop" className="fixed inset-0 z-40" onClick={onClose} />
+      <div className="fixed bottom-20 right-4 z-50 overflow-hidden rounded-xl bg-white shadow-xl">
+        <button
+          className="flex w-full px-6 py-4 text-left text-sm font-medium hover:bg-gray-50"
+          onClick={() => onSelect('todo')}
+        >
+          Todo
+        </button>
+        <div className="border-t border-gray-100" />
+        <button
+          className="flex w-full px-6 py-4 text-left text-sm font-medium hover:bg-gray-50"
+          onClick={() => onSelect('schedule')}
+        >
+          Schedule
+        </button>
+      </div>
+    </>
+  )
+}

--- a/web/src/pages/EventDetailPage.tsx
+++ b/web/src/pages/EventDetailPage.tsx
@@ -96,12 +96,26 @@ export function EventDetailPage() {
 
   return (
     <div className="mx-auto max-w-lg px-4 py-6">
-      <button
-        className="mb-4 flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
-        onClick={() => navigate(-1)}
-      >
-        ← 뒤로
-      </button>
+      <div className="mb-4 flex items-center justify-between">
+        <button
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+          onClick={() => navigate(-1)}
+        >
+          ← 뒤로
+        </button>
+        {event && (
+          <button
+            className="text-sm text-blue-500 hover:text-blue-700"
+            onClick={() => {
+              const eventType = (location.state as { eventType?: string } | null)?.eventType
+              const path = eventType === 'schedule' ? `/schedules/${id}/edit` : `/todos/${id}/edit`
+              navigate(path, { state: { background: location } })
+            }}
+          >
+            수정
+          </button>
+        )}
+      </div>
 
       <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
         {/* Header */}

--- a/web/src/pages/EventDetailPage.tsx
+++ b/web/src/pages/EventDetailPage.tsx
@@ -35,13 +35,14 @@ export function EventDetailPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
+  const eventType = (location.state as { eventType?: string } | null)?.eventType
+
   useEffect(() => {
     if (!id) return
 
     async function load(eventId: string) {
       setLoading(true)
       try {
-        const eventType = (location.state as { eventType?: string } | null)?.eventType
         let item: EventItem
         if (eventType === 'schedule') {
           item = await scheduleApi.getSchedule(eventId)
@@ -71,7 +72,7 @@ export function EventDetailPage() {
     }
 
     load(id)
-  }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, eventType])
 
   if (loading) {
     return (

--- a/web/src/pages/MainPage.tsx
+++ b/web/src/pages/MainPage.tsx
@@ -1,13 +1,24 @@
+import { useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import MonthCalendar from '../calendar/MonthCalendar'
 import { DayEventList } from '../components/DayEventList'
 import { CurrentTodoList } from '../components/CurrentTodoList'
 import { ForemostEventBanner } from '../components/ForemostEventBanner'
+import { TypeSelectorPopup } from '../components/TypeSelectorPopup'
 import { useUiStore } from '../stores/uiStore'
 import { useForemostEventStore } from '../stores/foremostEventStore'
 
 export function MainPage() {
   const selectedDate = useUiStore(s => s.selectedDate)
   const foremostEvent = useForemostEventStore(s => s.foremostEvent)
+  const [showTypeSelector, setShowTypeSelector] = useState(false)
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  function handleTypeSelect(type: 'todo' | 'schedule') {
+    setShowTypeSelector(false)
+    navigate(type === 'todo' ? '/todos/new' : '/schedules/new', { state: { background: location } })
+  }
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-50 md:flex-row">
@@ -38,6 +49,19 @@ export function MainPage() {
           </section>
         )}
       </div>
+
+      {/* FAB */}
+      <button
+        className="fixed bottom-6 right-6 z-30 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-2xl text-white shadow-lg hover:bg-blue-700"
+        onClick={() => setShowTypeSelector(o => !o)}
+        aria-label="새 이벤트 추가"
+      >
+        +
+      </button>
+
+      {showTypeSelector && (
+        <TypeSelectorPopup onSelect={handleTypeSelect} onClose={() => setShowTypeSelector(false)} />
+      )}
     </div>
   )
 }

--- a/web/src/pages/ScheduleFormPage.tsx
+++ b/web/src/pages/ScheduleFormPage.tsx
@@ -15,7 +15,7 @@ export function ScheduleFormPage() {
   const navigate = useNavigate()
   const selectedDate = useUiStore(s => s.selectedDate)
 
-  const { addEvent, removeEvent, replaceEvent, refreshCurrentRange } = useCalendarEventsStore()
+  const { addEvent, removeEvent, refreshCurrentRange } = useCalendarEventsStore()
 
   const defaultEventTime = (): EventTime => {
     const base = selectedDate ?? new Date()
@@ -32,6 +32,7 @@ export function ScheduleFormPage() {
   const [showSaveScope, setShowSaveScope] = useState(false)
   const [showDeleteScope, setShowDeleteScope] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!id) return
@@ -63,14 +64,15 @@ export function ScheduleFormPage() {
   async function applyUpdate(scope: RepeatScope) {
     if (!id || !original) return
     if (!original.repeating) {
-      // Non-repeating: optimistic replaceEvent
+      // Non-repeating: event_time이 바뀌면 날짜 키가 달라질 수 있으므로 remove → add로 갱신
       const updated = await scheduleApi.updateSchedule(id, {
         name: name.trim(),
         event_tag_id: tagId,
         event_time: eventTime,
         repeating: repeating ?? undefined,
       })
-      replaceEvent(id, { type: 'schedule', event: updated })
+      removeEvent(id)
+      addEvent({ type: 'schedule', event: updated })
     } else if (scope === 'all') {
       // Full repeating series: refresh calendar
       await scheduleApi.updateSchedule(id, {
@@ -116,6 +118,7 @@ export function ScheduleFormPage() {
         await scheduleApi.deleteSchedule(id)
         await refreshCurrentRange()
       } else if (scope === 'this') {
+        // show_turns[0]: 현재 화면에 표시된 반복 회차. 없으면 0(첫 번째 회차)으로 폴백
         const turn = original.show_turns?.[0] ?? 0
         await scheduleApi.excludeRepeating(id, { exclude_repeatings: [...(original.exclude_repeatings ?? []), turn] })
         await refreshCurrentRange()
@@ -128,6 +131,7 @@ export function ScheduleFormPage() {
       navigate(-1)
     } catch (e) {
       console.warn('삭제 실패:', e)
+      setError('삭제에 실패했습니다. 다시 시도해주세요.')
       setShowDeleteScope(false)
       setShowDeleteConfirm(false)
     }
@@ -143,6 +147,7 @@ export function ScheduleFormPage() {
       navigate(-1)
     } catch (e) {
       console.warn('저장 실패:', e)
+      setError('저장에 실패했습니다. 다시 시도해주세요.')
     } finally {
       setSaving(false)
     }
@@ -156,6 +161,7 @@ export function ScheduleFormPage() {
       navigate(-1)
     } catch (e) {
       console.warn('저장 실패:', e)
+      setError('저장에 실패했습니다. 다시 시도해주세요.')
     } finally {
       setSaving(false)
     }
@@ -210,6 +216,9 @@ export function ScheduleFormPage() {
           </div>
         </div>
 
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
+        )}
         <div className="flex gap-3 pt-2">
           <button
             className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"

--- a/web/src/pages/ScheduleFormPage.tsx
+++ b/web/src/pages/ScheduleFormPage.tsx
@@ -1,0 +1,241 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { scheduleApi } from '../api/scheduleApi'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
+import { useUiStore } from '../stores/uiStore'
+import { EventTimePicker } from '../components/EventTimePicker'
+import { RepeatingPicker } from '../components/RepeatingPicker'
+import { TagSelector } from '../components/TagSelector'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import { RepeatingScopeDialog, type RepeatScope } from '../components/RepeatingScopeDialog'
+import type { Schedule, EventTime, Repeating } from '../models'
+
+export function ScheduleFormPage() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const selectedDate = useUiStore(s => s.selectedDate)
+
+  const { addEvent, removeEvent, replaceEvent, refreshCurrentRange } = useCalendarEventsStore()
+
+  const defaultEventTime = (): EventTime => {
+    const base = selectedDate ?? new Date()
+    return { time_type: 'at', timestamp: Math.floor(base.getTime() / 1000) }
+  }
+
+  const [loading, setLoading] = useState(!!id)
+  const [original, setOriginal] = useState<Schedule | null>(null)
+  const [name, setName] = useState('')
+  const [tagId, setTagId] = useState<string | null>(null)
+  const [eventTime, setEventTime] = useState<EventTime>(defaultEventTime)
+  const [repeating, setRepeating] = useState<Repeating | null>(null)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showSaveScope, setShowSaveScope] = useState(false)
+  const [showDeleteScope, setShowDeleteScope] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    scheduleApi.getSchedule(id).then(sch => {
+      setOriginal(sch)
+      setName(sch.name)
+      setTagId(sch.event_tag_id ?? null)
+      setEventTime(sch.event_time)
+      setRepeating(sch.repeating ?? null)
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [id])
+
+  function occurrenceStart(sch: Schedule): number {
+    const et = sch.event_time
+    return et.time_type === 'at' ? et.timestamp : et.period_start
+  }
+
+  async function applyCreate() {
+    const created = await scheduleApi.createSchedule({
+      name: name.trim(),
+      event_tag_id: tagId ?? undefined,
+      event_time: eventTime,
+      repeating: repeating ?? undefined,
+    })
+    addEvent({ type: 'schedule', event: created })
+  }
+
+  async function applyUpdate(scope: RepeatScope) {
+    if (!id || !original) return
+    if (!original.repeating || scope === 'all') {
+      const updated = await scheduleApi.updateSchedule(id, {
+        name: name.trim(),
+        event_tag_id: tagId,
+        event_time: eventTime,
+        repeating: repeating ?? undefined,
+      })
+      replaceEvent(id, { type: 'schedule', event: updated })
+    } else if (scope === 'this') {
+      const turn = original.show_turns?.[0] ?? 0
+      await scheduleApi.excludeRepeating(id, { exclude_repeatings: [...(original.exclude_repeatings ?? []), turn] })
+      await scheduleApi.createSchedule({
+        name: name.trim(),
+        event_tag_id: tagId ?? undefined,
+        event_time: eventTime,
+        repeating: undefined,
+      })
+      await refreshCurrentRange()
+    } else {
+      // scope === 'future'
+      const cutoff = occurrenceStart(original) - 1
+      await scheduleApi.updateSchedule(id, { repeating: { ...original.repeating, end: cutoff } })
+      await scheduleApi.createSchedule({
+        name: name.trim(),
+        event_tag_id: tagId ?? undefined,
+        event_time: eventTime,
+        repeating: repeating ?? undefined,
+      })
+      await refreshCurrentRange()
+    }
+  }
+
+  async function applyDelete(scope: RepeatScope) {
+    if (!id || !original) return
+    try {
+      if (!original.repeating || scope === 'all') {
+        await scheduleApi.deleteSchedule(id)
+        removeEvent(id)
+      } else if (scope === 'this') {
+        const turn = original.show_turns?.[0] ?? 0
+        await scheduleApi.excludeRepeating(id, { exclude_repeatings: [...(original.exclude_repeatings ?? []), turn] })
+        await refreshCurrentRange()
+      } else {
+        // scope === 'future'
+        const cutoff = occurrenceStart(original) - 1
+        await scheduleApi.updateSchedule(id, { repeating: { ...original.repeating, end: cutoff } })
+        await refreshCurrentRange()
+      }
+      navigate(-1)
+    } catch (e) {
+      console.warn('삭제 실패:', e)
+      setShowDeleteScope(false)
+      setShowDeleteConfirm(false)
+    }
+  }
+
+  async function handleSave() {
+    if (!name.trim()) return
+    if (id && original?.repeating) { setShowSaveScope(true); return }
+    setSaving(true)
+    try {
+      if (id) await applyUpdate('all')
+      else await applyCreate()
+      navigate(-1)
+    } catch (e) {
+      console.warn('저장 실패:', e)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleSaveWithScope(scope: RepeatScope) {
+    setShowSaveScope(false)
+    setSaving(true)
+    try {
+      await applyUpdate(scope)
+      navigate(-1)
+    } catch (e) {
+      console.warn('저장 실패:', e)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-lg font-bold">{id ? 'Schedule 수정' : '새 Schedule'}</h1>
+        <button className="text-sm text-gray-500" onClick={() => navigate(-1)}>취소</button>
+      </div>
+
+      <div className="space-y-5 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">이름</label>
+          <input
+            aria-label="이름"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">태그</label>
+          <div className="mt-1"><TagSelector value={tagId} onChange={setTagId} /></div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">시간</label>
+          <div className="mt-1">
+            <EventTimePicker value={eventTime} onChange={v => v && setEventTime(v)} required={true} />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">반복</label>
+          <div className="mt-1">
+            <RepeatingPicker
+              value={repeating}
+              onChange={setRepeating}
+              startTimestamp={eventTime.time_type === 'at' ? eventTime.timestamp : eventTime.period_start}
+            />
+          </div>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button
+            className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            저장
+          </button>
+          {id && (
+            <button
+              className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50"
+              onClick={() => original?.repeating ? setShowDeleteScope(true) : setShowDeleteConfirm(true)}
+            >
+              삭제
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showDeleteConfirm && (
+        <ConfirmDialog
+          title="Schedule 삭제"
+          message={`"${name}"을 삭제할까요?`}
+          onConfirm={async () => { setShowDeleteConfirm(false); await applyDelete('all') }}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      )}
+      {showSaveScope && (
+        <RepeatingScopeDialog
+          mode="edit"
+          onSelect={handleSaveWithScope}
+          onCancel={() => setShowSaveScope(false)}
+        />
+      )}
+      {showDeleteScope && (
+        <RepeatingScopeDialog
+          mode="delete"
+          onSelect={async scope => { setShowDeleteScope(false); await applyDelete(scope) }}
+          onCancel={() => setShowDeleteScope(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/ScheduleFormPage.tsx
+++ b/web/src/pages/ScheduleFormPage.tsx
@@ -42,7 +42,7 @@ export function ScheduleFormPage() {
       setEventTime(sch.event_time)
       setRepeating(sch.repeating ?? null)
       setLoading(false)
-    }).catch(() => setLoading(false))
+    }).catch((e) => { console.warn('일정 로드 실패:', e); setLoading(false) })
   }, [id])
 
   function occurrenceStart(sch: Schedule): number {
@@ -62,7 +62,8 @@ export function ScheduleFormPage() {
 
   async function applyUpdate(scope: RepeatScope) {
     if (!id || !original) return
-    if (!original.repeating || scope === 'all') {
+    if (!original.repeating) {
+      // Non-repeating: optimistic replaceEvent
       const updated = await scheduleApi.updateSchedule(id, {
         name: name.trim(),
         event_tag_id: tagId,
@@ -70,6 +71,15 @@ export function ScheduleFormPage() {
         repeating: repeating ?? undefined,
       })
       replaceEvent(id, { type: 'schedule', event: updated })
+    } else if (scope === 'all') {
+      // Full repeating series: refresh calendar
+      await scheduleApi.updateSchedule(id, {
+        name: name.trim(),
+        event_tag_id: tagId,
+        event_time: eventTime,
+        repeating: repeating ?? undefined,
+      })
+      await refreshCurrentRange()
     } else if (scope === 'this') {
       const turn = original.show_turns?.[0] ?? 0
       await scheduleApi.excludeRepeating(id, { exclude_repeatings: [...(original.exclude_repeatings ?? []), turn] })
@@ -97,9 +107,14 @@ export function ScheduleFormPage() {
   async function applyDelete(scope: RepeatScope) {
     if (!id || !original) return
     try {
-      if (!original.repeating || scope === 'all') {
+      if (!original.repeating) {
+        // Non-repeating: optimistic removeEvent
         await scheduleApi.deleteSchedule(id)
         removeEvent(id)
+      } else if (scope === 'all') {
+        // Full repeating series: refresh calendar
+        await scheduleApi.deleteSchedule(id)
+        await refreshCurrentRange()
       } else if (scope === 'this') {
         const turn = original.show_turns?.[0] ?? 0
         await scheduleApi.excludeRepeating(id, { exclude_repeatings: [...(original.exclude_repeatings ?? []), turn] })

--- a/web/src/pages/TagManagementPage.tsx
+++ b/web/src/pages/TagManagementPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useEventTagStore } from '../stores/eventTagStore'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import type { EventTag } from '../models'
+
+export function TagManagementPage() {
+  const navigate = useNavigate()
+  const { tags, createTag, updateTag, deleteTag } = useEventTagStore()
+  const [newName, setNewName] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editColor, setEditColor] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<EventTag | null>(null)
+
+  async function handleCreate() {
+    if (!newName.trim()) return
+    await createTag(newName.trim())
+    setNewName('')
+  }
+
+  async function handleUpdate(id: string) {
+    await updateTag(id, { name: editName, color_hex: editColor || undefined })
+    setEditingId(null)
+  }
+
+  function startEdit(tag: EventTag) {
+    setEditingId(tag.uuid)
+    setEditName(tag.name)
+    setEditColor(tag.color_hex ?? '')
+  }
+
+  return (
+    <div className="mx-auto max-w-sm px-4 py-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-lg font-bold">태그 관리</h1>
+        <button className="text-sm text-gray-500" onClick={() => navigate(-1)}>닫기</button>
+      </div>
+
+      {/* Create */}
+      <div className="mb-4 flex gap-2">
+        <input
+          className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm"
+          placeholder="새 태그 이름"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+        />
+        <button
+          className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          onClick={handleCreate}
+        >
+          추가
+        </button>
+      </div>
+
+      {/* List */}
+      <ul className="divide-y divide-gray-100">
+        {Array.from(tags.values()).map(tag => (
+          <li key={tag.uuid} className="py-3">
+            {editingId === tag.uuid ? (
+              <div className="flex gap-2">
+                <input className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm" value={editName} onChange={e => setEditName(e.target.value)} />
+                <input type="color" className="h-8 w-8 rounded border" value={editColor || '#000000'} onChange={e => setEditColor(e.target.value)} />
+                <button className="text-xs text-blue-500" onClick={() => handleUpdate(tag.uuid)}>저장</button>
+                <button className="text-xs text-gray-400" onClick={() => setEditingId(null)}>취소</button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  {tag.color_hex && <span className="h-3 w-3 rounded-full" style={{ backgroundColor: tag.color_hex }} />}
+                  <span className="text-sm">{tag.name}</span>
+                </div>
+                <div className="flex gap-2">
+                  <button className="text-xs text-gray-500" onClick={() => startEdit(tag)}>수정</button>
+                  <button className="text-xs text-red-500" onClick={() => setDeleteTarget(tag)}>삭제</button>
+                </div>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {deleteTarget && (
+        <ConfirmDialog
+          title="태그 삭제"
+          message={`"${deleteTarget.name}" 태그를 삭제할까요?`}
+          onConfirm={async () => { await deleteTag(deleteTarget.uuid); setDeleteTarget(null) }}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/TodoFormPage.tsx
+++ b/web/src/pages/TodoFormPage.tsx
@@ -52,8 +52,20 @@ export function TodoFormPage() {
           event_time: eventTime,
           repeating,
         })
-        replaceEvent(id, { type: 'todo', event: updated })
-        if (updated.is_current) replaceTodo(updated)
+        if (updated.event_time && !original?.event_time) {
+          addEvent({ type: 'todo', event: updated })
+        } else if (!updated.event_time && original?.event_time) {
+          removeEvent(id)
+        } else {
+          replaceEvent(id, { type: 'todo', event: updated })
+        }
+        if (updated.is_current && original?.is_current) {
+          replaceTodo(updated)
+        } else if (updated.is_current && !original?.is_current) {
+          addTodo(updated)
+        } else if (!updated.is_current && original?.is_current) {
+          removeTodo(id)
+        }
       } else {
         const created = await todoApi.createTodo({
           name: name.trim(),
@@ -74,14 +86,19 @@ export function TodoFormPage() {
 
   async function handleDelete() {
     if (!id) return
-    await todoApi.deleteTodo(id)
-    if (original?.repeating) {
-      await refreshCurrentRange()
-    } else {
-      removeEvent(id)
-      removeTodo(id)
+    try {
+      await todoApi.deleteTodo(id)
+      if (original?.repeating) {
+        await refreshCurrentRange()
+      } else {
+        removeEvent(id)
+        removeTodo(id)
+      }
+      navigate(-1)
+    } catch (e) {
+      console.warn('삭제 실패:', e)
+      setShowConfirm(false)
     }
-    navigate(-1)
   }
 
   if (loading) {

--- a/web/src/pages/TodoFormPage.tsx
+++ b/web/src/pages/TodoFormPage.tsx
@@ -15,7 +15,7 @@ export function TodoFormPage() {
   const navigate = useNavigate()
   const selectedDate = useUiStore(s => s.selectedDate)
 
-  const { addEvent, removeEvent, replaceEvent, refreshCurrentRange } = useCalendarEventsStore()
+  const { addEvent, removeEvent, refreshCurrentRange } = useCalendarEventsStore()
   const { addTodo, removeTodo, replaceTodo } = useCurrentTodosStore()
 
   const [loading, setLoading] = useState(!!id)
@@ -28,6 +28,7 @@ export function TodoFormPage() {
   const [repeating, setRepeating] = useState<Repeating | null>(null)
   const [showConfirm, setShowConfirm] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!id) return
@@ -56,8 +57,10 @@ export function TodoFormPage() {
           addEvent({ type: 'todo', event: updated })
         } else if (!updated.event_time && original?.event_time) {
           removeEvent(id)
-        } else {
-          replaceEvent(id, { type: 'todo', event: updated })
+        } else if (updated.event_time && original?.event_time) {
+          // event_time이 바뀌면 날짜 키가 달라질 수 있으므로 remove → add로 갱신
+          removeEvent(id)
+          addEvent({ type: 'todo', event: updated })
         }
         if (updated.is_current && original?.is_current) {
           replaceTodo(updated)
@@ -79,6 +82,7 @@ export function TodoFormPage() {
       navigate(-1)
     } catch (e) {
       console.warn('저장 실패:', e)
+      setError('저장에 실패했습니다. 다시 시도해주세요.')
     } finally {
       setSaving(false)
     }
@@ -97,6 +101,7 @@ export function TodoFormPage() {
       navigate(-1)
     } catch (e) {
       console.warn('삭제 실패:', e)
+      setError('삭제에 실패했습니다. 다시 시도해주세요.')
       setShowConfirm(false)
     }
   }
@@ -154,6 +159,9 @@ export function TodoFormPage() {
           </div>
         )}
 
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
+        )}
         <div className="flex gap-3 pt-2">
           <button
             className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"

--- a/web/src/pages/TodoFormPage.tsx
+++ b/web/src/pages/TodoFormPage.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { todoApi } from '../api/todoApi'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
+import { useCurrentTodosStore } from '../stores/currentTodosStore'
+import { useUiStore } from '../stores/uiStore'
+import { EventTimePicker } from '../components/EventTimePicker'
+import { RepeatingPicker } from '../components/RepeatingPicker'
+import { TagSelector } from '../components/TagSelector'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import type { Todo, EventTime, Repeating } from '../models'
+
+export function TodoFormPage() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const selectedDate = useUiStore(s => s.selectedDate)
+
+  const { addEvent, removeEvent, replaceEvent, refreshCurrentRange } = useCalendarEventsStore()
+  const { addTodo, removeTodo, replaceTodo } = useCurrentTodosStore()
+
+  const [loading, setLoading] = useState(!!id)
+  const [original, setOriginal] = useState<Todo | null>(null)
+  const [name, setName] = useState('')
+  const [tagId, setTagId] = useState<string | null>(null)
+  const [eventTime, setEventTime] = useState<EventTime | null>(() =>
+    selectedDate ? { time_type: 'at', timestamp: Math.floor(selectedDate.getTime() / 1000) } : null
+  )
+  const [repeating, setRepeating] = useState<Repeating | null>(null)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    todoApi.getTodo(id).then(todo => {
+      setOriginal(todo)
+      setName(todo.name)
+      setTagId(todo.event_tag_id ?? null)
+      setEventTime(todo.event_time ?? null)
+      setRepeating(todo.repeating ?? null)
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [id])
+
+  async function handleSave() {
+    if (!name.trim()) return
+    setSaving(true)
+    try {
+      if (id && original) {
+        const updated = await todoApi.updateTodo(id, {
+          name: name.trim(),
+          event_tag_id: tagId,
+          event_time: eventTime,
+          repeating,
+        })
+        replaceEvent(id, { type: 'todo', event: updated })
+        if (updated.is_current) replaceTodo(updated)
+      } else {
+        const created = await todoApi.createTodo({
+          name: name.trim(),
+          event_tag_id: tagId ?? undefined,
+          event_time: eventTime ?? undefined,
+          repeating: repeating ?? undefined,
+        })
+        if (created.event_time) addEvent({ type: 'todo', event: created })
+        if (created.is_current) addTodo(created)
+      }
+      navigate(-1)
+    } catch (e) {
+      console.warn('저장 실패:', e)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!id) return
+    await todoApi.deleteTodo(id)
+    if (original?.repeating) {
+      await refreshCurrentRange()
+    } else {
+      removeEvent(id)
+      removeTodo(id)
+    }
+    navigate(-1)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-lg font-bold">{id ? 'Todo 수정' : '새 Todo'}</h1>
+        <button className="text-sm text-gray-500" onClick={() => navigate(-1)}>취소</button>
+      </div>
+
+      <div className="space-y-5 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">이름</label>
+          <input
+            aria-label="이름"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">태그</label>
+          <div className="mt-1"><TagSelector value={tagId} onChange={setTagId} /></div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">시간</label>
+          <div className="mt-1"><EventTimePicker value={eventTime} onChange={setEventTime} required={false} /></div>
+        </div>
+
+        {eventTime && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700">반복</label>
+            <div className="mt-1">
+              <RepeatingPicker
+                value={repeating}
+                onChange={setRepeating}
+                startTimestamp={
+                  eventTime.time_type === 'at'
+                    ? eventTime.timestamp
+                    : eventTime.period_start
+                }
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <button
+            className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            저장
+          </button>
+          {id && (
+            <button
+              className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50"
+              onClick={() => setShowConfirm(true)}
+            >
+              삭제
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showConfirm && (
+        <ConfirmDialog
+          title="Todo 삭제"
+          message={`"${name}" 을 정말 삭제할까요?${original?.repeating ? '\n반복 Todo는 전체 시리즈가 삭제됩니다.' : ''}`}
+          onConfirm={handleDelete}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/stores/calendarEventsStore.ts
+++ b/web/src/stores/calendarEventsStore.ts
@@ -1,21 +1,27 @@
 import { create } from 'zustand'
 import { todoApi } from '../api/todoApi'
 import { scheduleApi } from '../api/scheduleApi'
-import { groupEventsByDate } from '../utils/eventTimeUtils'
+import { groupEventsByDate, eventTimeOverlapsRange, eventTimeToStartDate, eventTimeToEndDate, formatDateKey } from '../utils/eventTimeUtils'
 import type { CalendarEvent } from '../utils/eventTimeUtils'
 
 interface CalendarEventsState {
   eventsByDate: Map<string, CalendarEvent[]>
   loading: boolean
+  lastRange: { lower: number; upper: number } | null
   fetchEventsForRange: (lower: number, upper: number) => Promise<void>
+  refreshCurrentRange: () => Promise<void>
+  addEvent: (event: CalendarEvent) => void
+  removeEvent: (uuid: string) => void
+  replaceEvent: (uuid: string, next: CalendarEvent) => void
 }
 
-export const useCalendarEventsStore = create<CalendarEventsState>((set) => ({
+export const useCalendarEventsStore = create<CalendarEventsState>((set, get) => ({
   eventsByDate: new Map(),
   loading: false,
+  lastRange: null,
 
   fetchEventsForRange: async (lower: number, upper: number) => {
-    set({ loading: true, eventsByDate: new Map() })
+    set({ loading: true, eventsByDate: new Map(), lastRange: { lower, upper } })
     try {
       const [todos, schedules] = await Promise.all([
         todoApi.getTodos(lower, upper),
@@ -27,5 +33,55 @@ export const useCalendarEventsStore = create<CalendarEventsState>((set) => ({
       console.warn('이벤트 로드 실패:', e)
       set({ loading: false })
     }
+  },
+
+  refreshCurrentRange: async () => {
+    const { lastRange, fetchEventsForRange } = get()
+    if (!lastRange) return
+    await fetchEventsForRange(lastRange.lower, lastRange.upper)
+  },
+
+  addEvent: (event: CalendarEvent) => {
+    const { eventsByDate, lastRange } = get()
+    if (!lastRange) return
+    const eventTime = event.type === 'todo'
+      ? (event.event.event_time ?? null)
+      : event.event.event_time
+    if (!eventTime) return
+
+    if (!eventTimeOverlapsRange(eventTime, lastRange.lower, lastRange.upper)) return
+
+    const updated = new Map(eventsByDate)
+    const start = eventTimeToStartDate(eventTime)
+    const end = eventTimeToEndDate(eventTime)
+    const cur = new Date(start)
+    cur.setHours(0, 0, 0, 0)
+    const endDay = new Date(end)
+    endDay.setHours(0, 0, 0, 0)
+    while (cur <= endDay) {
+      const key = formatDateKey(cur)
+      updated.set(key, [...(updated.get(key) ?? []), event])
+      cur.setDate(cur.getDate() + 1)
+    }
+    set({ eventsByDate: updated })
+  },
+
+  removeEvent: (uuid: string) => {
+    const { eventsByDate } = get()
+    const updated = new Map<string, CalendarEvent[]>()
+    for (const [key, events] of eventsByDate) {
+      const filtered = events.filter(e => e.event.uuid !== uuid)
+      if (filtered.length > 0) updated.set(key, filtered)
+    }
+    set({ eventsByDate: updated })
+  },
+
+  replaceEvent: (uuid: string, next: CalendarEvent) => {
+    const { eventsByDate } = get()
+    const updated = new Map<string, CalendarEvent[]>()
+    for (const [key, events] of eventsByDate) {
+      updated.set(key, events.map(e => e.event.uuid === uuid ? next : e))
+    }
+    set({ eventsByDate: updated })
   },
 }))

--- a/web/src/stores/currentTodosStore.ts
+++ b/web/src/stores/currentTodosStore.ts
@@ -5,9 +5,12 @@ import type { Todo } from '../models'
 interface CurrentTodosState {
   todos: Todo[]
   fetch: () => Promise<void>
+  addTodo: (todo: Todo) => void
+  removeTodo: (uuid: string) => void
+  replaceTodo: (todo: Todo) => void
 }
 
-export const useCurrentTodosStore = create<CurrentTodosState>((set) => ({
+export const useCurrentTodosStore = create<CurrentTodosState>((set, get) => ({
   todos: [],
 
   fetch: async () => {
@@ -18,4 +21,8 @@ export const useCurrentTodosStore = create<CurrentTodosState>((set) => ({
       console.warn('Current todo 로드 실패:', e)
     }
   },
+
+  addTodo: (todo: Todo) => set(s => ({ todos: [...s.todos, todo] })),
+  removeTodo: (uuid: string) => set(s => ({ todos: s.todos.filter(t => t.uuid !== uuid) })),
+  replaceTodo: (todo: Todo) => set(s => ({ todos: s.todos.map(t => t.uuid === todo.uuid ? todo : t) })),
 }))

--- a/web/src/stores/currentTodosStore.ts
+++ b/web/src/stores/currentTodosStore.ts
@@ -10,7 +10,7 @@ interface CurrentTodosState {
   replaceTodo: (todo: Todo) => void
 }
 
-export const useCurrentTodosStore = create<CurrentTodosState>((set, get) => ({
+export const useCurrentTodosStore = create<CurrentTodosState>((set, _get) => ({
   todos: [],
 
   fetch: async () => {

--- a/web/src/stores/eventTagStore.ts
+++ b/web/src/stores/eventTagStore.ts
@@ -6,6 +6,9 @@ interface EventTagState {
   tags: Map<string, EventTag>
   fetchAll: () => Promise<void>
   getColorForTagId: (id: string) => string | null | undefined
+  createTag: (name: string, color_hex?: string) => Promise<EventTag>
+  updateTag: (id: string, updates: { name?: string; color_hex?: string }) => Promise<EventTag>
+  deleteTag: (id: string) => Promise<void>
 }
 
 export const useEventTagStore = create<EventTagState>((set, get) => ({
@@ -15,16 +18,29 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
     try {
       const list = await eventTagApi.getAllTags()
       const map = new Map<string, EventTag>()
-      for (const tag of list) {
-        map.set(tag.uuid, tag)
-      }
+      for (const tag of list) map.set(tag.uuid, tag)
       set({ tags: map })
     } catch (e) {
       console.warn('태그 로드 실패:', e)
     }
   },
 
-  getColorForTagId: (id: string) => {
-    return get().tags.get(id)?.color_hex
+  getColorForTagId: (id: string) => get().tags.get(id)?.color_hex,
+
+  createTag: async (name: string, color_hex?: string) => {
+    const tag = await eventTagApi.createTag({ name, color_hex })
+    set(s => { const tags = new Map(s.tags); tags.set(tag.uuid, tag); return { tags } })
+    return tag
+  },
+
+  updateTag: async (id: string, updates: { name?: string; color_hex?: string }) => {
+    const tag = await eventTagApi.updateTag(id, { name: updates.name ?? '', color_hex: updates.color_hex })
+    set(s => { const tags = new Map(s.tags); tags.set(tag.uuid, tag); return { tags } })
+    return tag
+  },
+
+  deleteTag: async (id: string) => {
+    await eventTagApi.deleteTag(id)
+    set(s => { const tags = new Map(s.tags); tags.delete(id); return { tags } })
   },
 }))

--- a/web/src/stores/eventTagStore.ts
+++ b/web/src/stores/eventTagStore.ts
@@ -34,7 +34,7 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
   },
 
   updateTag: async (id: string, updates: { name?: string; color_hex?: string }) => {
-    const tag = await eventTagApi.updateTag(id, { name: updates.name ?? '', color_hex: updates.color_hex })
+    const tag = await eventTagApi.updateTag(id, { name: updates.name ?? get().tags.get(id)?.name ?? '', color_hex: updates.color_hex })
     set(s => { const tags = new Map(s.tags); tags.set(tag.uuid, tag); return { tags } })
     return tag
   },

--- a/web/src/utils/eventTimeUtils.ts
+++ b/web/src/utils/eventTimeUtils.ts
@@ -56,7 +56,7 @@ export function monthRange(year: number, month: number): { lower: number; upper:
 
 export type CalendarEvent = { type: 'todo'; event: Todo } | { type: 'schedule'; event: Schedule }
 
-function eventTimeOverlapsRange(eventTime: EventTime, lower: number, upper: number): boolean {
+export function eventTimeOverlapsRange(eventTime: EventTime, lower: number, upper: number): boolean {
   switch (eventTime.time_type) {
     case 'at':
       return eventTime.timestamp >= lower && eventTime.timestamp <= upper

--- a/web/tests/components/ConfirmDialog.test.tsx
+++ b/web/tests/components/ConfirmDialog.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConfirmDialog } from '../../src/components/ConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  it('제목과 메시지를 표시한다', () => {
+    render(<ConfirmDialog title="삭제 확인" message="정말 삭제할까요?" onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('삭제 확인')).toBeInTheDocument()
+    expect(screen.getByText('정말 삭제할까요?')).toBeInTheDocument()
+  })
+
+  it('확인 버튼을 클릭하면 onConfirm이 호출된다', async () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDialog title="삭제" message="삭제?" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('취소 버튼을 클릭하면 onCancel이 호출된다', async () => {
+    const onCancel = vi.fn()
+    render(<ConfirmDialog title="삭제" message="삭제?" onConfirm={vi.fn()} onCancel={onCancel} />)
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/web/tests/components/CurrentTodoList.test.tsx
+++ b/web/tests/components/CurrentTodoList.test.tsx
@@ -1,14 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { CurrentTodoList } from '../../src/components/CurrentTodoList'
 import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
+import { useCalendarEventsStore } from '../../src/stores/calendarEventsStore'
 import { useEventTagStore } from '../../src/stores/eventTagStore'
 
-vi.mock('../../src/stores/currentTodosStore', () => ({ useCurrentTodosStore: vi.fn() }))
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: {
+    getCurrentTodos: vi.fn(),
+    completeTodo: vi.fn(),
+  },
+}))
+vi.mock('../../src/api/scheduleApi', () => ({
+  scheduleApi: {
+    getSchedules: vi.fn().mockResolvedValue([]),
+  },
+}))
 vi.mock('../../src/stores/eventTagStore', () => ({ useEventTagStore: vi.fn() }))
-vi.mock('../../src/api/todoApi', () => ({ todoApi: { getCurrentTodos: async () => [] } }))
+vi.mock('../../src/firebase', () => ({
+  auth: {},
+  db: {},
+}))
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -30,12 +44,11 @@ describe('CurrentTodoList', () => {
     vi.mocked(useEventTagStore).mockImplementation((selector: any) =>
       selector({ getColorForTagId: () => null })
     )
+    useCurrentTodosStore.setState({ todos: [] })
   })
 
   it('current todo가 없으면 아무것도 렌더링하지 않는다', () => {
-    vi.mocked(useCurrentTodosStore).mockImplementation((selector: any) =>
-      selector({ todos: [], fetch: vi.fn() })
-    )
+    useCurrentTodosStore.setState({ todos: [] })
 
     const { container } = renderComponent()
 
@@ -47,9 +60,7 @@ describe('CurrentTodoList', () => {
       { uuid: 'ct1', name: '시간 없는 할 일 A', is_current: true, event_time: null },
       { uuid: 'ct2', name: '시간 없는 할 일 B', is_current: true, event_time: null },
     ]
-    vi.mocked(useCurrentTodosStore).mockImplementation((selector: any) =>
-      selector({ todos, fetch: vi.fn() })
-    )
+    useCurrentTodosStore.setState({ todos: todos as any })
 
     renderComponent()
 
@@ -59,13 +70,53 @@ describe('CurrentTodoList', () => {
 
   it('항목을 클릭하면 해당 이벤트 상세 페이지로 이동한다', async () => {
     const todos = [{ uuid: 'ct-nav', name: '이동 테스트', is_current: true, event_time: null }]
-    vi.mocked(useCurrentTodosStore).mockImplementation((selector: any) =>
-      selector({ todos, fetch: vi.fn() })
-    )
+    useCurrentTodosStore.setState({ todos: todos as any })
 
     renderComponent()
     await userEvent.click(screen.getByRole('button', { name: /이동 테스트/ }))
 
     expect(mockNavigate.mock.calls[0][0]).toBe('/events/ct-nav')
+  })
+})
+
+describe('CurrentTodoList — 완료', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useEventTagStore).mockImplementation((selector: any) =>
+      selector({ getColorForTagId: () => null })
+    )
+    useCurrentTodosStore.setState({ todos: [] })
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+  })
+
+  it('체크박스 클릭 시 completeTodo API가 호출된다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
+    const todo = { uuid: 't1', name: '완료 할 일', is_current: true, event_time: null }
+    useCurrentTodosStore.setState({ todos: [todo as any] })
+
+    render(
+      <MemoryRouter>
+        <CurrentTodoList />
+      </MemoryRouter>
+    )
+
+    await userEvent.click(screen.getByRole('checkbox', { name: '완료 할 일' }))
+    expect(todoApi.completeTodo).toHaveBeenCalled()
+  })
+
+  it('완료 후 해당 Todo가 목록에서 사라진다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
+    const todo = { uuid: 't1', name: '완료 할 일', is_current: true, event_time: null }
+    useCurrentTodosStore.setState({ todos: [todo as any] })
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+
+    render(<MemoryRouter><CurrentTodoList /></MemoryRouter>)
+    await userEvent.click(screen.getByRole('checkbox', { name: '완료 할 일' }))
+
+    await waitFor(() => {
+      expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(false)
+    })
   })
 })

--- a/web/tests/components/CurrentTodoList.test.tsx
+++ b/web/tests/components/CurrentTodoList.test.tsx
@@ -11,6 +11,7 @@ vi.mock('../../src/api/todoApi', () => ({
   todoApi: {
     getCurrentTodos: vi.fn(),
     completeTodo: vi.fn(),
+    getTodos: vi.fn().mockResolvedValue([]),
   },
 }))
 vi.mock('../../src/api/scheduleApi', () => ({
@@ -89,23 +90,7 @@ describe('CurrentTodoList — 완료', () => {
     useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
   })
 
-  it('체크박스 클릭 시 completeTodo API가 호출된다', async () => {
-    const { todoApi } = await import('../../src/api/todoApi')
-    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
-    const todo = { uuid: 't1', name: '완료 할 일', is_current: true, event_time: null }
-    useCurrentTodosStore.setState({ todos: [todo as any] })
-
-    render(
-      <MemoryRouter>
-        <CurrentTodoList />
-      </MemoryRouter>
-    )
-
-    await userEvent.click(screen.getByRole('checkbox', { name: '완료 할 일' }))
-    expect(todoApi.completeTodo).toHaveBeenCalled()
-  })
-
-  it('완료 후 해당 Todo가 목록에서 사라진다', async () => {
+  it('비반복 Todo 체크박스 클릭 시 해당 Todo가 목록에서 사라진다', async () => {
     const { todoApi } = await import('../../src/api/todoApi')
     vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
     const todo = { uuid: 't1', name: '완료 할 일', is_current: true, event_time: null }
@@ -117,6 +102,28 @@ describe('CurrentTodoList — 완료', () => {
 
     await waitFor(() => {
       expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(false)
+    })
+  })
+
+  it('반복 Todo 체크박스 클릭 시 currentRange가 갱신된다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
+    const repeatingTodo = {
+      uuid: 't2',
+      name: '반복 할 일',
+      is_current: true,
+      event_time: { time_type: 'at' as const, timestamp: 1743375600 },
+      repeating: { start: 1743375600, option: { optionType: 'every_day' as const, interval: 1 } },
+    }
+    useCurrentTodosStore.setState({ todos: [repeatingTodo as any] })
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: { lower: 0, upper: 9999999999 } })
+
+    render(<MemoryRouter><CurrentTodoList /></MemoryRouter>)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복 할 일' }))
+
+    // After completion, loading state cycles (fetch triggered by refreshCurrentRange)
+    await waitFor(() => {
+      expect(useCalendarEventsStore.getState().loading).toBe(false)
     })
   })
 })

--- a/web/tests/components/DayEventList.test.tsx
+++ b/web/tests/components/DayEventList.test.tsx
@@ -69,9 +69,9 @@ describe('DayEventList', () => {
 
     renderComponent(new Date(2024, 2, 15))
 
-    const items = screen.getAllByRole('button')
-    expect(items[0]).toHaveTextContent('할 일')
-    expect(items[1]).toHaveTextContent('일정')
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems[0]).toHaveTextContent('할 일')
+    expect(listItems[1]).toHaveTextContent('일정')
   })
 
   it('이벤트를 클릭하면 해당 이벤트 상세 페이지로 이동한다', async () => {
@@ -86,5 +86,27 @@ describe('DayEventList', () => {
     await userEvent.click(screen.getByRole('button', { name: /상세 확인 할 일/ }))
 
     expect(mockNavigate.mock.calls[0][0]).toBe('/events/todo-abc')
+  })
+})
+
+describe('DayEventList — 편집 메뉴', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEventTagStore()
+  })
+
+  it('이벤트 아이템에 "···" 메뉴 버튼이 표시된다', () => {
+    const todo = { uuid: 't1', name: '할 일', is_current: false, event_time: null }
+    mockCalendarEventsStore(new Map([['2024-03-15', [{ type: 'todo' as const, event: todo }]]]))
+    renderComponent(new Date(2024, 2, 15))
+    expect(screen.getByRole('button', { name: '메뉴' })).toBeInTheDocument()
+  })
+
+  it('"···" 메뉴 클릭 시 수정 옵션이 표시된다', async () => {
+    const todo = { uuid: 't1', name: '할 일', is_current: false, event_time: null }
+    mockCalendarEventsStore(new Map([['2024-03-15', [{ type: 'todo' as const, event: todo }]]]))
+    renderComponent(new Date(2024, 2, 15))
+    await userEvent.click(screen.getByRole('button', { name: '메뉴' }))
+    expect(screen.getByText('수정')).toBeInTheDocument()
   })
 })

--- a/web/tests/components/EventTimePicker.test.tsx
+++ b/web/tests/components/EventTimePicker.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EventTimePicker } from '../../src/components/EventTimePicker'
+
+describe('EventTimePicker', () => {
+  it('required=false이고 value=null이면 "시간 없음" 옵션이 선택된다', () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} required={false} />)
+    expect(screen.getByRole('radio', { name: '시간 없음' })).toBeChecked()
+  })
+
+  it('"특정 시각" 탭을 선택하면 단일 datetime 입력 필드가 표시된다', async () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('radio', { name: '특정 시각' }))
+    expect(screen.getByLabelText('시각')).toBeInTheDocument()
+  })
+
+  it('"기간" 탭을 선택하면 시작/종료 datetime 필드가 표시된다', async () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('radio', { name: '기간' }))
+    expect(screen.getByLabelText('시작')).toBeInTheDocument()
+    expect(screen.getByLabelText('종료')).toBeInTheDocument()
+  })
+
+  it('"종일" 탭을 선택하면 날짜만 있는 시작/종료 필드가 표시된다', async () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('radio', { name: '종일' }))
+    expect(screen.getByLabelText('시작일')).toBeInTheDocument()
+    expect(screen.getByLabelText('종료일')).toBeInTheDocument()
+  })
+
+  it('기존 at 값이 있으면 "특정 시각" 타입으로 초기화된다', () => {
+    const value = { time_type: 'at' as const, timestamp: 1743375600 }
+    render(<EventTimePicker value={value} onChange={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: '특정 시각' })).toBeChecked()
+    expect(screen.getByLabelText('시각')).toBeInTheDocument()
+  })
+
+  it('기존 period 값이 있으면 "기간" 타입으로 초기화된다', () => {
+    const value = { time_type: 'period' as const, period_start: 1743375600, period_end: 1743379200 }
+    render(<EventTimePicker value={value} onChange={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: '기간' })).toBeChecked()
+  })
+
+  it('required=true이면 "시간 없음" 옵션이 표시되지 않는다', () => {
+    render(<EventTimePicker value={null} onChange={vi.fn()} required={true} />)
+    expect(screen.queryByRole('radio', { name: '시간 없음' })).not.toBeInTheDocument()
+  })
+})

--- a/web/tests/components/RepeatingPicker.test.tsx
+++ b/web/tests/components/RepeatingPicker.test.tsx
@@ -34,4 +34,19 @@ describe('RepeatingPicker', () => {
     render(<RepeatingPicker value={value} onChange={vi.fn()} startTimestamp={1743375600} />)
     expect(screen.getByRole('checkbox', { name: '반복' })).toBeChecked()
   })
+
+  it('종료 날짜 선택 시 onChange에 end 필드가 포함된다', async () => {
+    const onChange = vi.fn()
+    render(<RepeatingPicker value={null} onChange={onChange} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    await userEvent.click(screen.getByRole('radio', { name: '날짜' }))
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it('"매년" 선택 시 월 입력 필드가 표시된다', async () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '반복 유형' }), 'every_year')
+    expect(screen.getByLabelText('월')).toBeInTheDocument()
+  })
 })

--- a/web/tests/components/RepeatingPicker.test.tsx
+++ b/web/tests/components/RepeatingPicker.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RepeatingPicker } from '../../src/components/RepeatingPicker'
+
+describe('RepeatingPicker', () => {
+  it('기본값은 반복 없음이다', () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    expect(screen.getByRole('checkbox', { name: '반복' })).not.toBeChecked()
+  })
+
+  it('반복 토글 ON 시 기본 타입 "매일" 옵션이 표시된다', async () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    expect(screen.getByRole('combobox', { name: '반복 유형' })).toBeInTheDocument()
+  })
+
+  it('"매주" 선택 시 요일 체크박스가 표시된다', async () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '반복 유형' }), 'every_week')
+    expect(screen.getByText('월')).toBeInTheDocument()
+  })
+
+  it('"매월" 선택 시 날짜/요일 선택 라디오가 표시된다', async () => {
+    render(<RepeatingPicker value={null} onChange={vi.fn()} startTimestamp={1743375600} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: '반복' }))
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '반복 유형' }), 'every_month')
+    expect(screen.getByRole('radio', { name: '날짜 지정' })).toBeInTheDocument()
+  })
+
+  it('기존 반복 값이 있으면 반복 토글이 ON 상태로 초기화된다', () => {
+    const value = { start: 1743375600, option: { optionType: 'every_day' as const, interval: 1 } }
+    render(<RepeatingPicker value={value} onChange={vi.fn()} startTimestamp={1743375600} />)
+    expect(screen.getByRole('checkbox', { name: '반복' })).toBeChecked()
+  })
+})

--- a/web/tests/components/RepeatingScopeDialog.test.tsx
+++ b/web/tests/components/RepeatingScopeDialog.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RepeatingScopeDialog } from '../../src/components/RepeatingScopeDialog'
+
+describe('RepeatingScopeDialog', () => {
+  it('삭제 모드에서는 "반복 일정 삭제" 제목을 표시한다', () => {
+    render(<RepeatingScopeDialog mode="delete" onSelect={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('반복 일정 삭제')).toBeInTheDocument()
+  })
+
+  it('수정 모드에서는 "반복 일정 수정" 제목을 표시한다', () => {
+    render(<RepeatingScopeDialog mode="edit" onSelect={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('반복 일정 수정')).toBeInTheDocument()
+  })
+
+  it('"이 이벤트만" 선택 시 scope "this"로 onSelect가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<RepeatingScopeDialog mode="delete" onSelect={onSelect} onCancel={vi.fn()} />)
+    await userEvent.click(screen.getByText('이 이벤트만'))
+    expect(onSelect).toHaveBeenCalledWith('this')
+  })
+
+  it('"이 이벤트 및 이후 이벤트" 선택 시 scope "future"로 onSelect가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<RepeatingScopeDialog mode="delete" onSelect={onSelect} onCancel={vi.fn()} />)
+    await userEvent.click(screen.getByText('이 이벤트 및 이후 이벤트'))
+    expect(onSelect).toHaveBeenCalledWith('future')
+  })
+
+  it('"모든 이벤트" 선택 시 scope "all"로 onSelect가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<RepeatingScopeDialog mode="edit" onSelect={onSelect} onCancel={vi.fn()} />)
+    await userEvent.click(screen.getByText('모든 이벤트'))
+    expect(onSelect).toHaveBeenCalledWith('all')
+  })
+
+  it('취소 버튼을 클릭하면 onCancel이 호출된다', async () => {
+    const onCancel = vi.fn()
+    render(<RepeatingScopeDialog mode="delete" onSelect={vi.fn()} onCancel={onCancel} />)
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/web/tests/components/TagSelector.test.tsx
+++ b/web/tests/components/TagSelector.test.tsx
@@ -36,7 +36,7 @@ describe('TagSelector', () => {
   it('"태그 관리" 버튼 클릭 시 /tags로 이동한다', async () => {
     mockTags([])
     render(<MemoryRouter><TagSelector value={null} onChange={vi.fn()} /></MemoryRouter>)
-    await userEvent.click(screen.getByRole('button', { name: '태그 관리' }))
+    await userEvent.click(screen.getByRole('button', { name: '태그 관리 >' }))
     expect(mockNavigate).toHaveBeenCalled()
   })
 })

--- a/web/tests/components/TagSelector.test.tsx
+++ b/web/tests/components/TagSelector.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { TagSelector } from '../../src/components/TagSelector'
+import { useEventTagStore } from '../../src/stores/eventTagStore'
+
+vi.mock('../../src/stores/eventTagStore', () => ({ useEventTagStore: vi.fn() }))
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function mockTags(tags: Array<{ uuid: string; name: string; color_hex?: string }>) {
+  vi.mocked(useEventTagStore).mockImplementation((sel: any) => sel({ tags: new Map(tags.map(t => [t.uuid, t])), getColorForTagId: (id: string) => tags.find(t => t.uuid === id)?.color_hex }))
+}
+
+describe('TagSelector', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('태그 목록을 표시한다', () => {
+    mockTags([{ uuid: 't1', name: '업무', color_hex: '#ff0000' }])
+    render(<MemoryRouter><TagSelector value={null} onChange={vi.fn()} /></MemoryRouter>)
+    expect(screen.getByText('업무')).toBeInTheDocument()
+  })
+
+  it('태그를 선택하면 onChange가 해당 uuid로 호출된다', async () => {
+    const onChange = vi.fn()
+    mockTags([{ uuid: 't1', name: '업무', color_hex: '#ff0000' }])
+    render(<MemoryRouter><TagSelector value={null} onChange={onChange} /></MemoryRouter>)
+    await userEvent.click(screen.getByText('업무'))
+    expect(onChange).toHaveBeenCalledWith('t1')
+  })
+
+  it('"태그 관리" 버튼 클릭 시 /tags로 이동한다', async () => {
+    mockTags([])
+    render(<MemoryRouter><TagSelector value={null} onChange={vi.fn()} /></MemoryRouter>)
+    await userEvent.click(screen.getByRole('button', { name: '태그 관리' }))
+    expect(mockNavigate).toHaveBeenCalled()
+  })
+})

--- a/web/tests/components/TypeSelectorPopup.test.tsx
+++ b/web/tests/components/TypeSelectorPopup.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TypeSelectorPopup } from '../../src/components/TypeSelectorPopup'
+
+describe('TypeSelectorPopup', () => {
+  it('Todo와 Schedule 선택지를 표시한다', () => {
+    render(<TypeSelectorPopup onSelect={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByText('Todo')).toBeInTheDocument()
+    expect(screen.getByText('Schedule')).toBeInTheDocument()
+  })
+
+  it('Todo 클릭 시 onSelect("todo")가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<TypeSelectorPopup onSelect={onSelect} onClose={vi.fn()} />)
+    await userEvent.click(screen.getByText('Todo'))
+    expect(onSelect).toHaveBeenCalledWith('todo')
+  })
+
+  it('Schedule 클릭 시 onSelect("schedule")가 호출된다', async () => {
+    const onSelect = vi.fn()
+    render(<TypeSelectorPopup onSelect={onSelect} onClose={vi.fn()} />)
+    await userEvent.click(screen.getByText('Schedule'))
+    expect(onSelect).toHaveBeenCalledWith('schedule')
+  })
+
+  it('배경 클릭 시 onClose가 호출된다', async () => {
+    const onClose = vi.fn()
+    render(<TypeSelectorPopup onSelect={vi.fn()} onClose={onClose} />)
+    await userEvent.click(screen.getByTestId('popup-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/tests/pages/ScheduleFormPage.test.tsx
+++ b/web/tests/pages/ScheduleFormPage.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { ScheduleFormPage } from '../../src/pages/ScheduleFormPage'
+
+vi.mock('../../src/api/scheduleApi', () => ({
+  scheduleApi: {
+    getSchedule: vi.fn(),
+    createSchedule: vi.fn(),
+    updateSchedule: vi.fn(),
+    excludeRepeating: vi.fn(),
+    deleteSchedule: vi.fn(),
+  },
+}))
+vi.mock('../../src/stores/eventTagStore', () => ({ useEventTagStore: vi.fn() }))
+vi.mock('../../src/stores/uiStore', () => ({ useUiStore: vi.fn() }))
+vi.mock('../../src/stores/calendarEventsStore', () => ({ useCalendarEventsStore: vi.fn() }))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+import { useEventTagStore } from '../../src/stores/eventTagStore'
+import { useUiStore } from '../../src/stores/uiStore'
+import { useCalendarEventsStore } from '../../src/stores/calendarEventsStore'
+
+const mockAddEvent = vi.fn()
+const mockRemoveEvent = vi.fn()
+const mockReplaceEvent = vi.fn()
+const mockRefreshCurrentRange = vi.fn()
+
+function setupMocks() {
+  vi.mocked(useEventTagStore).mockImplementation((sel: any) => sel({ tags: new Map(), getColorForTagId: () => null }))
+  vi.mocked(useUiStore).mockImplementation((sel: any) => sel({ selectedDate: new Date('2025-03-31') }))
+  const calendarState = {
+    addEvent: mockAddEvent,
+    removeEvent: mockRemoveEvent,
+    replaceEvent: mockReplaceEvent,
+    refreshCurrentRange: mockRefreshCurrentRange,
+  }
+  vi.mocked(useCalendarEventsStore).mockImplementation((sel?: any) =>
+    sel ? sel(calendarState) : calendarState
+  )
+}
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/schedules/new']}>
+      <Routes><Route path="/schedules/new" element={<ScheduleFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+function renderEdit(id: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/schedules/${id}/edit`]}>
+      <Routes><Route path="/schedules/:id/edit" element={<ScheduleFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('ScheduleFormPage — create', () => {
+  beforeEach(() => {
+    setupMocks()
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('"새 Schedule" 제목을 표시한다', () => {
+    renderCreate()
+    expect(screen.getByText('새 Schedule')).toBeInTheDocument()
+  })
+
+  it('이름 입력 후 저장하면 createSchedule이 호출되고 화면을 닫는다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(scheduleApi.createSchedule).mockResolvedValue({
+      uuid: 'new-1', name: '회의', event_time: { time_type: 'at', timestamp: 1743375600 },
+    })
+    renderCreate()
+    await userEvent.type(screen.getByLabelText('이름'), '회의')
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+  })
+
+  it('이름이 비어 있으면 저장 버튼을 클릭해도 API가 호출되지 않는다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    renderCreate()
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    expect(scheduleApi.createSchedule).not.toHaveBeenCalled()
+  })
+})
+
+describe('ScheduleFormPage — edit (반복)', () => {
+  const repeatingSch = {
+    uuid: 'sch-1',
+    name: '주간 미팅',
+    event_time: { time_type: 'at' as const, timestamp: 1743375600 },
+    repeating: { start: 1743375600, option: { optionType: 'every_week' as const, interval: 1, dayOfWeek: [1], timeZone: 'Asia/Seoul' } },
+    show_turns: [3],
+  }
+
+  beforeEach(() => {
+    setupMocks()
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('기존 schedule을 불러와 이름 필드에 표시한다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(scheduleApi.getSchedule).mockResolvedValue(repeatingSch as any)
+    renderEdit('sch-1')
+    await waitFor(() => expect(screen.getByDisplayValue('주간 미팅')).toBeInTheDocument())
+  })
+
+  it('반복 Schedule 수정 시 scope 선택 다이얼로그가 표시된다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(scheduleApi.getSchedule).mockResolvedValue(repeatingSch as any)
+    renderEdit('sch-1')
+    await waitFor(() => screen.getByDisplayValue('주간 미팅'))
+    await userEvent.type(screen.getByLabelText('이름'), ' 수정')
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    expect(screen.getByText('반복 일정 수정')).toBeInTheDocument()
+  })
+
+  it('반복 Schedule 삭제 시 scope 선택 다이얼로그가 표시된다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(scheduleApi.getSchedule).mockResolvedValue(repeatingSch as any)
+    renderEdit('sch-1')
+    await waitFor(() => screen.getByRole('button', { name: '삭제' }))
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    expect(screen.getByText('반복 일정 삭제')).toBeInTheDocument()
+  })
+
+  it('비반복 Schedule 삭제 시 확인 다이얼로그가 표시된다', async () => {
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    const simpleSch = { uuid: 'sch-2', name: '단순 일정', event_time: { time_type: 'at' as const, timestamp: 1743375600 } }
+    vi.mocked(scheduleApi.getSchedule).mockResolvedValue(simpleSch as any)
+    renderEdit('sch-2')
+    await waitFor(() => screen.getByRole('button', { name: '삭제' }))
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    expect(screen.getByText(/삭제할까요/)).toBeInTheDocument()
+  })
+})

--- a/web/tests/pages/ScheduleFormPage.test.tsx
+++ b/web/tests/pages/ScheduleFormPage.test.tsx
@@ -64,7 +64,6 @@ function renderEdit(id: string) {
 
 describe('ScheduleFormPage — create', () => {
   beforeEach(() => {
-    setupMocks()
     vi.clearAllMocks()
     setupMocks()
   })
@@ -103,7 +102,6 @@ describe('ScheduleFormPage — edit (반복)', () => {
   }
 
   beforeEach(() => {
-    setupMocks()
     vi.clearAllMocks()
     setupMocks()
   })

--- a/web/tests/pages/TagManagementPage.test.tsx
+++ b/web/tests/pages/TagManagementPage.test.tsx
@@ -24,19 +24,49 @@ function renderPage() {
 }
 
 describe('TagManagementPage', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const { useEventTagStore } = await import('../../src/stores/eventTagStore')
+    useEventTagStore.setState({ tags: new Map() })
+  })
 
   it('"태그 관리" 제목을 표시한다', () => {
     renderPage()
     expect(screen.getByText('태그 관리')).toBeInTheDocument()
   })
 
-  it('새 태그 이름 입력 후 추가하면 createTag API가 호출된다', async () => {
+  it('새 태그 이름 입력 후 추가하면 새 태그가 목록에 표시된다', async () => {
     const { eventTagApi } = await import('../../src/api/eventTagApi')
     vi.mocked(eventTagApi.createTag).mockResolvedValue({ uuid: 'new', name: '새 태그' })
     renderPage()
     await userEvent.type(screen.getByPlaceholderText('새 태그 이름'), '새 태그')
     await userEvent.click(screen.getByRole('button', { name: '추가' }))
-    expect(eventTagApi.createTag).toHaveBeenCalled()
+    expect(screen.getByText('새 태그')).toBeInTheDocument()
+  })
+
+  it('태그 수정 버튼 클릭 시 인라인 편집 폼이 표시된다', async () => {
+    // given: 태그가 있는 상태 — store에 직접 주입
+    const { useEventTagStore } = await import('../../src/stores/eventTagStore')
+    useEventTagStore.setState({
+      tags: new Map([['t1', { uuid: 't1', name: '업무', color_hex: '#ff0000' }]])
+    })
+    renderPage()
+    // when: 수정 버튼 클릭
+    await userEvent.click(screen.getByRole('button', { name: '수정' }))
+    // then: 인라인 편집 입력 필드가 나타남
+    expect(screen.getByDisplayValue('업무')).toBeInTheDocument()
+  })
+
+  it('태그 삭제 버튼 클릭 시 확인 다이얼로그가 표시된다', async () => {
+    // given: 태그가 있는 상태
+    const { useEventTagStore } = await import('../../src/stores/eventTagStore')
+    useEventTagStore.setState({
+      tags: new Map([['t1', { uuid: 't1', name: '업무', color_hex: '#ff0000' }]])
+    })
+    renderPage()
+    // when: 삭제 버튼 클릭
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    // then: 확인 다이얼로그가 표시됨
+    expect(screen.getByText('태그 삭제')).toBeInTheDocument()
   })
 })

--- a/web/tests/pages/TagManagementPage.test.tsx
+++ b/web/tests/pages/TagManagementPage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { TagManagementPage } from '../../src/pages/TagManagementPage'
+
+vi.mock('../../src/api/eventTagApi', () => ({
+  eventTagApi: {
+    getAllTags: vi.fn().mockResolvedValue([]),
+    createTag: vi.fn(),
+    updateTag: vi.fn(),
+    deleteTag: vi.fn(),
+  },
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function renderPage() {
+  return render(<MemoryRouter><TagManagementPage /></MemoryRouter>)
+}
+
+describe('TagManagementPage', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('"태그 관리" 제목을 표시한다', () => {
+    renderPage()
+    expect(screen.getByText('태그 관리')).toBeInTheDocument()
+  })
+
+  it('새 태그 이름 입력 후 추가하면 createTag API가 호출된다', async () => {
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi.createTag).mockResolvedValue({ uuid: 'new', name: '새 태그' })
+    renderPage()
+    await userEvent.type(screen.getByPlaceholderText('새 태그 이름'), '새 태그')
+    await userEvent.click(screen.getByRole('button', { name: '추가' }))
+    expect(eventTagApi.createTag).toHaveBeenCalled()
+  })
+})

--- a/web/tests/pages/TodoFormPage.test.tsx
+++ b/web/tests/pages/TodoFormPage.test.tsx
@@ -114,4 +114,29 @@ describe('TodoFormPage — edit', () => {
     await userEvent.click(screen.getByRole('button', { name: '삭제' }))
     expect(screen.getByText(/정말 삭제/)).toBeInTheDocument()
   })
+
+  it('수정 후 navigate가 호출된다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.getTodo).mockResolvedValue({ uuid: 'todo-1', name: '기존 이름', is_current: false, event_time: null })
+    vi.mocked(todoApi.updateTodo).mockResolvedValue({ uuid: 'todo-1', name: '수정됨', is_current: false, event_time: null })
+    renderEdit('todo-1')
+    await waitFor(() => screen.getByDisplayValue('기존 이름'))
+    await userEvent.clear(screen.getByLabelText('이름'))
+    await userEvent.type(screen.getByLabelText('이름'), '수정됨')
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+  })
+
+  it('삭제 확인 후 navigate가 호출된다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.getTodo).mockResolvedValue({ uuid: 'todo-1', name: '할 일', is_current: false, event_time: null })
+    vi.mocked(todoApi.deleteTodo).mockResolvedValue(undefined as any)
+    renderEdit('todo-1')
+    await waitFor(() => screen.getByRole('button', { name: '삭제' }))
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    // ConfirmDialog 열린 후 두 개의 "삭제" 버튼 중 마지막(다이얼로그 확인) 버튼 클릭
+    const deleteButtons = screen.getAllByRole('button', { name: '삭제' })
+    await userEvent.click(deleteButtons[deleteButtons.length - 1])
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+  })
 })

--- a/web/tests/pages/TodoFormPage.test.tsx
+++ b/web/tests/pages/TodoFormPage.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { TodoFormPage } from '../../src/pages/TodoFormPage'
+
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: {
+    getTodo: vi.fn(),
+    createTodo: vi.fn(),
+    updateTodo: vi.fn(),
+    deleteTodo: vi.fn(),
+  },
+}))
+vi.mock('../../src/stores/eventTagStore', () => ({ useEventTagStore: vi.fn() }))
+vi.mock('../../src/stores/uiStore', () => ({ useUiStore: vi.fn() }))
+vi.mock('../../src/stores/calendarEventsStore', () => ({ useCalendarEventsStore: vi.fn() }))
+vi.mock('../../src/stores/currentTodosStore', () => ({ useCurrentTodosStore: vi.fn() }))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+import { useEventTagStore } from '../../src/stores/eventTagStore'
+import { useUiStore } from '../../src/stores/uiStore'
+import { useCalendarEventsStore } from '../../src/stores/calendarEventsStore'
+import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
+
+const mockAddEvent = vi.fn()
+const mockRemoveEvent = vi.fn()
+const mockReplaceEvent = vi.fn()
+const mockRefreshCurrentRange = vi.fn()
+const mockAddTodo = vi.fn()
+const mockRemoveTodo = vi.fn()
+const mockReplaceTodo = vi.fn()
+
+function setupMocks() {
+  vi.mocked(useEventTagStore).mockImplementation((sel: any) => sel({ tags: new Map(), getColorForTagId: () => null }))
+  vi.mocked(useUiStore).mockImplementation((sel: any) => sel({ selectedDate: null }))
+  const calendarState = { addEvent: mockAddEvent, removeEvent: mockRemoveEvent, replaceEvent: mockReplaceEvent, refreshCurrentRange: mockRefreshCurrentRange }
+  vi.mocked(useCalendarEventsStore).mockImplementation((sel?: any) =>
+    sel ? sel(calendarState) : calendarState
+  )
+  const todosState = { addTodo: mockAddTodo, removeTodo: mockRemoveTodo, replaceTodo: mockReplaceTodo }
+  vi.mocked(useCurrentTodosStore).mockImplementation((sel?: any) =>
+    sel ? sel(todosState) : todosState
+  )
+}
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/todos/new']}>
+      <Routes><Route path="/todos/new" element={<TodoFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+function renderEdit(id: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/todos/${id}/edit`]}>
+      <Routes><Route path="/todos/:id/edit" element={<TodoFormPage />} /></Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('TodoFormPage — create', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('"새 Todo" 제목을 표시한다', () => {
+    renderCreate()
+    expect(screen.getByText('새 Todo')).toBeInTheDocument()
+  })
+
+  it('이름을 입력하고 저장하면 createTodo가 호출되고 화면을 닫는다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.createTodo).mockResolvedValue({ uuid: 'new-1', name: '테스트', is_current: false })
+    renderCreate()
+    await userEvent.type(screen.getByLabelText('이름'), '테스트')
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+  })
+
+  it('이름이 비어 있으면 저장 버튼을 클릭해도 API가 호출되지 않는다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    renderCreate()
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    expect(todoApi.createTodo).not.toHaveBeenCalled()
+  })
+})
+
+describe('TodoFormPage — edit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('기존 todo를 불러와 이름 필드에 표시한다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.getTodo).mockResolvedValue({ uuid: 'todo-1', name: '기존 이름', is_current: false })
+    renderEdit('todo-1')
+    await waitFor(() => expect(screen.getByDisplayValue('기존 이름')).toBeInTheDocument())
+  })
+
+  it('삭제 버튼 클릭 시 확인 다이얼로그가 표시된다', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.getTodo).mockResolvedValue({ uuid: 'todo-1', name: '할 일', is_current: false })
+    renderEdit('todo-1')
+    await waitFor(() => screen.getByRole('button', { name: '삭제' }))
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    expect(screen.getByText(/정말 삭제/)).toBeInTheDocument()
+  })
+})

--- a/web/tests/stores/calendarEventsStore.test.ts
+++ b/web/tests/stores/calendarEventsStore.test.ts
@@ -61,3 +61,68 @@ describe('calendarEventsStore', () => {
     expect(useCalendarEventsStore.getState().eventsByDate.size).toBe(0)
   })
 })
+
+// 2025-03-31 UTC
+const AT_TIMESTAMP = 1743375600
+// 'MARCH31_KEY' and 'MARCH31_KEY' already defined at top of file as '2025-03-31'
+
+describe('calendarEventsStore — mutation', () => {
+  beforeEach(() => {
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+    vi.clearAllMocks()
+  })
+
+  it('addEvent를 호출하면 해당 이벤트를 날짜별 목록에서 조회할 수 있다', async () => {
+    // given: 범위 fetch 후 lastRange가 저장됨
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(todoApi.getTodos).mockResolvedValue([])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([])
+    await useCalendarEventsStore.getState().fetchEventsForRange(1743292800, 1743465600)
+
+    // when: 새 todo 이벤트 추가
+    const newTodo = { uuid: 'new-1', name: '새 할 일', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } }
+    useCalendarEventsStore.getState().addEvent({ type: 'todo', event: newTodo })
+
+    // then: 해당 날짜에서 조회 가능
+    const events = useCalendarEventsStore.getState().eventsByDate.get(MARCH31_KEY)
+    expect(events?.some(e => e.event.uuid === 'new-1')).toBe(true)
+  })
+
+  it('removeEvent를 호출하면 해당 이벤트를 더 이상 조회할 수 없다', async () => {
+    // given: 이벤트가 있는 상태
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(todoApi.getTodos).mockResolvedValue([
+      { uuid: 'todo-1', name: 'Task', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } },
+    ])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([])
+    await useCalendarEventsStore.getState().fetchEventsForRange(1743292800, 1743465600)
+
+    // when: 이벤트 제거
+    useCalendarEventsStore.getState().removeEvent('todo-1')
+
+    // then: 해당 날짜에서 조회 불가
+    const events = useCalendarEventsStore.getState().eventsByDate.get(MARCH31_KEY) ?? []
+    expect(events.some(e => e.event.uuid === 'todo-1')).toBe(false)
+  })
+
+  it('replaceEvent를 호출하면 기존 이벤트가 새 이벤트로 교체된다', async () => {
+    // given: 이벤트가 있는 상태
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(todoApi.getTodos).mockResolvedValue([
+      { uuid: 'todo-1', name: '원래 이름', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } },
+    ])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([])
+    await useCalendarEventsStore.getState().fetchEventsForRange(1743292800, 1743465600)
+
+    // when: 이벤트 교체
+    const updated = { uuid: 'todo-1', name: '수정된 이름', is_current: false, event_time: { time_type: 'at' as const, timestamp: AT_TIMESTAMP } }
+    useCalendarEventsStore.getState().replaceEvent('todo-1', { type: 'todo', event: updated })
+
+    // then: 새 이름으로 조회됨
+    const events = useCalendarEventsStore.getState().eventsByDate.get(MARCH31_KEY) ?? []
+    expect(events.find(e => e.event.uuid === 'todo-1')?.event.name).toBe('수정된 이름')
+  })
+})

--- a/web/tests/stores/currentTodosStore.test.ts
+++ b/web/tests/stores/currentTodosStore.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
+import type { Todo } from '../../src/models/Todo'
 
 vi.mock('../../src/api/todoApi', () => ({
   todoApi: { getCurrentTodos: vi.fn() },
 }))
 
-const makeTodo = (uuid: string, name: string) => ({
-  uuid, name, is_current: true as const,
+const makeTodo = (uuid: string, name: string): Todo => ({
+  uuid, name, is_current: true, event_time: null,
 })
 
 describe('useCurrentTodosStore', () => {
@@ -18,14 +19,14 @@ describe('useCurrentTodosStore', () => {
   it('addTodo를 호출하면 todos 목록에서 해당 todo를 찾을 수 있다', () => {
     // given: 빈 스토어
     // when: todo 추가
-    useCurrentTodosStore.getState().addTodo(makeTodo('t1', '할 일') as any)
+    useCurrentTodosStore.getState().addTodo(makeTodo('t1', '할 일'))
     // then: 목록에서 조회 가능
     expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(true)
   })
 
   it('removeTodo를 호출하면 해당 todo를 더 이상 목록에서 찾을 수 없다', () => {
     // given: todo가 있는 상태
-    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '할 일') as any] })
+    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '할 일')] })
     // when: 제거
     useCurrentTodosStore.getState().removeTodo('t1')
     // then: 목록에 없음
@@ -34,9 +35,9 @@ describe('useCurrentTodosStore', () => {
 
   it('replaceTodo를 호출하면 기존 todo가 새 데이터로 교체된다', () => {
     // given: todo가 있는 상태
-    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '원래') as any] })
+    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '원래')] })
     // when: 교체
-    useCurrentTodosStore.getState().replaceTodo(makeTodo('t1', '수정됨') as any)
+    useCurrentTodosStore.getState().replaceTodo(makeTodo('t1', '수정됨'))
     // then: 새 이름으로 조회됨
     expect(useCurrentTodosStore.getState().todos.find(t => t.uuid === 't1')?.name).toBe('수정됨')
   })

--- a/web/tests/stores/currentTodosStore.test.ts
+++ b/web/tests/stores/currentTodosStore.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
+
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: { getCurrentTodos: vi.fn() },
+}))
+
+const makeTodo = (uuid: string, name: string) => ({
+  uuid, name, is_current: true as const,
+})
+
+describe('useCurrentTodosStore', () => {
+  beforeEach(() => {
+    useCurrentTodosStore.setState({ todos: [] })
+    vi.clearAllMocks()
+  })
+
+  it('addTodo를 호출하면 todos 목록에서 해당 todo를 찾을 수 있다', () => {
+    // given: 빈 스토어
+    // when: todo 추가
+    useCurrentTodosStore.getState().addTodo(makeTodo('t1', '할 일') as any)
+    // then: 목록에서 조회 가능
+    expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(true)
+  })
+
+  it('removeTodo를 호출하면 해당 todo를 더 이상 목록에서 찾을 수 없다', () => {
+    // given: todo가 있는 상태
+    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '할 일') as any] })
+    // when: 제거
+    useCurrentTodosStore.getState().removeTodo('t1')
+    // then: 목록에 없음
+    expect(useCurrentTodosStore.getState().todos.some(t => t.uuid === 't1')).toBe(false)
+  })
+
+  it('replaceTodo를 호출하면 기존 todo가 새 데이터로 교체된다', () => {
+    // given: todo가 있는 상태
+    useCurrentTodosStore.setState({ todos: [makeTodo('t1', '원래') as any] })
+    // when: 교체
+    useCurrentTodosStore.getState().replaceTodo(makeTodo('t1', '수정됨') as any)
+    // then: 새 이름으로 조회됨
+    expect(useCurrentTodosStore.getState().todos.find(t => t.uuid === 't1')?.name).toBe('수정됨')
+  })
+})

--- a/web/tests/stores/eventTagStore.test.ts
+++ b/web/tests/stores/eventTagStore.test.ts
@@ -4,6 +4,9 @@ import { useEventTagStore } from '../../src/stores/eventTagStore'
 vi.mock('../../src/api/eventTagApi', () => ({
   eventTagApi: {
     getAllTags: vi.fn(),
+    createTag: vi.fn(),
+    updateTag: vi.fn(),
+    deleteTag: vi.fn(),
   },
 }))
 
@@ -63,5 +66,44 @@ describe('eventTagStore', () => {
 
     // then: 이전 태그 색상은 여전히 조회 가능하다
     expect(useEventTagStore.getState().getColorForTagId('tag-1')).toBe('#ff0000')
+  })
+})
+
+describe('eventTagStore — CRUD', () => {
+  beforeEach(() => {
+    useEventTagStore.setState({ tags: new Map() })
+    vi.clearAllMocks()
+  })
+
+  it('createTag를 호출하면 생성된 태그를 ID로 조회할 수 있다', async () => {
+    // given: API가 새 태그를 반환
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi.createTag).mockResolvedValue({ uuid: 'tag-new', name: '업무', color_hex: '#ff0000' })
+    // when: 태그 생성
+    await useEventTagStore.getState().createTag('업무', '#ff0000')
+    // then: 태그 조회 가능
+    expect(useEventTagStore.getState().getColorForTagId('tag-new')).toBe('#ff0000')
+  })
+
+  it('updateTag를 호출하면 변경된 색상으로 조회된다', async () => {
+    // given: 태그가 있는 상태
+    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]) })
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi.updateTag).mockResolvedValue({ uuid: 'tag-1', name: '업무', color_hex: '#0000ff' })
+    // when: 색상 수정
+    await useEventTagStore.getState().updateTag('tag-1', { name: '업무', color_hex: '#0000ff' })
+    // then: 새 색상으로 조회됨
+    expect(useEventTagStore.getState().getColorForTagId('tag-1')).toBe('#0000ff')
+  })
+
+  it('deleteTag를 호출하면 해당 태그를 더 이상 조회할 수 없다', async () => {
+    // given: 태그가 있는 상태
+    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]) })
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    vi.mocked(eventTagApi.deleteTag).mockResolvedValue({ status: 'ok' })
+    // when: 삭제
+    await useEventTagStore.getState().deleteTag('tag-1')
+    // then: 조회 불가
+    expect(useEventTagStore.getState().getColorForTagId('tag-1')).toBeUndefined()
   })
 })

--- a/web/tests/utils/eventTimeUtils.test.ts
+++ b/web/tests/utils/eventTimeUtils.test.ts
@@ -7,6 +7,7 @@ import {
   monthRange,
   groupEventsByDate,
   formatDateKey,
+  eventTimeOverlapsRange,
 } from '../../src/utils/eventTimeUtils'
 import type { EventTime, Todo, Schedule } from '../../src/models'
 
@@ -142,5 +143,17 @@ describe('groupEventsByDate', () => {
 
     const result = groupEventsByDate(todos, [], lower, upper)
     expect(result.size).toBe(0)
+  })
+})
+
+describe('eventTimeOverlapsRange', () => {
+  it('at 이벤트가 범위 안에 있으면 true를 반환한다', () => {
+    const et: EventTime = { time_type: 'at', timestamp: 1000 }
+    expect(eventTimeOverlapsRange(et, 900, 1100)).toBe(true)
+  })
+
+  it('at 이벤트가 범위 밖에 있으면 false를 반환한다', () => {
+    const et: EventTime = { time_type: 'at', timestamp: 500 }
+    expect(eventTimeOverlapsRange(et, 900, 1100)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Phase 5 구현: Todo/Schedule 생성·수정·삭제·완료 + 반복 이벤트 6종 + 태그 관리

### 스토어 확장
- `calendarEventsStore` — `lastRange` 보존 + `addEvent` / `removeEvent` / `replaceEvent` / `refreshCurrentRange`
- `currentTodosStore` — `addTodo` / `removeTodo` / `replaceTodo`
- `eventTagStore` — `createTag` / `updateTag` / `deleteTag`

### 신규 컴포넌트
- `ConfirmDialog` — 삭제 확인 다이얼로그
- `RepeatingScopeDialog` — 반복 이벤트 범위 선택 (이 이벤트만 / 이후 전체 / 모든 이벤트)
- `TypeSelectorPopup` — FAB에서 Todo / Schedule 선택
- `EventTimePicker` — at / period / allday 타입 시간 입력
- `RepeatingPicker` — 반복 설정 (6종: 매일·매주·매월·매년·매년특정일·음력매년, 종료조건 포함)
- `TagSelector` — 태그 선택 + 태그 관리 진입
- `TagManagementPage` — 태그 생성·수정·삭제

### 신규 페이지
- `TodoFormPage` — Todo 생성/수정/삭제 (반복 Todo는 항상 전체 삭제)
- `ScheduleFormPage` — Schedule 생성/수정/삭제 + 3-scope 범위 처리

### 기존 컴포넌트 수정
- `DayEventList` — 이벤트 아이템에 "···" 편집 메뉴 추가
- `EventDetailPage` — 수정 버튼 추가
- `MainPage` — FAB "+" → TypeSelectorPopup
- `App.tsx` — background location overlay 패턴으로 5개 폼 라우트 추가

## 커밋 구성

19개 커밋, Task별 분리:
- `5-1` eventTimeOverlapsRange export
- `5-2` calendarEventsStore mutation 메서드
- `5-3` currentTodosStore + eventTagStore mutation 메서드
- `5-4` ConfirmDialog + RepeatingScopeDialog + TypeSelectorPopup
- `5-5` EventTimePicker
- `5-6` RepeatingPicker (스펙 갭 + 코드 품질 수정 포함)
- `5-7` TagSelector + TagManagementPage
- `5-8` TodoFormPage
- `5-9` ScheduleFormPage
- `5-10` FAB + 라우팅 + DayEventList 편집 메뉴 + EventDetailPage 수정 버튼
- `5-11` CurrentTodoList Todo 완료 체크박스

## Test plan

- [ ] 전체 테스트 통과 확인: `npm --prefix web test` → 171 tests, 30 files, all passing
- [ ] 빌드 확인: `npm --prefix web run build`
- [ ] Todo 생성: FAB → Todo → 이름 입력 → 저장 → 캘린더에 표시
- [ ] Schedule 생성: FAB → Schedule → 이름 + 시간 입력 → 저장
- [ ] 반복 Schedule 수정: "이후 전체" scope → 기존 시리즈 잘라내기 + 신규 생성
- [ ] 반복 Schedule 삭제: "이 이벤트만" scope → excludeRepeating
- [ ] 태그 관리: 생성 → 색상 지정 → TodoForm에서 선택
- [ ] CurrentTodoList 완료 체크박스 → Todo 목록에서 제거