### PR TITLE
[Phase1] 반복 Todo 정합성 수정 — scope 선택 지원

### DIFF
--- a/web/src/api/todoApi.ts
+++ b/web/src/api/todoApi.ts
@@ -26,7 +26,7 @@ export const todoApi = {
     return apiClient.post(`/v1/todos/todo/${id}/complete`, body)
   },
 
-  replaceTodo(id: string, body: { new: Record<string, unknown>; origin_next_event_time?: EventTime; next_repeating_turn?: number }): Promise<unknown> {
+  replaceTodo(id: string, body: { new: Record<string, unknown>; origin_next_event_time?: EventTime; next_repeating_turn?: number }): Promise<{ new_todo: Todo; next_repeating?: Todo }> {
     return apiClient.post(`/v1/todos/todo/${id}/replace`, body)
   },
 

--- a/web/src/api/todoApi.ts
+++ b/web/src/api/todoApi.ts
@@ -26,6 +26,14 @@ export const todoApi = {
     return apiClient.post(`/v1/todos/todo/${id}/complete`, body)
   },
 
+  replaceTodo(id: string, body: { new: Record<string, unknown>; origin_next_event_time?: EventTime; next_repeating_turn?: number }): Promise<unknown> {
+    return apiClient.post(`/v1/todos/todo/${id}/replace`, body)
+  },
+
+  patchTodo(id: string, body: Record<string, unknown>): Promise<Todo> {
+    return apiClient.patch(`/v1/todos/todo/${id}`, body)
+  },
+
   deleteTodo(id: string): Promise<{ status: string }> {
     return apiClient.delete(`/v1/todos/todo/${id}`)
   },

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -1,33 +1,63 @@
+import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { todoApi } from '../api/todoApi'
 import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
+import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
+import { nextRepeatingTime } from '../utils/repeatingTimeCalculator'
 import type { Todo } from '../models'
-
-// 이벤트 핸들러로 전달되므로 렌더 사이클 밖에서 실행됨.
-// React 훅 규칙 위반 없이 스토어 상태를 읽으려면 getState()를 직접 호출해야 한다.
-async function completeTodo(todo: Todo) {
-  const { removeTodo } = useCurrentTodosStore.getState()
-  const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
-  try {
-    await todoApi.completeTodo(todo.uuid, { origin: todo })
-    if (todo.repeating) {
-      await refreshCurrentRange()
-    } else {
-      removeEvent(todo.uuid)
-      removeTodo(todo.uuid)
-    }
-  } catch (e) {
-    console.warn('완료 처리 실패:', e)
-  }
-}
 
 export function CurrentTodoList() {
   const todos = useCurrentTodosStore(s => s.todos)
+  const fetchTodos = useCurrentTodosStore(s => s.fetch)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
   const navigate = useNavigate()
   const location = useLocation()
+  const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
+
+  async function handleComplete(todo: Todo) {
+    if (todo.repeating && todo.event_time) {
+      setScopeTarget(todo)
+      return
+    }
+    await doComplete(todo)
+  }
+
+  async function doComplete(todo: Todo, scope?: RepeatScope) {
+    const { removeTodo } = useCurrentTodosStore.getState()
+    const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
+    try {
+      if (scope === 'this' && todo.repeating && todo.event_time) {
+        // 이번만 완료: next_event_time 전달로 시리즈 유지
+        const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
+        await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
+      } else if (scope === 'future') {
+        // 지금부터 완료: next_event_time 없이 → 시리즈 종료
+        await todoApi.completeTodo(todo.uuid, { origin: todo })
+      } else {
+        // 비반복
+        await todoApi.completeTodo(todo.uuid, { origin: todo })
+      }
+
+      if (todo.repeating) {
+        await refreshCurrentRange()
+        await fetchTodos()
+      } else {
+        removeEvent(todo.uuid)
+        removeTodo(todo.uuid)
+      }
+    } catch (e) {
+      console.warn('완료 처리 실패:', e)
+    }
+  }
+
+  async function handleCompleteWithScope(scope: RepeatScope) {
+    if (!scopeTarget) return
+    const todo = scopeTarget
+    setScopeTarget(null)
+    await doComplete(todo, scope)
+  }
 
   if (todos.length === 0) return null
 
@@ -47,7 +77,7 @@ export function CurrentTodoList() {
                 type="checkbox"
                 aria-label={todo.name}
                 className="h-4 w-4 rounded border-gray-300"
-                onChange={() => completeTodo(todo)}
+                onChange={() => handleComplete(todo)}
               />
               <button
                 className="flex flex-1 items-center gap-2 rounded text-left hover:bg-gray-50"
@@ -62,6 +92,14 @@ export function CurrentTodoList() {
           )
         })}
       </ul>
