### PR TITLE
[Phase3] 미완료 Todo 섹션 + 반복 Todo 건너뛰기

### DIFF
--- a/web/src/api/todoApi.ts
+++ b/web/src/api/todoApi.ts
@@ -10,6 +10,10 @@ export const todoApi = {
     return apiClient.get('/v1/todos')
   },
 
+  getUncompletedTodos(): Promise<Todo[]> {
+    return apiClient.get('/v1/todos/uncompleted')
+  },
+
   getTodo(id: string): Promise<Todo> {
     return apiClient.get(`/v1/todos/todo/${id}`)
   },

--- a/web/src/components/AuthGuard.tsx
+++ b/web/src/components/AuthGuard.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../stores/authStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useForemostEventStore } from '../stores/foremostEventStore'
+import { useUncompletedTodosStore } from '../stores/uncompletedTodosStore'
 import { useToastStore } from '../stores/toastStore'
 
 interface AuthGuardProps {
@@ -19,6 +20,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
         useEventTagStore.getState().fetchAll(),
         useCurrentTodosStore.getState().fetch(),
         useForemostEventStore.getState().fetch(),
+        useUncompletedTodosStore.getState().fetch(),
       ]).catch(() => {
         useToastStore.getState().show('데이터 로드에 실패했습니다', 'error')
       })

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -6,11 +6,11 @@ import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
+import { skipRepeatingTodo, refreshAllTodoStores } from '../utils/todoActions'
 import type { Todo } from '../models'
 
 export function CurrentTodoList() {
   const todos = useCurrentTodosStore(s => s.todos)
-  const fetchTodos = useCurrentTodosStore(s => s.fetch)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
   const navigate = useNavigate()
   const location = useLocation()
@@ -26,7 +26,7 @@ export function CurrentTodoList() {
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
     const { removeTodo } = useCurrentTodosStore.getState()
-    const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
+    const { removeEvent } = useCalendarEventsStore.getState()
     try {
       if (scope === 'this' && todo.repeating && todo.event_time) {
         // 이번만 완료: next_event_time 전달로 시리즈 유지
@@ -43,8 +43,7 @@ export function CurrentTodoList() {
       }
 
       if (todo.repeating) {
-        await refreshCurrentRange()
-        await fetchTodos()
+        await refreshAllTodoStores()
       } else {
         removeEvent(todo.uuid)
         removeTodo(todo.uuid)
@@ -62,16 +61,8 @@ export function CurrentTodoList() {
   }
 
   async function handleSkip(todo: Todo) {
-    if (!todo.repeating || !todo.event_time) return
     try {
-      const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
-      if (next) {
-        await todoApi.patchTodo(todo.uuid, { event_time: next.time, repeating_turn: next.turn })
-      } else {
-        await todoApi.deleteTodo(todo.uuid)
-      }
-      await fetchTodos()
-      await useCalendarEventsStore.getState().refreshCurrentRange()
+      await skipRepeatingTodo(todo)
     } catch (e) {
       console.warn('건너뛰기 실패:', e)
     }

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -61,6 +61,22 @@ export function CurrentTodoList() {
     await doComplete(todo, scope)
   }
 
+  async function handleSkip(todo: Todo) {
+    if (!todo.repeating || !todo.event_time) return
+    try {
+      const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
+      if (next) {
+        await todoApi.patchTodo(todo.uuid, { event_time: next.time, repeating_turn: next.turn })
+      } else {
+        await todoApi.deleteTodo(todo.uuid)
+      }
+      await fetchTodos()
+      await useCalendarEventsStore.getState().refreshCurrentRange()
+    } catch (e) {
+      console.warn('건너뛰기 실패:', e)
+    }
+  }
+
   if (todos.length === 0) return null
 
   return (
@@ -90,6 +106,14 @@ export function CurrentTodoList() {
                 <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
                 <span className="truncate text-sm text-gray-900">{todo.name}</span>
               </button>
+              {todo.repeating && (
+                <button
+                  onClick={() => handleSkip(todo)}
+                  className="shrink-0 text-xs text-gray-400 hover:text-gray-600"
+                >
+                  건너뛰기
+                </button>
+              )}
             </li>
           )
         })}

--- a/web/src/components/UncompletedTodoList.tsx
+++ b/web/src/components/UncompletedTodoList.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { todoApi } from '../api/todoApi'
+import { useUncompletedTodosStore } from '../stores/uncompletedTodosStore'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
+import { useEventTagStore } from '../stores/eventTagStore'
+import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
+import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
+import type { Todo } from '../models'
+
+export function UncompletedTodoList() {
+  const todos = useUncompletedTodosStore(s => s.todos)
+  const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
+
+  async function handleComplete(todo: Todo) {
+    if (todo.repeating && todo.event_time) {
+      setScopeTarget(todo)
+      return
+    }
+    await doComplete(todo)
+  }
+
+  async function doComplete(todo: Todo, scope?: RepeatScope) {
+    const { removeTodo } = useUncompletedTodosStore.getState()
+    const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
+    try {
+      if (scope === 'this' && todo.repeating && todo.event_time) {
+        const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
+        await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
+      } else if (scope === 'future') {
+        const startTs = getStartTimestamp(todo.event_time!)
+        await todoApi.patchTodo(todo.uuid, { repeating: { ...todo.repeating, end: startTs - 1 } })
+        await todoApi.completeTodo(todo.uuid, { origin: todo })
+      } else {
+        await todoApi.completeTodo(todo.uuid, { origin: todo })
+      }
+
+      if (todo.repeating) {
+        await refreshCurrentRange()
+        await useUncompletedTodosStore.getState().fetch()
+      } else {
+        removeEvent(todo.uuid)
+        removeTodo(todo.uuid)
+      }
+    } catch (e) {
+      console.warn('완료 처리 실패:', e)
+    }
+  }
+
+  async function handleCompleteWithScope(scope: RepeatScope) {
+    if (!scopeTarget) return
+    const todo = scopeTarget
+    setScopeTarget(null)
+    await doComplete(todo, scope)
+  }
+
+  async function handleSkip(todo: Todo) {
+    if (!todo.repeating || !todo.event_time) return
+    try {
+      const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
+      if (next) {
+        await todoApi.patchTodo(todo.uuid, { event_time: next.time, repeating_turn: next.turn })
+      } else {
+        await todoApi.deleteTodo(todo.uuid)
+      }
+      await useUncompletedTodosStore.getState().fetch()
+      await useCalendarEventsStore.getState().refreshCurrentRange()
+    } catch (e) {
+      console.warn('건너뛰기 실패:', e)
+    }
+  }
+
+  if (todos.length === 0) return null
+
+  return (
+    <section>
+      <h3 className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-red-400">
+        미완료
+      </h3>
+      <ul className="divide-y divide-gray-100">
+        {todos.map(todo => {
+          const color = todo.event_tag_id
+            ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
+            : '#9ca3af'
+          return (
+            <li key={todo.uuid} className="flex items-center gap-2 px-3 py-2">
+              <input
+                type="checkbox"
+                aria-label={todo.name}
+                className="h-4 w-4 rounded border-gray-300"
+                onChange={() => handleComplete(todo)}
+              />
+              <button
+                className="flex flex-1 items-center gap-2 rounded text-left hover:bg-gray-50"
+                onClick={() => navigate(`/events/${todo.uuid}?type=todo`, {
+                  state: { background: location, eventType: 'todo' },
+                })}
+              >
+                <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                <span className="truncate text-sm text-gray-900">{todo.name}</span>
+              </button>
+              {todo.repeating && (
+                <button
+                  onClick={() => handleSkip(todo)}
+                  className="shrink-0 text-xs text-gray-400 hover:text-gray-600"
+                >
+                  건너뛰기
+                </button>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+      {scopeTarget && (
+        <RepeatingScopeDialog
+          mode="complete"
+          eventType="todo"
+          onSelect={handleCompleteWithScope}
+          onCancel={() => setScopeTarget(null)}
+        />
+      )}
+    </section>
+  )
+}

--- a/web/src/components/UncompletedTodoList.tsx
+++ b/web/src/components/UncompletedTodoList.tsx
@@ -6,6 +6,7 @@ import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
+import { skipRepeatingTodo, refreshAllTodoStores } from '../utils/todoActions'
 import type { Todo } from '../models'
 
 export function UncompletedTodoList() {
@@ -25,7 +26,7 @@ export function UncompletedTodoList() {
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
     const { removeTodo } = useUncompletedTodosStore.getState()
-    const { removeEvent, refreshCurrentRange } = useCalendarEventsStore.getState()
+    const { removeEvent } = useCalendarEventsStore.getState()
     try {
       if (scope === 'this' && todo.repeating && todo.event_time) {
         const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
@@ -39,8 +40,7 @@ export function UncompletedTodoList() {
       }
 
       if (todo.repeating) {
-        await refreshCurrentRange()
-        await useUncompletedTodosStore.getState().fetch()
+        await refreshAllTodoStores()
       } else {
         removeEvent(todo.uuid)
         removeTodo(todo.uuid)
@@ -58,16 +58,8 @@ export function UncompletedTodoList() {
   }
 
   async function handleSkip(todo: Todo) {
-    if (!todo.repeating || !todo.event_time) return
     try {
-      const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
-      if (next) {
-        await todoApi.patchTodo(todo.uuid, { event_time: next.time, repeating_turn: next.turn })
-      } else {
-        await todoApi.deleteTodo(todo.uuid)
-      }
-      await useUncompletedTodosStore.getState().fetch()
-      await useCalendarEventsStore.getState().refreshCurrentRange()
+      await skipRepeatingTodo(todo)
     } catch (e) {
       console.warn('건너뛰기 실패:', e)
     }

--- a/web/src/pages/MainPage.tsx
+++ b/web/src/pages/MainPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import MonthCalendar from '../calendar/MonthCalendar'
 import { DayEventList } from '../components/DayEventList'
 import { CurrentTodoList } from '../components/CurrentTodoList'
+import { UncompletedTodoList } from '../components/UncompletedTodoList'
 import { ForemostEventBanner } from '../components/ForemostEventBanner'
 import { TypeSelectorPopup } from '../components/TypeSelectorPopup'
 import { useUiStore } from '../stores/uiStore'
@@ -35,6 +36,9 @@ export function MainPage() {
             <ForemostEventBanner />
           </div>
         )}
+
+        {/* Uncompleted todos */}
+        <UncompletedTodoList />
 
         {/* Current todos */}
         <CurrentTodoList />

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -57,10 +57,12 @@ export const useAuthStore = create<AuthState>((set) => {
       const { useCurrentTodosStore } = await import('./currentTodosStore')
       const { useForemostEventStore } = await import('./foremostEventStore')
       const { useCalendarEventsStore } = await import('./calendarEventsStore')
+      const { useUncompletedTodosStore } = await import('./uncompletedTodosStore')
       useEventTagStore.getState().reset()
       useCurrentTodosStore.getState().reset()
       useForemostEventStore.getState().reset()
       useCalendarEventsStore.getState().reset()
+      useUncompletedTodosStore.getState().reset()
     },
   }
 })

--- a/web/src/stores/uncompletedTodosStore.ts
+++ b/web/src/stores/uncompletedTodosStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+import { todoApi } from '../api/todoApi'
+import type { Todo } from '../models'
+
+interface UncompletedTodosState {
+  todos: Todo[]
+  fetch: () => Promise<void>
+  removeTodo: (id: string) => void
+  reset: () => void
+}
+
+export const useUncompletedTodosStore = create<UncompletedTodosState>((set, get) => ({
+  todos: [],
+
+  fetch: async () => {
+    try {
+      const todos = await todoApi.getUncompletedTodos()
+      set({ todos })
+    } catch (e) {
+      console.warn('미완료 할일 로드 실패:', e)
+    }
+  },
+
+  removeTodo: (id: string) => {
+    set({ todos: get().todos.filter(t => t.uuid !== id) })
+  },
+
+  reset: () => set({ todos: [] }),
+}))

--- a/web/src/utils/todoActions.ts
+++ b/web/src/utils/todoActions.ts
@@ -1,0 +1,25 @@
+import { todoApi } from '../api/todoApi'
+import { nextRepeatingTime } from './repeatingTimeCalculator'
+import { useCalendarEventsStore } from '../stores/calendarEventsStore'
+import { useCurrentTodosStore } from '../stores/currentTodosStore'
+import { useUncompletedTodosStore } from '../stores/uncompletedTodosStore'
+import type { Todo } from '../models'
+
+export async function skipRepeatingTodo(todo: Todo): Promise<void> {
+  if (!todo.repeating || !todo.event_time) return
+  const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
+  if (next) {
+    await todoApi.patchTodo(todo.uuid, { event_time: next.time, repeating_turn: next.turn })
+  } else {
+    await todoApi.deleteTodo(todo.uuid)
+  }
+  await refreshAllTodoStores()
+}
+
+export async function refreshAllTodoStores(): Promise<void> {
+  await Promise.all([
+    useUncompletedTodosStore.getState().fetch(),
+    useCurrentTodosStore.getState().fetch(),
+    useCalendarEventsStore.getState().refreshCurrentRange(),
+  ]).catch(() => {})
+}


### PR DESCRIPTION
## Summary\n\n- 미완료(기한 지난) Todo를 별도 섹션으로 표시 (빨간색 '미완료' 헤더)\n- uncompletedTodosStore + UncompletedTodoList 컴포넌트 신규\n- 반복 Todo에 '건너뛰기' 버튼 추가 (UncompletedTodoList + CurrentTodoList 모두)\n- MainPage에 미완료 섹션 배치 (ForemostBanner 아래, CurrentTodoList 위)\n- AuthGuard/authStore 부트/로그아웃 연동\n\n## Test plan\n\n- [ ] 기한 지난 Todo가 '미완료' 섹션에 표시되는지 확인\n- [ ] 미완료 Todo 완료 → scope 선택 (반복) 또는 바로 완료 (비반복)\n- [ ] 반복 Todo '건너뛰기' 클릭 → 다음 인스턴스로 이동\n- [ ] CurrentTodoList에서도 건너뛰기 버튼 동작 확인\n- [ ] 로그인/로그아웃 시 미완료 목록 정상 초기화\n- [ ] 234 tests passed, build 성공\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)