### PR TITLE
[Phase5] Settings 확장 — 공휴일 국가, 다크 모드, 기본값, 타임존

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { LoadingSkeleton } from './components/LoadingSkeleton'
 import { ToastContainer } from './components/Toast'
 import { LoginPage } from './pages/LoginPage'
 import { MainPage } from './pages/MainPage'
+import './stores/themeStore'
 
 const EventDetailPage = React.lazy(() => import('./pages/EventDetailPage').then(m => ({ default: m.EventDetailPage })))
 const TodoFormPage = React.lazy(() => import('./pages/TodoFormPage').then(m => ({ default: m.TodoFormPage })))

--- a/web/src/calendar/CalendarGrid.tsx
+++ b/web/src/calendar/CalendarGrid.tsx
@@ -25,7 +25,7 @@ export default function CalendarGrid({ days }: CalendarGridProps) {
       {WEEKDAYS.map((day, i) => (
         <div
           key={day}
-          className={`py-2 text-center text-xs font-medium ${i === 0 ? 'text-red-400' : 'text-gray-500'}`}
+          className={`py-2 text-center text-xs font-medium ${i === 0 ? 'text-red-400' : 'text-gray-500 dark:text-gray-400'}`}
         >
           {day}
         </div>
@@ -47,10 +47,10 @@ export default function CalendarGrid({ days }: CalendarGridProps) {
         const textColor = day.isToday
           ? 'font-semibold text-white'
           : !day.isCurrentMonth
-            ? 'text-gray-300'
+            ? 'text-gray-300 dark:text-gray-600'
             : (isHoliday || isSunday)
               ? 'text-red-500'
-              : 'text-gray-900'
+              : 'text-gray-900 dark:text-gray-100'
 
         const bgClass = day.isToday ? 'bg-blue-500 rounded-full' : ''
         const selectedClass = isSelected && !day.isToday ? 'ring-2 ring-blue-400 rounded-full' : ''

--- a/web/src/calendar/CalendarHeader.tsx
+++ b/web/src/calendar/CalendarHeader.tsx
@@ -12,15 +12,15 @@ export default function CalendarHeader({ year, month, onPrev, onNext }: Calendar
     <div className="mb-4 flex items-center justify-between">
       <button
         onClick={onPrev}
-        className="rounded px-3 py-1 hover:bg-gray-100"
+        className="rounded px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
         aria-label="Previous month"
       >
         ‹
       </button>
-      <h2 className="text-lg font-semibold">{formatMonthTitle(year, month)}</h2>
+      <h2 className="text-lg font-semibold dark:text-gray-100">{formatMonthTitle(year, month)}</h2>
       <button
         onClick={onNext}
-        className="rounded px-3 py-1 hover:bg-gray-100"
+        className="rounded px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
         aria-label="Next month"
       >
         ›

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -10,12 +10,12 @@ interface ConfirmDialogProps {
 export function ConfirmDialog({ title, message, confirmLabel = '확인', onConfirm, onCancel, danger = true }: ConfirmDialogProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="mx-4 w-full max-w-sm rounded-xl bg-white p-6 shadow-lg">
-        {title && <h2 className="text-base font-semibold text-gray-900">{title}</h2>}
-        <p className={`text-sm text-gray-700${title ? ' mt-2' : ''}`}>{message}</p>
+      <div className="mx-4 w-full max-w-sm rounded-xl bg-white dark:bg-gray-800 p-6 shadow-lg">
+        {title && <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">{title}</h2>}
+        <p className={`text-sm text-gray-700 dark:text-gray-300${title ? ' mt-2' : ''}`}>{message}</p>
         <div className="mt-5 flex justify-end gap-2">
           <button
-            className="rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100"
+            className="rounded-lg px-4 py-2 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
             onClick={onCancel}
           >
             취소

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -3,12 +3,12 @@ import { NavLink } from 'react-router-dom'
 export function Header() {
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     `rounded-md px-3 py-2 text-xs md:text-sm font-medium transition-colors ${
-      isActive ? 'bg-gray-100 text-gray-900' : 'text-gray-500 hover:text-gray-700'
+      isActive ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
     }`
 
   return (
-    <header className="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-gray-200 bg-white px-4">
-      <span className="text-sm font-bold text-gray-900">TodoCalendar</span>
+    <header className="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4">
+      <span className="text-sm font-bold text-gray-900 dark:text-gray-100">TodoCalendar</span>
       <nav className="flex gap-1">
         <NavLink to="/" end className={linkClass}>캘린더</NavLink>
         <NavLink to="/done" className={linkClass}>Done</NavLink>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:is(.dark *));
+
 html {
   -webkit-text-size-adjust: 100%;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -19,10 +19,10 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50">
-      <div className="w-full max-w-sm p-8 bg-white rounded-2xl shadow-md">
-        <h1 className="text-2xl font-bold text-center text-gray-800 mb-2">TodoCalendar</h1>
-        <p className="text-sm text-center text-gray-500 mb-8">계속하려면 로그인하세요</p>
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="w-full max-w-sm p-8 bg-white dark:bg-gray-800 rounded-2xl shadow-md">
+        <h1 className="text-2xl font-bold text-center text-gray-800 dark:text-gray-100 mb-2">TodoCalendar</h1>
+        <p className="text-sm text-center text-gray-500 dark:text-gray-400 mb-8">계속하려면 로그인하세요</p>
 
         {error && (
           <div role="alert" className="mb-4 p-3 text-sm text-red-700 bg-red-50 rounded-lg">
@@ -34,7 +34,7 @@ export function LoginPage() {
           <button
             onClick={() => handleSignIn(signInWithGoogle)}
             disabled={loading}
-            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-gray-300 rounded-xl text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-xl text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
               <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
@@ -48,7 +48,7 @@ export function LoginPage() {
           <button
             onClick={() => handleSignIn(signInWithApple)}
             disabled={loading}
-            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-gray-300 rounded-xl text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-xl text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>

--- a/web/src/pages/MainPage.tsx
+++ b/web/src/pages/MainPage.tsx
@@ -22,9 +22,9 @@ export function MainPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-gray-50 md:flex-row">
+    <div className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900 md:flex-row">
       {/* Calendar panel */}
-      <div className="w-full shrink-0 bg-white shadow-sm md:w-80 md:min-h-screen">
+      <div className="w-full shrink-0 bg-white dark:bg-gray-800 shadow-sm md:w-80 md:min-h-screen">
         <MonthCalendar />
       </div>
 
@@ -46,7 +46,7 @@ export function MainPage() {
         {/* Day events */}
         {selectedDate && (
           <section className="mt-4">
-            <h2 className="mb-2 px-3 text-sm font-semibold text-gray-700">
+            <h2 className="mb-2 px-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
               {selectedDate.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric', weekday: 'short' })}
             </h2>
             <DayEventList selectedDate={selectedDate} />

--- a/web/src/pages/ScheduleFormPage.tsx
+++ b/web/src/pages/ScheduleFormPage.tsx
@@ -9,6 +9,7 @@ import { TagSelector } from '../components/TagSelector'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { RepeatingScopeDialog, type RepeatScope } from '../components/RepeatingScopeDialog'
 import { NotificationPicker } from '../components/NotificationPicker'
+import { useEventDefaultsStore } from '../stores/eventDefaultsStore'
 import type { Schedule, EventTime, Repeating, NotificationOption } from '../models'
 
 export function ScheduleFormPage() {
@@ -17,6 +18,7 @@ export function ScheduleFormPage() {
   const selectedDate = useUiStore(s => s.selectedDate)
 
   const { addEvent, removeEvent, refreshCurrentRange } = useCalendarEventsStore()
+  const { defaultTagId, defaultNotificationSeconds } = useEventDefaultsStore()
 
   const defaultEventTime = (): EventTime => {
     const base = selectedDate ?? new Date()
@@ -26,10 +28,12 @@ export function ScheduleFormPage() {
   const [loading, setLoading] = useState(!!id)
   const [original, setOriginal] = useState<Schedule | null>(null)
   const [name, setName] = useState('')
-  const [tagId, setTagId] = useState<string | null>(null)
+  const [tagId, setTagId] = useState<string | null>(() => id ? null : defaultTagId)
   const [eventTime, setEventTime] = useState<EventTime>(defaultEventTime)
   const [repeating, setRepeating] = useState<Repeating | null>(null)
-  const [notifications, setNotifications] = useState<NotificationOption[]>([])
+  const [notifications, setNotifications] = useState<NotificationOption[]>(() =>
+    !id && defaultNotificationSeconds != null ? [{ type: 'time' as const, seconds: defaultNotificationSeconds }] : []
+  )
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [showSaveScope, setShowSaveScope] = useState(false)
   const [showDeleteScope, setShowDeleteScope] = useState(false)

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -3,11 +3,21 @@ import { useAuthStore } from '../stores/authStore'
 import { useToastStore } from '../stores/toastStore'
 import { useHolidayStore, type HolidayCountry } from '../stores/holidayStore'
 import { useThemeStore } from '../stores/themeStore'
+import { useEventDefaultsStore } from '../stores/eventDefaultsStore'
+import { useEventTagStore } from '../stores/eventTagStore'
 import { settingApi } from '../api/settingApi'
 import { accountApi } from '../api/accountApi'
 import { ColorPalette } from '../components/ColorPalette'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import type { DefaultTagColors } from '../models'
+
+const NOTIFICATION_PRESETS = [
+  { label: '없음', value: null },
+  { label: '5분 전', value: -300 },
+  { label: '10분 전', value: -600 },
+  { label: '30분 전', value: -1800 },
+  { label: '1시간 전', value: -3600 },
+]
 
 const COUNTRIES = [
   { label: '한국', locale: 'ko', region: 'south_korea' },
@@ -26,6 +36,8 @@ export function SettingsPage() {
   const setHolidayCountry = useHolidayStore(s => s.setCountry)
   const theme = useThemeStore(s => s.theme)
   const setTheme = useThemeStore(s => s.setTheme)
+  const { defaultTagId, defaultNotificationSeconds, setDefaults } = useEventDefaultsStore()
+  const tags = useEventTagStore(s => s.tags)
   const [_colors, setColors] = useState<DefaultTagColors | null>(null)
   const [editColors, setEditColors] = useState<DefaultTagColors | null>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -123,6 +135,36 @@ export function SettingsPage() {
             <option key={c.region} value={`${c.locale}:${c.region}`}>{c.label}</option>
           ))}
         </select>
+      </section>
+
+      {/* 이벤트 기본값 */}
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm space-y-4">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">이벤트 기본값</h2>
+        <div>
+          <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">기본 태그</p>
+          <select
+            className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            value={defaultTagId ?? ''}
+            onChange={e => setDefaults({ defaultTagId: e.target.value || null })}
+          >
+            <option value="">없음</option>
+            {Array.from(tags.values()).map(tag => (
+              <option key={tag.uuid} value={tag.uuid}>{tag.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">기본 알림</p>
+          <select
+            className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            value={defaultNotificationSeconds ?? ''}
+            onChange={e => setDefaults({ defaultNotificationSeconds: e.target.value ? Number(e.target.value) : null })}
+          >
+            {NOTIFICATION_PRESETS.map(p => (
+              <option key={p.label} value={p.value ?? ''}>{p.label}</option>
+            ))}
+          </select>
+        </div>
       </section>
 
       {/* 계정 정보 */}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -5,11 +5,23 @@ import { useHolidayStore, type HolidayCountry } from '../stores/holidayStore'
 import { useThemeStore } from '../stores/themeStore'
 import { useEventDefaultsStore } from '../stores/eventDefaultsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
+import { useTimezoneStore } from '../stores/timezoneStore'
 import { settingApi } from '../api/settingApi'
 import { accountApi } from '../api/accountApi'
 import { ColorPalette } from '../components/ColorPalette'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import type { DefaultTagColors } from '../models'
+
+const TIMEZONES = [
+  { label: '시스템 기본', value: '' },
+  { label: 'Asia/Seoul (KST)', value: 'Asia/Seoul' },
+  { label: 'Asia/Tokyo (JST)', value: 'Asia/Tokyo' },
+  { label: 'America/New_York (EST)', value: 'America/New_York' },
+  { label: 'America/Los_Angeles (PST)', value: 'America/Los_Angeles' },
+  { label: 'Europe/London (GMT)', value: 'Europe/London' },
+  { label: 'Europe/Berlin (CET)', value: 'Europe/Berlin' },
+  { label: 'UTC', value: 'UTC' },
+]
 
 const NOTIFICATION_PRESETS = [
   { label: '없음', value: null },
@@ -38,6 +50,8 @@ export function SettingsPage() {
   const setTheme = useThemeStore(s => s.setTheme)
   const { defaultTagId, defaultNotificationSeconds, setDefaults } = useEventDefaultsStore()
   const tags = useEventTagStore(s => s.tags)
+  const timezoneState = useTimezoneStore()
+  const { timezone, isCustom, setTimezone } = timezoneState
   const [_colors, setColors] = useState<DefaultTagColors | null>(null)
   const [editColors, setEditColors] = useState<DefaultTagColors | null>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -135,6 +149,23 @@ export function SettingsPage() {
             <option key={c.region} value={`${c.locale}:${c.region}`}>{c.label}</option>
           ))}
         </select>
+      </section>
+
+      {/* 타임존 */}
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm space-y-3">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">타임존</h2>
+        <select
+          className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+          value={isCustom ? timezone : ''}
+          onChange={e => setTimezone(e.target.value || null)}
+        >
+          {TIMEZONES.map(tz => (
+            <option key={tz.value} value={tz.value}>{tz.label}</option>
+          ))}
+        </select>
+        <p className="text-xs text-gray-400 dark:text-gray-500">
+          현재: {timezone}
+        </p>
       </section>
 
       {/* 이벤트 기본값 */}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,15 +1,28 @@
 import { useEffect, useState } from 'react'
 import { useAuthStore } from '../stores/authStore'
 import { useToastStore } from '../stores/toastStore'
+import { useHolidayStore, type HolidayCountry } from '../stores/holidayStore'
 import { settingApi } from '../api/settingApi'
 import { accountApi } from '../api/accountApi'
 import { ColorPalette } from '../components/ColorPalette'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import type { DefaultTagColors } from '../models'
 
+const COUNTRIES = [
+  { label: '한국', locale: 'ko', region: 'south_korea' },
+  { label: '미국', locale: 'en', region: 'united_states' },
+  { label: '일본', locale: 'ja', region: 'japan' },
+  { label: '중국', locale: 'zh', region: 'china' },
+  { label: '영국', locale: 'en', region: 'united_kingdom' },
+  { label: '독일', locale: 'de', region: 'germany' },
+  { label: '프랑스', locale: 'fr', region: 'france' },
+]
+
 export function SettingsPage() {
   const account = useAuthStore(s => s.account)
   const signOut = useAuthStore(s => s.signOut)
+  const holidayCountry = useHolidayStore(s => s.country)
+  const setHolidayCountry = useHolidayStore(s => s.setCountry)
   const [_colors, setColors] = useState<DefaultTagColors | null>(null)
   const [editColors, setEditColors] = useState<DefaultTagColors | null>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -74,6 +87,23 @@ export function SettingsPage() {
             </button>
           </>
         )}
+      </section>
+
+      {/* 공휴일 국가 */}
+      <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm space-y-3">
+        <h2 className="text-sm font-semibold text-gray-700">공휴일 국가</h2>
+        <select
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+          value={`${holidayCountry.locale}:${holidayCountry.region}`}
+          onChange={e => {
+            const [locale, region] = e.target.value.split(':')
+            setHolidayCountry({ locale, region } as HolidayCountry)
+          }}
+        >
+          {COUNTRIES.map(c => (
+            <option key={c.region} value={`${c.locale}:${c.region}`}>{c.label}</option>
+          ))}
+        </select>
       </section>
 
       {/* 계정 정보 */}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useAuthStore } from '../stores/authStore'
 import { useToastStore } from '../stores/toastStore'
 import { useHolidayStore, type HolidayCountry } from '../stores/holidayStore'
+import { useThemeStore } from '../stores/themeStore'
 import { settingApi } from '../api/settingApi'
 import { accountApi } from '../api/accountApi'
 import { ColorPalette } from '../components/ColorPalette'
@@ -23,6 +24,8 @@ export function SettingsPage() {
   const signOut = useAuthStore(s => s.signOut)
   const holidayCountry = useHolidayStore(s => s.country)
   const setHolidayCountry = useHolidayStore(s => s.setCountry)
+  const theme = useThemeStore(s => s.theme)
+  const setTheme = useThemeStore(s => s.setTheme)
   const [_colors, setColors] = useState<DefaultTagColors | null>(null)
   const [editColors, setEditColors] = useState<DefaultTagColors | null>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -58,22 +61,38 @@ export function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-lg px-4 py-6 space-y-8">
-      <h1 className="text-lg font-bold text-gray-900">설정</h1>
+      <h1 className="text-lg font-bold text-gray-900 dark:text-gray-100">설정</h1>
+
+      {/* 테마 */}
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm space-y-3">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">테마</h2>
+        <div className="flex gap-2">
+          {(['system', 'light', 'dark'] as const).map(t => (
+            <button
+              key={t}
+              onClick={() => setTheme(t)}
+              className={`rounded-lg px-3 py-2 text-sm ${theme === t ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'}`}
+            >
+              {t === 'system' ? '시스템' : t === 'light' ? '라이트' : '다크'}
+            </button>
+          ))}
+        </div>
+      </section>
 
       {/* 기본 태그 색상 */}
-      <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm space-y-4">
-        <h2 className="text-sm font-semibold text-gray-700">기본 태그 색상</h2>
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm space-y-4">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">기본 태그 색상</h2>
         {editColors && (
           <>
             <div>
-              <p className="mb-2 text-xs text-gray-500">공휴일 색상</p>
+              <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">공휴일 색상</p>
               <ColorPalette
                 selected={editColors.holiday}
                 onChange={hex => setEditColors(c => c ? { ...c, holiday: hex } : c)}
               />
             </div>
             <div>
-              <p className="mb-2 text-xs text-gray-500">기본 색상</p>
+              <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">기본 색상</p>
               <ColorPalette
                 selected={editColors.default}
                 onChange={hex => setEditColors(c => c ? { ...c, default: hex } : c)}
@@ -90,10 +109,10 @@ export function SettingsPage() {
       </section>
 
       {/* 공휴일 국가 */}
-      <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm space-y-3">
-        <h2 className="text-sm font-semibold text-gray-700">공휴일 국가</h2>
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm space-y-3">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">공휴일 국가</h2>
         <select
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+          className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
           value={`${holidayCountry.locale}:${holidayCountry.region}`}
           onChange={e => {
             const [locale, region] = e.target.value.split(':')
@@ -107,13 +126,13 @@ export function SettingsPage() {
       </section>
 
       {/* 계정 정보 */}
-      <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm space-y-3">
-        <h2 className="text-sm font-semibold text-gray-700">계정</h2>
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm space-y-3">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">계정</h2>
         {account && (
-          <p className="text-sm text-gray-500">{account.email ?? account.uid}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{account.email ?? account.uid}</p>
         )}
         <button
-          className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50"
+          className="rounded-lg border border-gray-200 dark:border-gray-600 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
           onClick={signOut}
         >
           로그아웃
@@ -121,10 +140,10 @@ export function SettingsPage() {
       </section>
 
       {/* 계정 삭제 */}
-      <section className="rounded-xl border border-red-100 bg-white p-5 shadow-sm">
+      <section className="rounded-xl border border-red-100 dark:border-red-900 bg-white dark:bg-gray-800 p-5 shadow-sm">
         <h2 className="mb-3 text-sm font-semibold text-red-500">위험 구역</h2>
         <button
-          className="rounded-lg border border-red-200 px-4 py-2 text-sm text-red-500 hover:bg-red-50"
+          className="rounded-lg border border-red-200 dark:border-red-800 px-4 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30"
           onClick={() => setShowDeleteConfirm(true)}
         >
           계정 삭제

--- a/web/src/pages/TodoFormPage.tsx
+++ b/web/src/pages/TodoFormPage.tsx
@@ -11,6 +11,7 @@ import { ConfirmDialog } from '../components/ConfirmDialog'
 import { RepeatingScopeDialog, type RepeatScope } from '../components/RepeatingScopeDialog'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import { NotificationPicker } from '../components/NotificationPicker'
+import { useEventDefaultsStore } from '../stores/eventDefaultsStore'
 import type { Todo, EventTime, Repeating, NotificationOption } from '../models'
 
 export function TodoFormPage() {
@@ -20,16 +21,19 @@ export function TodoFormPage() {
 
   const { addEvent, removeEvent, refreshCurrentRange } = useCalendarEventsStore()
   const { addTodo, removeTodo, replaceTodo } = useCurrentTodosStore()
+  const { defaultTagId, defaultNotificationSeconds } = useEventDefaultsStore()
 
   const [loading, setLoading] = useState(!!id)
   const [original, setOriginal] = useState<Todo | null>(null)
   const [name, setName] = useState('')
-  const [tagId, setTagId] = useState<string | null>(null)
+  const [tagId, setTagId] = useState<string | null>(() => id ? null : defaultTagId)
   const [eventTime, setEventTime] = useState<EventTime | null>(() =>
     selectedDate ? { time_type: 'at', timestamp: Math.floor(selectedDate.getTime() / 1000) } : null
   )
   const [repeating, setRepeating] = useState<Repeating | null>(null)
-  const [notifications, setNotifications] = useState<NotificationOption[]>([])
+  const [notifications, setNotifications] = useState<NotificationOption[]>(() =>
+    !id && defaultNotificationSeconds != null ? [{ type: 'time' as const, seconds: defaultNotificationSeconds }] : []
+  )
   const [showConfirm, setShowConfirm] = useState(false)
   const [showSaveScope, setShowSaveScope] = useState(false)
   const [showDeleteScope, setShowDeleteScope] = useState(false)

--- a/web/src/stores/eventDefaultsStore.ts
+++ b/web/src/stores/eventDefaultsStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand'
+
+const STORAGE_KEY = 'event_defaults'
+
+interface EventDefaults {
+  defaultTagId: string | null
+  defaultNotificationSeconds: number | null
+}
+
+const DEFAULT_VALUES: EventDefaults = { defaultTagId: null, defaultNotificationSeconds: null }
+
+function load(): EventDefaults {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored ? { ...DEFAULT_VALUES, ...JSON.parse(stored) } : DEFAULT_VALUES
+  } catch { return DEFAULT_VALUES }
+}
+
+interface EventDefaultsState extends EventDefaults {
+  setDefaults: (updates: Partial<EventDefaults>) => void
+}
+
+export const useEventDefaultsStore = create<EventDefaultsState>((set, get) => ({
+  ...load(),
+  setDefaults: (updates) => {
+    const next = { ...get(), ...updates }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ defaultTagId: next.defaultTagId, defaultNotificationSeconds: next.defaultNotificationSeconds }))
+    set(updates)
+  },
+}))

--- a/web/src/stores/holidayStore.ts
+++ b/web/src/stores/holidayStore.ts
@@ -1,24 +1,43 @@
 import { create } from 'zustand'
 import { holidayApi } from '../api/holidayApi'
 
-const HOLIDAY_LOCALE = 'ko'
-const HOLIDAY_REGION = 'south_korea'
+const STORAGE_KEY = 'holiday_country'
+
+export interface HolidayCountry { locale: string; region: string }
+
+const DEFAULT_COUNTRY: HolidayCountry = { locale: 'ko', region: 'south_korea' }
+
+function loadCountry(): HolidayCountry {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored ? JSON.parse(stored) : DEFAULT_COUNTRY
+  } catch { return DEFAULT_COUNTRY }
+}
 
 interface HolidayState {
+  country: HolidayCountry
   holidays: Map<string, string[]>
   loadedYears: Set<number>
+  setCountry: (country: HolidayCountry) => void
   fetchHolidays: (year: number) => Promise<void>
   getHolidayNames: (dateKey: string) => string[]
 }
 
 export const useHolidayStore = create<HolidayState>((set, get) => ({
+  country: loadCountry(),
   holidays: new Map(),
   loadedYears: new Set(),
 
+  setCountry: (country: HolidayCountry) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(country))
+    set({ country, holidays: new Map(), loadedYears: new Set() })
+  },
+
   fetchHolidays: async (year: number) => {
     if (get().loadedYears.has(year)) return
+    const { locale, region } = get().country
     try {
-      const response = await holidayApi.getHolidays(year, HOLIDAY_LOCALE, HOLIDAY_REGION)
+      const response = await holidayApi.getHolidays(year, locale, region)
       const newHolidays = new Map(get().holidays)
       for (const item of response.items) {
         const dateKey = item.start.date

--- a/web/src/stores/holidayStore.ts
+++ b/web/src/stores/holidayStore.ts
@@ -31,6 +31,9 @@ export const useHolidayStore = create<HolidayState>((set, get) => ({
   setCountry: (country: HolidayCountry) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(country))
     set({ country, holidays: new Map(), loadedYears: new Set() })
+    // 현재 연도 공휴일 자동 fetch
+    const currentYear = new Date().getFullYear()
+    get().fetchHolidays(currentYear)
   },
 
   fetchHolidays: async (year: number) => {

--- a/web/src/stores/themeStore.ts
+++ b/web/src/stores/themeStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand'
+
+type Theme = 'system' | 'light' | 'dark'
+const STORAGE_KEY = 'theme'
+
+function loadTheme(): Theme {
+  return (localStorage.getItem(STORAGE_KEY) as Theme) ?? 'system'
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement
+  if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}
+
+interface ThemeState {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+export const useThemeStore = create<ThemeState>((set) => ({
+  theme: loadTheme(),
+  setTheme: (theme) => {
+    localStorage.setItem(STORAGE_KEY, theme)
+    applyTheme(theme)
+    set({ theme })
+  },
+}))
+
+// 초기 적용
+applyTheme(loadTheme())

--- a/web/src/stores/themeStore.ts
+++ b/web/src/stores/themeStore.ts
@@ -4,7 +4,11 @@ type Theme = 'system' | 'light' | 'dark'
 const STORAGE_KEY = 'theme'
 
 function loadTheme(): Theme {
-  return (localStorage.getItem(STORAGE_KEY) as Theme) ?? 'system'
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'system' || stored === 'light' || stored === 'dark') return stored
+    return 'system'
+  } catch { return 'system' }
 }
 
 function applyTheme(theme: Theme) {
@@ -32,3 +36,13 @@ export const useThemeStore = create<ThemeState>((set) => ({
 
 // 초기 적용
 applyTheme(loadTheme())
+
+// OS 테마 변경 감지 리스너
+if (typeof window !== 'undefined') {
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    const { theme } = useThemeStore.getState()
+    if (theme === 'system') {
+      applyTheme('system')
+    }
+  })
+}

--- a/web/src/stores/timezoneStore.ts
+++ b/web/src/stores/timezoneStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand'
+
+const STORAGE_KEY = 'custom_timezone'
+
+interface TimezoneState {
+  timezone: string
+  isCustom: boolean
+  setTimezone: (tz: string | null) => void
+}
+
+export const useTimezoneStore = create<TimezoneState>((set) => {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  const systemTz = Intl.DateTimeFormat().resolvedOptions().timeZone
+  return {
+    timezone: stored ?? systemTz,
+    isCustom: !!stored,
+    setTimezone: (tz) => {
+      if (tz) {
+        localStorage.setItem(STORAGE_KEY, tz)
+        set({ timezone: tz, isCustom: true })
+      } else {
+        localStorage.removeItem(STORAGE_KEY)
+        set({ timezone: systemTz, isCustom: false })
+      }
+    },
+  }
+})

--- a/web/src/stores/timezoneStore.ts
+++ b/web/src/stores/timezoneStore.ts
@@ -8,12 +8,22 @@ interface TimezoneState {
   setTimezone: (tz: string | null) => void
 }
 
+const systemTz = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+function loadTimezone(): { timezone: string; isCustom: boolean } {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored ? { timezone: stored, isCustom: true } : { timezone: systemTz, isCustom: false }
+  } catch {
+    return { timezone: systemTz, isCustom: false }
+  }
+}
+
 export const useTimezoneStore = create<TimezoneState>((set) => {
-  const stored = localStorage.getItem(STORAGE_KEY)
-  const systemTz = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const initial = loadTimezone()
   return {
-    timezone: stored ?? systemTz,
-    isCustom: !!stored,
+    timezone: initial.timezone,
+    isCustom: initial.isCustom,
     setTimezone: (tz) => {
       if (tz) {
         localStorage.setItem(STORAGE_KEY, tz)


### PR DESCRIPTION
## Summary\n\n- 공휴일 국가 선택 (7개국 드롭다운, localStorage 저장, 변경 시 캐시 초기화)\n- 다크 모드 (system/light/dark, Tailwind dark 클래스, 6개 핵심 컴포넌트 적용)\n- 이벤트 기본값 (기본 태그/알림, 새 이벤트 생성 시 자동 적용)\n- 타임존 설정 (시스템 기본 + 7개 주요 타임존)\n\n## Test plan\n\n- [ ] Settings에서 국가 변경 → 캘린더 공휴일 표시 변경 확인\n- [ ] 다크 모드 토글 → 전체 UI 테마 전환 확인\n- [ ] 시스템 테마 → OS 설정 따라감 확인\n- [ ] 기본 태그/알림 설정 후 새 Todo 생성 → 기본값 적용 확인\n- [ ] 타임존 설정 변경 후 저장/유지 확인\n- [ ] 새로고침 후 모든 설정 유지 (localStorage)\n- [ ] 224 tests passed, build 성공\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)