+      {scopeTarget && (
+        <RepeatingScopeDialog
+          mode="complete"
+          eventType="todo"
+          onSelect={handleCompleteWithScope}
+          onCancel={() => setScopeTarget(null)}
+        />
+      )}
     </section>
   )
 }

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -5,7 +5,7 @@ import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
-import { nextRepeatingTime } from '../utils/repeatingTimeCalculator'
+import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import type { Todo } from '../models'
 
 export function CurrentTodoList() {
@@ -33,7 +33,9 @@ export function CurrentTodoList() {
         const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
         await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
       } else if (scope === 'future') {
-        // 지금부터 완료: next_event_time 없이 → 시리즈 종료
+        // 먼저 시리즈 종료 후 완료 처리
+        const startTs = getStartTimestamp(todo.event_time!)
+        await todoApi.patchTodo(todo.uuid, { repeating: { ...todo.repeating, end: startTs - 1 } })
         await todoApi.completeTodo(todo.uuid, { origin: todo })
       } else {
         // 비반복

--- a/web/src/components/RepeatingScopeDialog.tsx
+++ b/web/src/components/RepeatingScopeDialog.tsx
@@ -1,17 +1,31 @@
 export type RepeatScope = 'this' | 'future' | 'all'
 
 interface RepeatingScopeDialogProps {
-  mode: 'edit' | 'delete'
+  mode: 'edit' | 'delete' | 'complete'
+  eventType?: 'todo' | 'schedule'
   onSelect: (scope: RepeatScope) => void
   onCancel: () => void
 }
 
-export function RepeatingScopeDialog({ mode, onSelect, onCancel }: RepeatingScopeDialogProps) {
+function dialogTitle(mode: 'edit' | 'delete' | 'complete', eventType: 'todo' | 'schedule'): string {
+  if (eventType === 'todo') {
+    switch (mode) {
+      case 'edit': return '반복 할일 수정'
+      case 'delete': return '반복 할일 삭제'
+      case 'complete': return '반복 할일 완료'
+    }
+  }
+  return mode === 'delete' ? '반복 일정 삭제' : '반복 일정 수정'
+}
+
+export function RepeatingScopeDialog({ mode, eventType = 'schedule', onSelect, onCancel }: RepeatingScopeDialogProps) {
+  const isTodo = eventType === 'todo'
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
         <h2 className="text-base font-semibold text-gray-900">
-          {mode === 'delete' ? '반복 일정 삭제' : '반복 일정 수정'}
+          {dialogTitle(mode, eventType)}
         </h2>
         <div className="mt-4 flex flex-col divide-y divide-gray-100">
           <button
@@ -26,12 +40,14 @@ export function RepeatingScopeDialog({ mode, onSelect, onCancel }: RepeatingScop
           >
             이 이벤트 및 이후 이벤트
           </button>
-          <button
-            className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
-            onClick={() => onSelect('all')}
-          >
-            모든 이벤트
-          </button>
+          {!isTodo && (
+            <button
+              className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+              onClick={() => onSelect('all')}
+            >
+              모든 이벤트
+            </button>
+          )}
         </div>
         <button
           className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100"

--- a/web/src/models/Todo.ts
+++ b/web/src/models/Todo.ts
@@ -7,6 +7,8 @@ export interface Todo {
   event_tag_id?: string | null
   event_time?: EventTime | null
   repeating?: Repeating | null
+  repeating_turn?: number
+  exclude_repeatings?: number[]
   notification_options?: unknown[] | null
   is_current: boolean
 }

--- a/web/src/pages/TodoFormPage.tsx
+++ b/web/src/pages/TodoFormPage.tsx
@@ -174,6 +174,7 @@ export function TodoFormPage() {
       console.warn('삭제 실패:', e)
       setError('삭제에 실패했습니다.')
       setShowDeleteScope(false)
+      setShowConfirm(false)
     }
   }
 
@@ -237,7 +238,7 @@ export function TodoFormPage() {
           <button
             className="flex-1 rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
             onClick={handleSave}
-            disabled={saving}
+            disabled={saving || showSaveScope || showDeleteScope}
           >
             저장
           </button>

--- a/web/src/pages/TodoFormPage.tsx
+++ b/web/src/pages/TodoFormPage.tsx
@@ -8,6 +8,8 @@ import { EventTimePicker } from '../components/EventTimePicker'
 import { RepeatingPicker } from '../components/RepeatingPicker'
 import { TagSelector } from '../components/TagSelector'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { RepeatingScopeDialog, type RepeatScope } from '../components/RepeatingScopeDialog'
+import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import type { Todo, EventTime, Repeating } from '../models'
 
 export function TodoFormPage() {
@@ -27,6 +29,8 @@ export function TodoFormPage() {
   )
   const [repeating, setRepeating] = useState<Repeating | null>(null)
   const [showConfirm, setShowConfirm] = useState(false)
+  const [showSaveScope, setShowSaveScope] = useState(false)
+  const [showDeleteScope, setShowDeleteScope] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -44,40 +48,13 @@ export function TodoFormPage() {
 
   async function handleSave() {
     if (!name.trim()) return
+    if (id && original?.repeating) { setShowSaveScope(true); return }
     setSaving(true)
     try {
       if (id && original) {
-        const updated = await todoApi.updateTodo(id, {
-          name: name.trim(),
-          event_tag_id: tagId,
-          event_time: eventTime,
-          repeating,
-        })
-        if (updated.event_time && !original?.event_time) {
-          addEvent({ type: 'todo', event: updated })
-        } else if (!updated.event_time && original?.event_time) {
-          removeEvent(id)
-        } else if (updated.event_time && original?.event_time) {
-          // event_time이 바뀌면 날짜 키가 달라질 수 있으므로 remove → add로 갱신
-          removeEvent(id)
-          addEvent({ type: 'todo', event: updated })
-        }
-        if (updated.is_current && original?.is_current) {
-          replaceTodo(updated)
-        } else if (updated.is_current && !original?.is_current) {
-          addTodo(updated)
-        } else if (!updated.is_current && original?.is_current) {
-          removeTodo(id)
-        }
+        await applyUpdate()
       } else {
-        const created = await todoApi.createTodo({
-          name: name.trim(),
-          event_tag_id: tagId ?? undefined,
-          event_time: eventTime ?? undefined,
-          repeating: repeating ?? undefined,
-        })
-        if (created.event_time) addEvent({ type: 'todo', event: created })
-        if (created.is_current) addTodo(created)
+        await applyCreate()
       }
       navigate(-1)
     } catch (e) {
@@ -88,21 +65,115 @@ export function TodoFormPage() {
     }
   }
 
-  async function handleDelete() {
-    if (!id) return
+  async function handleSaveWithScope(scope: RepeatScope) {
+    setShowSaveScope(false)
+    setSaving(true)
     try {
-      await todoApi.deleteTodo(id)
-      if (original?.repeating) {
-        await refreshCurrentRange()
-      } else {
+      await applyUpdate(scope)
+      navigate(-1)
+    } catch (e) {
+      console.warn('저장 실패:', e)
+      setError('저장에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function applyCreate() {
+    const created = await todoApi.createTodo({
+      name: name.trim(),
+      event_tag_id: tagId ?? undefined,
+      event_time: eventTime ?? undefined,
+      repeating: repeating ?? undefined,
+    })
+    if (created.event_time) addEvent({ type: 'todo', event: created })
+    if (created.is_current) addTodo(created)
+  }
+
+  async function applyUpdate(scope?: RepeatScope) {
+    if (!id || !original) return
+
+    if (!original.repeating) {
+      // 비반복: 기존 로직
+      const updated = await todoApi.updateTodo(id, {
+        name: name.trim(),
+        event_tag_id: tagId,
+        event_time: eventTime,
+        repeating,
+      })
+      if (updated.event_time && !original.event_time) {
+        addEvent({ type: 'todo', event: updated })
+      } else if (!updated.event_time && original.event_time) {
+        removeEvent(id)
+      } else if (updated.event_time && original.event_time) {
+        removeEvent(id)
+        addEvent({ type: 'todo', event: updated })
+      }
+      if (updated.is_current && original.is_current) {
+        replaceTodo(updated)
+      } else if (updated.is_current && !original.is_current) {
+        addTodo(updated)
+      } else if (!updated.is_current && original.is_current) {
+        removeTodo(id)
+      }
+    } else if (scope === 'this') {
+      // 이번만: 원본을 다음 턴으로 진행 + 수정된 내용으로 새 비반복 Todo 생성
+      const next = original.event_time
+        ? nextRepeatingTime(original.event_time, original.repeating_turn ?? 1, original.repeating, original.exclude_repeatings)
+        : null
+      await todoApi.replaceTodo(id, {
+        new: { name: name.trim(), event_tag_id: tagId, event_time: eventTime },
+        origin_next_event_time: next?.time,
+        next_repeating_turn: next?.turn,
+      })
+      await refreshCurrentRange()
+    } else {
+      // future: 원본 시리즈 종료 + 새 시리즈 생성
+      const startTs = original.event_time ? getStartTimestamp(original.event_time) : 0
+      const cutoff = startTs - 1
+      await todoApi.patchTodo(id, { repeating: { ...original.repeating, end: cutoff } })
+      if (eventTime) {
+        await todoApi.createTodo({
+          name: name.trim(),
+          event_tag_id: tagId ?? undefined,
+          event_time: eventTime,
+          repeating: repeating ?? undefined,
+        })
+      }
+      await refreshCurrentRange()
+    }
+  }
+
+  async function applyDelete(scope: RepeatScope) {
+    if (!id || !original) return
+    try {
+      if (!original.repeating) {
+        await todoApi.deleteTodo(id)
         removeEvent(id)
         removeTodo(id)
+      } else if (scope === 'this') {
+        // 이번만 삭제: 원본을 다음 턴으로 진행
+        const next = original.event_time
+          ? nextRepeatingTime(original.event_time, original.repeating_turn ?? 1, original.repeating, original.exclude_repeatings)
+          : null
+        if (next) {
+          await todoApi.patchTodo(id, { event_time: next.time, repeating_turn: next.turn })
+        } else {
+          await todoApi.deleteTodo(id)
+        }
+        await refreshCurrentRange()
+      } else {
+        // future: 시리즈 종료
+        const startTs = original.event_time ? getStartTimestamp(original.event_time) : 0
+        const cutoff = startTs - 1
+        await todoApi.patchTodo(id, { repeating: { ...original.repeating, end: cutoff } })
+        await refreshCurrentRange()
       }
       navigate(-1)
     } catch (e) {
       console.warn('삭제 실패:', e)
-      setError('삭제에 실패했습니다. 다시 시도해주세요.')
-      setShowConfirm(false)
+      setError('삭제에 실패했습니다.')
+      setShowDeleteScope(false)
     }
   }
 
@@ -173,7 +244,7 @@ export function TodoFormPage() {
           {id && (
             <button
               className="rounded-lg border border-red-300 px-4 py-2.5 text-sm font-medium text-red-600 hover:bg-red-50"
-              onClick={() => setShowConfirm(true)}
+              onClick={() => original?.repeating ? setShowDeleteScope(true) : setShowConfirm(true)}
             >
               삭제
             </button>
@@ -184,10 +255,26 @@ export function TodoFormPage() {
       {showConfirm && (
         <ConfirmDialog
           title="Todo 삭제"
-          message={`"${name}" 을 정말 삭제할까요?${original?.repeating ? '\n반복 Todo는 전체 시리즈가 삭제됩니다.' : ''}`}
+          message={`"${name}" 을 정말 삭제할까요?`}
           confirmLabel="삭제"
-          onConfirm={handleDelete}
+          onConfirm={async () => { setShowConfirm(false); await applyDelete('this') }}
           onCancel={() => setShowConfirm(false)}
+        />
+      )}
+      {showSaveScope && (
+        <RepeatingScopeDialog
+          mode="edit"
+          eventType="todo"
+          onSelect={handleSaveWithScope}
+          onCancel={() => setShowSaveScope(false)}
+        />
+      )}
+      {showDeleteScope && (
+        <RepeatingScopeDialog
+          mode="delete"
+          eventType="todo"
+          onSelect={async scope => { setShowDeleteScope(false); await applyDelete(scope) }}
+          onCancel={() => setShowDeleteScope(false)}
         />
       )}
     </div>

--- a/web/src/utils/repeatingTimeCalculator.ts
+++ b/web/src/utils/repeatingTimeCalculator.ts
@@ -1,0 +1,318 @@
+import type { EventTime, Repeating, RepeatingOption } from '../models'
+import type {
+  EveryMonthDaysSelection,
+  EveryMonthWeekSelection,
+  WeekOrdinal,
+} from '../models'
+
+export interface RepeatingTimes {
+  time: EventTime
+  turn: number
+}
+
+// --- public API ---
+
+export function nextRepeatingTime(
+  currentTime: EventTime,
+  currentTurn: number,
+  repeating: Repeating,
+  excludeTurns?: number[],
+): RepeatingTimes | null {
+  const nextTurn = currentTurn + 1
+  const intervalSeconds = computeIntervalSeconds(currentTime, repeating.option)
+  if (intervalSeconds === null) return null
+
+  const nextTime = shiftEventTime(currentTime, intervalSeconds)
+
+  // end 조건 확인
+  if (repeating.end != null) {
+    const ts = getStartTimestamp(nextTime)
+    if (ts > repeating.end) return null
+  }
+  if (repeating.end_count != null && nextTurn > repeating.end_count) return null
+
+  // 제외 턴이면 재귀적으로 다음 계산
+  if (excludeTurns?.includes(nextTurn)) {
+    return nextRepeatingTime(nextTime, nextTurn, repeating, excludeTurns)
+  }
+
+  return { time: nextTime, turn: nextTurn }
+}
+
+export function shiftEventTime(time: EventTime, intervalSeconds: number): EventTime {
+  switch (time.time_type) {
+    case 'at':
+      return { time_type: 'at', timestamp: time.timestamp + intervalSeconds }
+    case 'period':
+      return { time_type: 'period', period_start: time.period_start + intervalSeconds, period_end: time.period_end + intervalSeconds }
+    case 'allday':
+      return { time_type: 'allday', period_start: time.period_start + intervalSeconds, period_end: time.period_end + intervalSeconds, seconds_from_gmt: time.seconds_from_gmt }
+  }
+}
+
+export function getStartTimestamp(time: EventTime): number {
+  return time.time_type === 'at' ? time.timestamp : time.period_start
+}
+
+// --- internal helpers ---
+
+function dateToDayOfWeek(date: Date): number {
+  // Sunday=1, Monday=2, ..., Saturday=7
+  return date.getDay() + 1
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate()
+}
+
+function nthWeekdayOfMonth(year: number, month: number, weekday: number, nth: number): Date | null {
+  // weekday: 1(Sun)~7(Sat), nth: 1-based
+  const jsWeekday = weekday - 1 // convert to JS 0-6
+  const firstDay = new Date(year, month - 1, 1)
+  let firstOccurrence = firstDay.getDate() + ((jsWeekday - firstDay.getDay() + 7) % 7)
+  const targetDate = firstOccurrence + (nth - 1) * 7
+  if (targetDate > daysInMonth(year, month)) return null
+  return new Date(year, month - 1, targetDate)
+}
+
+function lastWeekdayOfMonth(year: number, month: number, weekday: number): Date {
+  const jsWeekday = weekday - 1
+  const lastDay = new Date(year, month, 0)
+  const diff = (lastDay.getDay() - jsWeekday + 7) % 7
+  return new Date(year, month - 1, lastDay.getDate() - diff)
+}
+
+function dateToTimestamp(date: Date): number {
+  return Math.floor(date.getTime() / 1000)
+}
+
+function timestampToDate(ts: number): Date {
+  return new Date(ts * 1000)
+}
+
+// --- interval computation per option ---
+
+function computeIntervalSeconds(currentTime: EventTime, option: RepeatingOption): number | null {
+  const startTs = getStartTimestamp(currentTime)
+  const currentDate = timestampToDate(startTs)
+
+  switch (option.optionType) {
+    case 'every_day':
+      return everyDayInterval(option.interval)
+    case 'every_week':
+      return everyWeekInterval(currentDate, option.interval, option.dayOfWeek)
+    case 'every_month':
+      return everyMonthInterval(currentDate, startTs, option.interval, option.monthDaySelection)
+    case 'every_year':
+      return everyYearInterval(currentDate, startTs, option.interval, option.months, option.weekOrdinals, option.dayOfWeek)
+    case 'every_year_some_day':
+      return everyYearSomeDayInterval(currentDate, startTs, option.interval)
+    case 'lunar_calendar_every_year':
+      // TODO: 정확한 음력 변환 필요 — 현재는 양력 기준 1년 후로 근사 처리
+      return everyYearSomeDayInterval(currentDate, startTs, 1)
+  }
+}
+
+// 1. every_day
+function everyDayInterval(interval: number): number {
+  return interval * 86400
+}
+
+// 2. every_week
+function everyWeekInterval(currentDate: Date, interval: number, dayOfWeeks: number[]): number {
+  if (dayOfWeeks.length === 0) return interval * 7 * 86400
+
+  const currentDow = dateToDayOfWeek(currentDate)
+  const sorted = [...dayOfWeeks].sort((a, b) => a - b)
+
+  // 같은 주에서 현재 요일보다 큰 다음 요일 찾기
+  const nextInWeek = sorted.find(d => d > currentDow)
+  if (nextInWeek !== undefined) {
+    return (nextInWeek - currentDow) * 86400
+  }
+
+  // 없으면 interval주 후의 첫 번째 선택된 요일
+  const daysToEndOfWeek = 7 - currentDow
+  const additionalWeeks = (interval - 1) * 7
+  const daysToFirst = sorted[0]
+  return (daysToEndOfWeek + additionalWeeks + daysToFirst) * 86400
+}
+
+// 3. every_month
+function everyMonthInterval(
+  currentDate: Date,
+  currentTs: number,
+  interval: number,
+  selection: import('../models').MonthDaySelection,
+): number | null {
+  if ('days' in selection) {
+    return everyMonthDaysInterval(currentDate, currentTs, interval, selection as EveryMonthDaysSelection)
+  }
+  return everyMonthWeekInterval(currentDate, currentTs, interval, selection as EveryMonthWeekSelection)
+}
+
+// 3a. every_month (days mode)
+function everyMonthDaysInterval(
+  currentDate: Date,
+  currentTs: number,
+  interval: number,
+  selection: EveryMonthDaysSelection,
+): number | null {
+  const currentDay = currentDate.getDate()
+  const currentYear = currentDate.getFullYear()
+  const currentMonth = currentDate.getMonth() + 1 // 1-based
+  const sorted = [...selection.days].sort((a, b) => a - b)
+
+  // 같은 달에서 현재 day보다 큰 day 찾기 (해당 날이 실제 존재해야 함)
+  const maxDay = daysInMonth(currentYear, currentMonth)
+  const nextInMonth = sorted.find(d => d > currentDay && d <= maxDay)
+  if (nextInMonth !== undefined) {
+    const target = new Date(currentYear, currentMonth - 1, nextInMonth,
+      currentDate.getHours(), currentDate.getMinutes(), currentDate.getSeconds())
+    return dateToTimestamp(target) - currentTs
+  }
+
+  // interval개월 후부터 유효한 day 찾기
+  let targetMonth = currentMonth + interval
+  let targetYear = currentYear
+  while (targetMonth > 12) { targetMonth -= 12; targetYear++ }
+
+  for (let attempt = 0; attempt < 24; attempt++) {
+    const maxDayTarget = daysInMonth(targetYear, targetMonth)
+    const validDay = sorted.find(d => d <= maxDayTarget)
+    if (validDay !== undefined) {
+      const target = new Date(targetYear, targetMonth - 1, validDay,
+        currentDate.getHours(), currentDate.getMinutes(), currentDate.getSeconds())
+      return dateToTimestamp(target) - currentTs
+    }
+    targetMonth += interval
+    while (targetMonth > 12) { targetMonth -= 12; targetYear++ }
+  }
+
+  return null
+}
+
+// 3b. every_month (week mode)
+function everyMonthWeekInterval(
+  currentDate: Date,
+  currentTs: number,
+  interval: number,
+  selection: EveryMonthWeekSelection,
+): number | null {
+  const currentYear = currentDate.getFullYear()
+  const currentMonth = currentDate.getMonth() + 1
+
+  // 같은 달에서 현재 날짜 이후의 매칭 날짜 찾기
+  const candidates = findWeekSelectionDates(currentYear, currentMonth, selection)
+  const nextInMonth = candidates.find(d => dateToTimestamp(d) > currentTs)
+  if (nextInMonth) {
+    preserveTime(nextInMonth, currentDate)
+    return dateToTimestamp(nextInMonth) - currentTs
+  }
+
+  // interval개월 후
+  let targetMonth = currentMonth + interval
+  let targetYear = currentYear
+  while (targetMonth > 12) { targetMonth -= 12; targetYear++ }
+
+  for (let attempt = 0; attempt < 24; attempt++) {
+    const futureCandidates = findWeekSelectionDates(targetYear, targetMonth, selection)
+    if (futureCandidates.length > 0) {
+      const target = futureCandidates[0]
+      preserveTime(target, currentDate)
+      return dateToTimestamp(target) - currentTs
+    }
+    targetMonth += interval
+    while (targetMonth > 12) { targetMonth -= 12; targetYear++ }
+  }
+
+  return null
+}
+
+// 4. every_year (months + weekOrdinals + dayOfWeek)
+function everyYearInterval(
+  currentDate: Date,
+  currentTs: number,
+  interval: number,
+  months: number[],
+  weekOrdinals: WeekOrdinal[],
+  dayOfWeeks: number[],
+): number | null {
+  const currentYear = currentDate.getFullYear()
+  const sortedMonths = [...months].sort((a, b) => a - b)
+
+  // 같은 해에서 현재 이후 찾기
+  for (const month of sortedMonths) {
+    const candidates = findYearWeekDates(currentYear, month, weekOrdinals, dayOfWeeks)
+    const next = candidates.find(d => dateToTimestamp(d) > currentTs)
+    if (next) {
+      preserveTime(next, currentDate)
+      return dateToTimestamp(next) - currentTs
+    }
+  }
+
+  // interval년 후
+  let targetYear = currentYear + interval
+  for (let attempt = 0; attempt < 10; attempt++) {
+    for (const month of sortedMonths) {
+      const candidates = findYearWeekDates(targetYear, month, weekOrdinals, dayOfWeeks)
+      if (candidates.length > 0) {
+        const target = candidates[0]
+        preserveTime(target, currentDate)
+        return dateToTimestamp(target) - currentTs
+      }
+    }
+    targetYear += interval
+  }
+
+  return null
+}
+
+// 5. every_year_some_day
+function everyYearSomeDayInterval(
+  currentDate: Date,
+  currentTs: number,
+  interval: number,
+): number | null {
+  const targetDate = new Date(currentDate)
+  targetDate.setFullYear(targetDate.getFullYear() + interval)
+  return dateToTimestamp(targetDate) - currentTs
+}
+
+// --- week selection helpers ---
+
+function findWeekSelectionDates(year: number, month: number, selection: EveryMonthWeekSelection): Date[] {
+  const results: Date[] = []
+  for (const ordinal of selection.weekOrdinals) {
+    for (const weekday of selection.weekDays) {
+      const d = resolveWeekOrdinalDate(year, month, weekday, ordinal)
+      if (d) results.push(d)
+    }
+  }
+  return results.sort((a, b) => a.getTime() - b.getTime())
+}
+
+function findYearWeekDates(year: number, month: number, weekOrdinals: WeekOrdinal[], dayOfWeeks: number[]): Date[] {
+  const results: Date[] = []
+  for (const ordinal of weekOrdinals) {
+    for (const weekday of dayOfWeeks) {
+      const d = resolveWeekOrdinalDate(year, month, weekday, ordinal)
+      if (d) results.push(d)
+    }
+  }
+  return results.sort((a, b) => a.getTime() - b.getTime())
+}
+
+function resolveWeekOrdinalDate(year: number, month: number, weekday: number, ordinal: WeekOrdinal): Date | null {
+  if (ordinal.isLast) {
+    return lastWeekdayOfMonth(year, month, weekday)
+  }
+  if (ordinal.seq != null) {
+    return nthWeekdayOfMonth(year, month, weekday, ordinal.seq)
+  }
+  return null
+}
+
+function preserveTime(target: Date, source: Date): void {
+  target.setHours(source.getHours(), source.getMinutes(), source.getSeconds(), source.getMilliseconds())
+}

--- a/web/src/utils/repeatingTimeCalculator.ts
+++ b/web/src/utils/repeatingTimeCalculator.ts
@@ -31,12 +31,22 @@ export function nextRepeatingTime(
   }
   if (repeating.end_count != null && nextTurn > repeating.end_count) return null
 
-  // 제외 턴이면 재귀적으로 다음 계산
-  if (excludeTurns?.includes(nextTurn)) {
-    return nextRepeatingTime(nextTime, nextTurn, repeating, excludeTurns)
+  // 제외 턴이면 반복문으로 다음 계산
+  let result: RepeatingTimes = { time: nextTime, turn: nextTurn }
+  while (excludeTurns?.includes(result.turn)) {
+    const nextInterval = computeIntervalSeconds(result.time, repeating.option)
+    if (nextInterval === null) return null
+    const skippedTime = shiftEventTime(result.time, nextInterval)
+    const skippedTurn = result.turn + 1
+    if (repeating.end != null) {
+      const ts = getStartTimestamp(skippedTime)
+      if (ts > repeating.end) return null
+    }
+    if (repeating.end_count != null && skippedTurn > repeating.end_count) return null
+    result = { time: skippedTime, turn: skippedTurn }
   }
 
-  return { time: nextTime, turn: nextTurn }
+  return result
 }
 
 export function shiftEventTime(time: EventTime, intervalSeconds: number): EventTime {
@@ -98,9 +108,9 @@ function computeIntervalSeconds(currentTime: EventTime, option: RepeatingOption)
 
   switch (option.optionType) {
     case 'every_day':
-      return everyDayInterval(option.interval)
+      return everyDayInterval(currentDate, startTs, option.interval)
     case 'every_week':
-      return everyWeekInterval(currentDate, option.interval, option.dayOfWeek)
+      return everyWeekInterval(currentDate, startTs, option.interval, option.dayOfWeek)
     case 'every_month':
       return everyMonthInterval(currentDate, startTs, option.interval, option.monthDaySelection)
     case 'every_year':
@@ -113,14 +123,20 @@ function computeIntervalSeconds(currentTime: EventTime, option: RepeatingOption)
   }
 }
 
-// 1. every_day
-function everyDayInterval(interval: number): number {
-  return interval * 86400
+// 1. every_day — Date 날짜 연산으로 DST 안전 처리
+function everyDayInterval(currentDate: Date, currentTs: number, interval: number): number {
+  const nextDate = new Date(currentDate)
+  nextDate.setDate(nextDate.getDate() + interval)
+  return dateToTimestamp(nextDate) - currentTs
 }
 
-// 2. every_week
-function everyWeekInterval(currentDate: Date, interval: number, dayOfWeeks: number[]): number {
-  if (dayOfWeeks.length === 0) return interval * 7 * 86400
+// 2. every_week — Date 날짜 연산으로 DST 안전 처리
+function everyWeekInterval(currentDate: Date, currentTs: number, interval: number, dayOfWeeks: number[]): number {
+  if (dayOfWeeks.length === 0) {
+    const nextDate = new Date(currentDate)
+    nextDate.setDate(nextDate.getDate() + interval * 7)
+    return dateToTimestamp(nextDate) - currentTs
+  }
 
   const currentDow = dateToDayOfWeek(currentDate)
   const sorted = [...dayOfWeeks].sort((a, b) => a - b)
@@ -128,14 +144,20 @@ function everyWeekInterval(currentDate: Date, interval: number, dayOfWeeks: numb
   // 같은 주에서 현재 요일보다 큰 다음 요일 찾기
   const nextInWeek = sorted.find(d => d > currentDow)
   if (nextInWeek !== undefined) {
-    return (nextInWeek - currentDow) * 86400
+    const daysToAdd = nextInWeek - currentDow
+    const nextDate = new Date(currentDate)
+    nextDate.setDate(nextDate.getDate() + daysToAdd)
+    return dateToTimestamp(nextDate) - currentTs
   }
 
   // 없으면 interval주 후의 첫 번째 선택된 요일
   const daysToEndOfWeek = 7 - currentDow
   const additionalWeeks = (interval - 1) * 7
   const daysToFirst = sorted[0]
-  return (daysToEndOfWeek + additionalWeeks + daysToFirst) * 86400
+  const totalDays = daysToEndOfWeek + additionalWeeks + daysToFirst
+  const nextDate = new Date(currentDate)
+  nextDate.setDate(nextDate.getDate() + totalDays)
+  return dateToTimestamp(nextDate) - currentTs
 }
 
 // 3. every_month
@@ -204,9 +226,9 @@ function everyMonthWeekInterval(
 
   // 같은 달에서 현재 날짜 이후의 매칭 날짜 찾기
   const candidates = findWeekSelectionDates(currentYear, currentMonth, selection)
+    .map(d => { preserveTime(d, currentDate); return d })
   const nextInMonth = candidates.find(d => dateToTimestamp(d) > currentTs)
   if (nextInMonth) {
-    preserveTime(nextInMonth, currentDate)
     return dateToTimestamp(nextInMonth) - currentTs
   }
 
@@ -217,9 +239,9 @@ function everyMonthWeekInterval(
 
   for (let attempt = 0; attempt < 24; attempt++) {
     const futureCandidates = findWeekSelectionDates(targetYear, targetMonth, selection)
+      .map(d => { preserveTime(d, currentDate); return d })
     if (futureCandidates.length > 0) {
       const target = futureCandidates[0]
-      preserveTime(target, currentDate)
       return dateToTimestamp(target) - currentTs
     }
     targetMonth += interval
@@ -244,9 +266,9 @@ function everyYearInterval(
   // 같은 해에서 현재 이후 찾기
   for (const month of sortedMonths) {
     const candidates = findYearWeekDates(currentYear, month, weekOrdinals, dayOfWeeks)
+      .map(d => { preserveTime(d, currentDate); return d })
     const next = candidates.find(d => dateToTimestamp(d) > currentTs)
     if (next) {
-      preserveTime(next, currentDate)
       return dateToTimestamp(next) - currentTs
     }
   }
@@ -256,9 +278,9 @@ function everyYearInterval(
   for (let attempt = 0; attempt < 10; attempt++) {
     for (const month of sortedMonths) {
       const candidates = findYearWeekDates(targetYear, month, weekOrdinals, dayOfWeeks)
+        .map(d => { preserveTime(d, currentDate); return d })
       if (candidates.length > 0) {
         const target = candidates[0]
-        preserveTime(target, currentDate)
         return dateToTimestamp(target) - currentTs
       }
     }

--- a/web/tests/utils/repeatingTimeCalculator.test.ts
+++ b/web/tests/utils/repeatingTimeCalculator.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import {
+  nextRepeatingTime,
+  shiftEventTime,
+  getStartTimestamp,
+} from '../../src/utils/repeatingTimeCalculator'
+import type { EventTime, Repeating } from '../../src/models'
+
+// Helper: 로컬 Date를 Unix timestamp(초)로 변환
+function ts(year: number, month: number, day: number, hour = 0, minute = 0, second = 0): number {
+  return Math.floor(new Date(year, month - 1, day, hour, minute, second).getTime() / 1000)
+}
+
+describe('shiftEventTime', () => {
+  it('at 타입 시간을 interval만큼 시프트한다', () => {
+    // given
+    const time: EventTime = { time_type: 'at', timestamp: 1000 }
+    // when
+    const result = shiftEventTime(time, 500)
+    // then
+    expect(result).toEqual({ time_type: 'at', timestamp: 1500 })
+  })
+
+  it('period 타입 시간을 interval만큼 시프트한다', () => {
+    // given
+    const time: EventTime = { time_type: 'period', period_start: 1000, period_end: 2000 }
+    // when
+    const result = shiftEventTime(time, 500)
+    // then
+    expect(result).toEqual({ time_type: 'period', period_start: 1500, period_end: 2500 })
+  })
+
+  it('allday 타입 시간을 interval만큼 시프트하되 seconds_from_gmt는 유지한다', () => {
+    // given
+    const time: EventTime = { time_type: 'allday', period_start: 1000, period_end: 2000, seconds_from_gmt: 32400 }
+    // when
+    const result = shiftEventTime(time, 86400)
+    // then
+    expect(result).toEqual({ time_type: 'allday', period_start: 87400, period_end: 88400, seconds_from_gmt: 32400 })
+  })
+})
+
+describe('nextRepeatingTime - every_day', () => {
+  it('interval일 후의 시간을 반환한다', () => {
+    // given: 2024-01-15 14:00:00
+    const startTs = ts(2024, 1, 15, 14, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_day', interval: 1 },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-01-16 14:00:00
+    const expectedTs = ts(2024, 1, 16, 14, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+    expect(result!.turn).toBe(2)
+  })
+
+  it('interval=3이면 3일 후를 반환한다', () => {
+    // given: 2024-01-15 10:00:00
+    const startTs = ts(2024, 1, 15, 10, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_day', interval: 3 },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-01-18 10:00:00
+    const expectedTs = ts(2024, 1, 18, 10, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+})
+
+describe('nextRepeatingTime - every_week', () => {
+  it('같은 주 다음 요일이 있으면 그 요일로 이동한다', () => {
+    // given: 2024-01-15 (월요일=2) → 다음은 수요일(4)
+    const startTs = ts(2024, 1, 15, 9, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_week', interval: 1, dayOfWeek: [2, 4, 6], timeZone: 'Asia/Seoul' },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-01-17 (수요일) 09:00
+    const expectedTs = ts(2024, 1, 17, 9, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+
+  it('같은 주 다음 요일이 없으면 interval주 후 첫 요일로 이동한다', () => {
+    // given: 2024-01-19 (금요일=6) → 같은 주 다음 없음 → 1주 후 월요일(2)
+    const startTs = ts(2024, 1, 19, 9, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_week', interval: 1, dayOfWeek: [2, 4, 6], timeZone: 'Asia/Seoul' },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-01-22 (월요일) 09:00
+    const expectedTs = ts(2024, 1, 22, 9, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+})
+
+describe('nextRepeatingTime - every_month (days)', () => {
+  it('같은 달에 다음 day가 있으면 그 day로 이동한다', () => {
+    // given: 2024-01-10 12:00 → days=[5,15,25]
+    const startTs = ts(2024, 1, 10, 12, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_month', interval: 1, monthDaySelection: { days: [5, 15, 25] }, timeZone: 'Asia/Seoul' },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-01-15 12:00
+    const expectedTs = ts(2024, 1, 15, 12, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+
+  it('같은 달에 다음 day가 없으면 interval개월 후 첫 day로 이동한다', () => {
+    // given: 2024-01-26 12:00 → days=[5,15,25] → 다음달 5일
+    const startTs = ts(2024, 1, 26, 12, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_month', interval: 1, monthDaySelection: { days: [5, 15, 25] }, timeZone: 'Asia/Seoul' },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-02-05 12:00
+    const expectedTs = ts(2024, 2, 5, 12, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+
+  it('31일이 없는 달은 건너뛴다', () => {
+    // given: 2024-01-31 12:00 → days=[31] → 2월에 31일 없으므로 3월 31일
+    const startTs = ts(2024, 1, 31, 12, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_month', interval: 1, monthDaySelection: { days: [31] }, timeZone: 'Asia/Seoul' },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-03-31 12:00
+    const expectedTs = ts(2024, 3, 31, 12, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+})
+
+describe('nextRepeatingTime - every_month (week)', () => {
+  it('해당 월의 N째 주 특정 요일을 찾는다', () => {
+    // given: 2024-01-08 (2째 주 월요일) → 다음: 2024-02의 2째 월요일 = 2024-02-12
+    const startTs = ts(2024, 1, 8, 10, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: {
+        optionType: 'every_month',
+        interval: 1,
+        monthDaySelection: { weekOrdinals: [{ isLast: false, seq: 2 }], weekDays: [2] },
+        timeZone: 'Asia/Seoul',
+      },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-02-12 10:00
+    const expectedTs = ts(2024, 2, 12, 10, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+
+  it('last 옵션은 마지막 해당 요일을 찾는다', () => {
+    // given: 2024-01-29 (마지막 월요일) → 다음: 2024-02 마지막 월요일 = 2024-02-26
+    const startTs = ts(2024, 1, 29, 10, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: {
+        optionType: 'every_month',
+        interval: 1,
+        monthDaySelection: { weekOrdinals: [{ isLast: true }], weekDays: [2] },
+        timeZone: 'Asia/Seoul',
+      },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2024-02-26 10:00
+    const expectedTs = ts(2024, 2, 26, 10, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+})
+
+describe('nextRepeatingTime - every_year_some_day', () => {
+  it('interval년 후 같은 월/일을 반환한다', () => {
+    // given: 2024-03-20 15:00
+    const startTs = ts(2024, 3, 20, 15, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_year_some_day', interval: 1, month: 3, day: 20, timeZone: 'Asia/Seoul' },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then: 2025-03-20 15:00
+    const expectedTs = ts(2025, 3, 20, 15, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+})
+
+describe('nextRepeatingTime - 종료 조건', () => {
+  it('end 시간을 초과하면 null을 반환한다', () => {
+    // given: 2024-01-15 → 다음: 01-16 but end가 01-15
+    const startTs = ts(2024, 1, 15, 14, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_day', interval: 1 },
+      end: ts(2024, 1, 15, 23, 59, 59),
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating)
+    // then
+    expect(result).toBeNull()
+  })
+
+  it('end_count를 초과하면 null을 반환한다', () => {
+    // given: currentTurn=3, end_count=3 → nextTurn=4 > 3
+    const startTs = ts(2024, 1, 15, 14, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_day', interval: 1 },
+      end_count: 3,
+    }
+    // when
+    const result = nextRepeatingTime(time, 3, repeating)
+    // then
+    expect(result).toBeNull()
+  })
+})
+
+describe('nextRepeatingTime - excludeTurns', () => {
+  it('제외된 턴은 건너뛰고 다음 턴을 반환한다', () => {
+    // given: turn 2가 제외 → turn 3을 반환
+    const startTs = ts(2024, 1, 15, 14, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_day', interval: 1 },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating, [2])
+    // then: turn 2 건너뛰고 turn 3 (2일 후)
+    const expectedTs = ts(2024, 1, 17, 14, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.turn).toBe(3)
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+
+  it('연속 제외 시 반복적으로 건너뛴다', () => {
+    // given: turn 2, 3이 제외 → turn 4를 반환
+    const startTs = ts(2024, 1, 15, 14, 0, 0)
+    const time: EventTime = { time_type: 'at', timestamp: startTs }
+    const repeating: Repeating = {
+      start: startTs,
+      option: { optionType: 'every_day', interval: 1 },
+    }
+    // when
+    const result = nextRepeatingTime(time, 1, repeating, [2, 3])
+    // then: turn 4 (3일 후)
+    const expectedTs = ts(2024, 1, 18, 14, 0, 0)
+    expect(result).not.toBeNull()
+    expect(result!.turn).toBe(4)
+    expect(result!.time).toEqual({ time_type: 'at', timestamp: expectedTs })
+  })
+})


### PR DESCRIPTION
## Summary\n\n- 반복 Todo 완료/수정/삭제 시 scope 선택(이번만/지금부터) 다이얼로그 추가\n- 반복 시간 계산 유틸리티(`repeatingTimeCalculator.ts`) 구현 — 6가지 반복 패턴 지원\n- RepeatingScopeDialog에 Todo 전용 모드(2옵션) 추가\n- TodoFormPage 수정/삭제 시 scope 분기 로직 구현\n- CurrentTodoList 완료 시 scope 분기 로직 구현\n\n## Changes\n\n| 파일 | 변경 내용 |\n|------|----------|\n| `repeatingTimeCalculator.ts` | 신규 — 6가지 반복 패턴 next 시간 계산 |\n| `Todo.ts` | `repeating_turn`, `exclude_repeatings` 필드 추가 |\n| `todoApi.ts` | `replaceTodo`, `patchTodo` 메서드 추가 |\n| `RepeatingScopeDialog.tsx` | `eventType` prop, `complete` 모드 추가 |\n| `TodoFormPage.tsx` | 반복 수정/삭제 scope 선택 + applyUpdate/applyDelete |\n| `CurrentTodoList.tsx` | 반복 완료 scope 선택 + doComplete 분기 |\n\n## Test plan\n\n- [ ] 반복 Todo 생성 후 완료 → scope 다이얼로그 표시 확인\n- [ ] '이번만 완료' → 시리즈 유지, 다음 인스턴스 표시\n- [ ] '지금부터 완료' → 시리즈 종료\n- [ ] 반복 Todo 수정 → scope 선택 후 정상 저장\n- [ ] 반복 Todo 삭제 → scope 선택 후 정상 삭제\n- [ ] 비반복 Todo는 기존 동작 유지\n- [ ] 236 unit tests passed, build 성공\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)