### PR TITLE
[Phase2] 이벤트 상세 & 태그 개선

### DIFF
--- a/web/src/api/eventTagApi.ts
+++ b/web/src/api/eventTagApi.ts
@@ -17,4 +17,8 @@ export const eventTagApi = {
   deleteTag(id: string): Promise<{ status: string }> {
     return apiClient.delete(`/v1/tags/tag/${id}`)
   },
+
+  deleteTagAndEvents(id: string): Promise<{ status: string }> {
+    return apiClient.delete(`/v1/tags/tag_and_events/${id}`)
+  },
 }

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -83,7 +83,7 @@ export function CurrentTodoList() {
               />
               <button
                 className="flex flex-1 items-center gap-2 rounded text-left hover:bg-gray-50"
-                onClick={() => navigate(`/events/${todo.uuid}`, {
+                onClick={() => navigate(`/events/${todo.uuid}?type=todo`, {
                   state: { background: location, eventType: 'todo' },
                 })}
               >

--- a/web/src/components/DayEventList.tsx
+++ b/web/src/components/DayEventList.tsx
@@ -91,7 +91,7 @@ export function DayEventList({ selectedDate }: DayEventListProps) {
         <li key={calEvent.event.uuid}>
           <EventItem
             calEvent={calEvent}
-            onNavigate={() => navigate(`/events/${calEvent.event.uuid}`, {
+            onNavigate={() => navigate(`/events/${calEvent.event.uuid}?type=${calEvent.type}`, {
               state: { background: location, eventType: calEvent.type },
             })}
           />

--- a/web/src/components/ForemostEventBanner.tsx
+++ b/web/src/components/ForemostEventBanner.tsx
@@ -25,7 +25,7 @@ export function ForemostEventBanner() {
     <button
       data-testid="foremost-banner"
       className="flex w-full items-start gap-3 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-left hover:bg-blue-100"
-      onClick={() => navigate(`/events/${event.uuid}`, {
+      onClick={() => navigate(`/events/${event.uuid}?type=${eventType}`, {
         state: { background: location, eventType },
       })}
     >

--- a/web/src/pages/EventDetailPage.tsx
+++ b/web/src/pages/EventDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useParams, useNavigate, useLocation } from 'react-router-dom'
+import { useParams, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
 import { todoApi } from '../api/todoApi'
 import { scheduleApi } from '../api/scheduleApi'
 import { eventDetailApi } from '../api/eventDetailApi'
@@ -40,7 +40,9 @@ export function EventDetailPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
+  const [searchParams] = useSearchParams()
   const eventType = (location.state as { eventType?: string } | null)?.eventType
+    ?? searchParams.get('type')
 
   const [isEditing, setIsEditing] = useState(false)
   const [editForm, setEditForm] = useState<EventDetail>({ place: '', url: '', memo: '' })
@@ -149,7 +151,6 @@ export function EventDetailPage() {
           <button
             className="text-sm text-blue-500 hover:text-blue-700"
             onClick={() => {
-              const eventType = (location.state as { eventType?: string } | null)?.eventType
               const path = eventType === 'schedule' ? `/schedules/${id}/edit` : `/todos/${id}/edit`
               navigate(path, { state: { background: location } })
             }}

--- a/web/src/pages/EventDetailPage.tsx
+++ b/web/src/pages/EventDetailPage.tsx
@@ -189,61 +189,79 @@ export function EventDetailPage() {
           </div>
         )}
 
-        {/* EventDetail */}
-        {detail && (
-          <div className="mt-4 space-y-3 border-t border-gray-100 pt-4">
-            {/* Edit / Save / Cancel buttons */}
-            <div className="flex justify-end gap-2">
-              {isEditing ? (
-                <>
-                  <button
-                    className="text-sm text-blue-500 hover:text-blue-700"
-                    onClick={handleEditSave}
-                  >
-                    저장
-                  </button>
-                  <button
-                    className="text-sm text-gray-500 hover:text-gray-700"
-                    onClick={handleEditCancel}
-                  >
-                    취소
-                  </button>
-                </>
-              ) : (
+        {/* EventDetail — 항상 표시 */}
+        <div className="mt-4 space-y-3 border-t border-gray-100 pt-4">
+          {/* Edit / Save / Cancel buttons */}
+          <div className="flex justify-end gap-2">
+            {isEditing ? (
+              <>
+                <button
+                  className="text-sm text-blue-500 hover:text-blue-700"
+                  onClick={handleEditSave}
+                >
+                  저장
+                </button>
                 <button
                   className="text-sm text-gray-500 hover:text-gray-700"
-                  onClick={handleEditStart}
+                  onClick={handleEditCancel}
                 >
-                  편집
+                  취소
                 </button>
-              )}
-            </div>
+              </>
+            ) : (
+              <button
+                className="text-sm text-gray-500 hover:text-gray-700"
+                onClick={handleEditStart}
+              >
+                {detail ? '편집' : '상세 추가'}
+              </button>
+            )}
+          </div>
 
-            {/* Place */}
-            <div>
-              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">장소</p>
-              {isEditing ? (
+          {isEditing ? (
+            <>
+              {/* Place */}
+              <div>
+                <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">장소</p>
                 <input
                   className="mt-1 w-full rounded border border-gray-300 px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-400"
                   value={editForm.place ?? ''}
                   onChange={e => setEditForm(f => ({ ...f, place: e.target.value }))}
                 />
-              ) : (
-                detail.place && <p className="mt-1 text-sm text-gray-700">{detail.place}</p>
-              )}
-            </div>
+              </div>
 
-            {/* URL */}
-            <div>
-              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">URL</p>
-              {isEditing ? (
+              {/* URL */}
+              <div>
+                <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">URL</p>
                 <input
                   className="mt-1 w-full rounded border border-gray-300 px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-400"
                   value={editForm.url ?? ''}
                   onChange={e => setEditForm(f => ({ ...f, url: e.target.value }))}
                 />
-              ) : (
-                detail.url && (
+              </div>
+
+              {/* Memo */}
+              <div>
+                <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">메모</p>
+                <textarea
+                  className="mt-1 w-full rounded border border-gray-300 px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  rows={4}
+                  value={editForm.memo ?? ''}
+                  onChange={e => setEditForm(f => ({ ...f, memo: e.target.value }))}
+                />
+              </div>
+            </>
+          ) : detail ? (
+            <>
+              {detail.place && (
+                <div>
+                  <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">장소</p>
+                  <p className="mt-1 text-sm text-gray-700">{detail.place}</p>
+                </div>
+              )}
+              {detail.url && (
+                <div>
+                  <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">URL</p>
                   <a
                     href={detail.url}
                     target="_blank"
@@ -252,28 +270,19 @@ export function EventDetailPage() {
                   >
                     {detail.url}
                   </a>
-                )
+                </div>
               )}
-            </div>
-
-            {/* Memo */}
-            <div>
-              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">메모</p>
-              {isEditing ? (
-                <textarea
-                  className="mt-1 w-full rounded border border-gray-300 px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-400"
-                  rows={4}
-                  value={editForm.memo ?? ''}
-                  onChange={e => setEditForm(f => ({ ...f, memo: e.target.value }))}
-                />
-              ) : (
-                detail.memo && (
+              {detail.memo && (
+                <div>
+                  <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">메모</p>
                   <p className="mt-1 whitespace-pre-wrap text-sm text-gray-700">{detail.memo}</p>
-                )
+                </div>
               )}
-            </div>
-          </div>
-        )}
+            </>
+          ) : (
+            <p className="text-sm text-gray-400">장소, URL, 메모를 추가하세요</p>
+          )}
+        </div>
       </div>
 
       {/* Foremost toggle */}

--- a/web/src/pages/TagManagementPage.tsx
+++ b/web/src/pages/TagManagementPage.tsx
@@ -101,13 +101,14 @@ export function TagManagementPage() {
               <button
                 className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
                 onClick={async () => {
+                  const target = deleteTarget
+                  setDeleteTarget(null)
                   try {
-                    await deleteTag(deleteTarget.uuid)
+                    await deleteTag(target.uuid)
                   } catch (e) {
                     console.warn('태그 삭제 실패:', e)
                     useToastStore.getState().show('태그 삭제에 실패했습니다', 'error')
                   }
-                  setDeleteTarget(null)
                 }}
               >
                 태그만 삭제
@@ -115,13 +116,14 @@ export function TagManagementPage() {
               <button
                 className="px-4 py-3 text-left text-sm text-red-600 hover:bg-red-50"
                 onClick={async () => {
+                  const target = deleteTarget
+                  setDeleteTarget(null)
                   try {
-                    await deleteTagAndEvents(deleteTarget.uuid)
+                    await deleteTagAndEvents(target.uuid)
                   } catch (e) {
                     console.warn('태그+이벤트 삭제 실패:', e)
                     useToastStore.getState().show('태그 및 이벤트 삭제에 실패했습니다', 'error')
                   }
-                  setDeleteTarget(null)
                 }}
               >
                 태그 + 연관 이벤트 모두 삭제

--- a/web/src/pages/TagManagementPage.tsx
+++ b/web/src/pages/TagManagementPage.tsx
@@ -2,12 +2,11 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { useToastStore } from '../stores/toastStore'
-import { ConfirmDialog } from '../components/ConfirmDialog'
 import type { EventTag } from '../models'
 
 export function TagManagementPage() {
   const navigate = useNavigate()
-  const { tags, createTag, updateTag, deleteTag } = useEventTagStore()
+  const { tags, createTag, updateTag, deleteTag, deleteTagAndEvents } = useEventTagStore()
   const [newName, setNewName] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editName, setEditName] = useState('')
@@ -92,22 +91,50 @@ export function TagManagementPage() {
       </ul>
 
       {deleteTarget && (
-        <ConfirmDialog
-          title="태그 삭제"
-          message={`"${deleteTarget.name}" 태그를 삭제할까요?`}
-          confirmLabel="삭제"
-          onConfirm={async () => {
-            try {
-              await deleteTag(deleteTarget.uuid)
-              setDeleteTarget(null)
-            } catch (e) {
-              console.warn('태그 삭제 실패:', e)
-              useToastStore.getState().show('태그 삭제에 실패했습니다', 'error')
-              setDeleteTarget(null)
-            }
-          }}
-          onCancel={() => setDeleteTarget(null)}
-        />
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+            <h2 className="text-base font-semibold text-gray-900">태그 삭제</h2>
+            <p className="mt-2 text-sm text-gray-600">
+              &ldquo;{deleteTarget.name}&rdquo; 태그를 어떻게 삭제할까요?
+            </p>
+            <div className="mt-4 flex flex-col divide-y divide-gray-100">
+              <button
+                className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+                onClick={async () => {
+                  try {
+                    await deleteTag(deleteTarget.uuid)
+                  } catch (e) {
+                    console.warn('태그 삭제 실패:', e)
+                    useToastStore.getState().show('태그 삭제에 실패했습니다', 'error')
+                  }
+                  setDeleteTarget(null)
+                }}
+              >
+                태그만 삭제
+              </button>
+              <button
+                className="px-4 py-3 text-left text-sm text-red-600 hover:bg-red-50"
+                onClick={async () => {
+                  try {
+                    await deleteTagAndEvents(deleteTarget.uuid)
+                  } catch (e) {
+                    console.warn('태그+이벤트 삭제 실패:', e)
+                    useToastStore.getState().show('태그 및 이벤트 삭제에 실패했습니다', 'error')
+                  }
+                  setDeleteTarget(null)
+                }}
+              >
+                태그 + 연관 이벤트 모두 삭제
+              </button>
+            </div>
+            <button
+              className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100"
+              onClick={() => setDeleteTarget(null)}
+            >
+              취소
+            </button>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/web/src/stores/eventTagStore.ts
+++ b/web/src/stores/eventTagStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { eventTagApi } from '../api/eventTagApi'
+import { useCalendarEventsStore } from './calendarEventsStore'
 import type { EventTag } from '../models'
 
 interface EventTagState {
@@ -9,6 +10,7 @@ interface EventTagState {
   createTag: (name: string, color_hex?: string) => Promise<EventTag>
   updateTag: (id: string, updates: { name?: string; color_hex?: string }) => Promise<EventTag>
   deleteTag: (id: string) => Promise<void>
+  deleteTagAndEvents: (id: string) => Promise<void>
   reset: () => void
 }
 
@@ -44,6 +46,12 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
   deleteTag: async (id: string) => {
     await eventTagApi.deleteTag(id)
     set(s => { const tags = new Map(s.tags); tags.delete(id); return { tags } })
+  },
+
+  deleteTagAndEvents: async (id: string) => {
+    await eventTagApi.deleteTagAndEvents(id)
+    set(s => { const tags = new Map(s.tags); tags.delete(id); return { tags } })
+    await useCalendarEventsStore.getState().refreshCurrentRange()
   },
 
   reset: () => set({ tags: new Map() }),

--- a/web/src/stores/eventTagStore.ts
+++ b/web/src/stores/eventTagStore.ts
@@ -51,7 +51,7 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
   deleteTagAndEvents: async (id: string) => {
     await eventTagApi.deleteTagAndEvents(id)
     set(s => { const tags = new Map(s.tags); tags.delete(id); return { tags } })
-    await useCalendarEventsStore.getState().refreshCurrentRange()
+    await useCalendarEventsStore.getState().refreshCurrentRange().catch(() => {})
   },
 
   reset: () => set({ tags: new Map() }),

--- a/web/tests/components/ForemostEventBanner.test.tsx
+++ b/web/tests/components/ForemostEventBanner.test.tsx
@@ -65,6 +65,6 @@ describe('ForemostEventBanner', () => {
     renderComponent()
     await userEvent.click(screen.getByTestId('foremost-banner'))
 
-    expect(mockNavigate.mock.calls[0][0]).toBe('/events/fe-nav')
+    expect(mockNavigate.mock.calls[0][0]).toBe('/events/fe-nav?type=todo')
   })
 })


### PR DESCRIPTION
## Summary\n\n- EventDetail 섹션을 detail이 null이어도 항상 표시하여 장소/URL/메모 추가 가능\n- 태그 삭제 시 cascade 옵션 추가 (태그만 삭제 / 태그+연관 이벤트 모두 삭제)\n- 직접 URL 접근 시 `?type=todo|schedule` 쿼리 파라미터로 이벤트 타입 보존\n\n## Test plan\n\n- [ ] 새 이벤트의 상세 페이지에서 '상세 추가' 버튼 → 장소/URL/메모 입력 → 저장\n- [ ] 태그 삭제 시 3옵션 다이얼로그 표시 확인\n- [ ] '태그+이벤트 삭제' 선택 시 연관 이벤트도 삭제 확인\n- [ ] `/events/:id?type=todo` 직접 접근 시 정상 로드 확인\n- [ ] 234 unit tests passed, build 성공\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)