### PR TITLE
[Phase6] 캘린더 UX 고도화 — 이벤트 바, 외형 설정, 키보드 단축키

### DIFF
--- a/web/src/calendar/CalendarGrid.tsx
+++ b/web/src/calendar/CalendarGrid.tsx
@@ -58,16 +58,40 @@ export default function CalendarGrid({ days }: CalendarGridProps) {
         return (
           <div
             key={i}
-            className="flex flex-col items-center py-1 cursor-pointer"
+            className="flex flex-col items-center py-1 cursor-pointer md:items-start md:min-h-[70px] md:py-1.5"
             data-testid="day-cell"
             onClick={() => setSelectedDate(day.date)}
             title={holidayNames.join(', ') || undefined}
           >
-            <div className={`flex h-7 w-7 items-center justify-center text-sm ${textColor} ${bgClass} ${selectedClass}`}>
+            <div className={`flex h-7 w-7 items-center justify-center text-sm md:ml-0.5 ${textColor} ${bgClass} ${selectedClass}`}>
               {day.dayOfMonth}
             </div>
+            {/* Desktop: color bars with event names */}
+            {events.length > 0 && (
+              <div className="hidden md:block mt-0.5 space-y-px w-full px-0.5">
+                {events.slice(0, 2).map((ev, j) => {
+                  const tagId = ev.event.event_tag_id
+                  const color = tagId ? getColorForTagId(tagId) : '#9ca3af'
+                  return (
+                    <div
+                      key={j}
+                      className="truncate rounded-sm px-0.5 text-[10px] leading-tight text-white"
+                      style={{ backgroundColor: color ?? '#9ca3af' }}
+                    >
+                      {ev.event.name}
+                    </div>
+                  )
+                })}
+                {events.length > 2 && (
+                  <div className="text-[9px] text-gray-400 dark:text-gray-500 px-0.5">
+                    +{events.length - 2}
+                  </div>
+                )}
+              </div>
+            )}
+            {/* Mobile: dots */}
             {dotColors.length > 0 && (
-              <div className="mt-0.5 flex gap-0.5" data-testid="event-dots">
+              <div className="md:hidden mt-0.5 flex gap-0.5" data-testid="event-dots">
                 {dotColors.map((color, j) => (
                   <span
                     key={j}

--- a/web/src/calendar/CalendarGrid.tsx
+++ b/web/src/calendar/CalendarGrid.tsx
@@ -5,6 +5,7 @@ import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useHolidayStore } from '../stores/holidayStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
+import { useCalendarAppearanceStore } from '../stores/calendarAppearanceStore'
 
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
@@ -19,6 +20,7 @@ export default function CalendarGrid({ days }: CalendarGridProps) {
   const getHolidayNames = useHolidayStore(s => s.getHolidayNames)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
   const isTagHidden = useTagFilterStore(s => s.isTagHidden)
+  const { rowHeight, fontSize, showEventNames } = useCalendarAppearanceStore()
 
   return (
     <div className="grid grid-cols-7">
@@ -58,8 +60,9 @@ export default function CalendarGrid({ days }: CalendarGridProps) {
         return (
           <div
             key={i}
-            className="flex flex-col items-center py-1 cursor-pointer md:items-start md:min-h-[70px] md:py-1.5"
+            className="flex flex-col items-center py-1 cursor-pointer md:items-start md:py-1.5"
             data-testid="day-cell"
+            style={{ minHeight: `${rowHeight}px`, fontSize: `${fontSize}px` }}
             onClick={() => setSelectedDate(day.date)}
             title={holidayNames.join(', ') || undefined}
           >
@@ -78,7 +81,7 @@ export default function CalendarGrid({ days }: CalendarGridProps) {
                       className="truncate rounded-sm px-0.5 text-[10px] leading-tight text-white"
                       style={{ backgroundColor: color ?? '#9ca3af' }}
                     >
-                      {ev.event.name}
+                      {showEventNames ? ev.event.name : '\u00A0'}
                     </div>
                   )
                 })}

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+
+export function useKeyboardShortcuts() {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      // Ignore when focus is in input fields
+      const target = e.target as HTMLElement
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return
+      if (target.isContentEditable) return
+
+      switch (e.key) {
+        case 'n':
+          // New event (Todo by default)
+          navigate('/todos/new', { state: { background: location } })
+          break
+        case 'Escape':
+          // Close overlay/modal
+          if (location.state?.background) navigate(-1)
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [navigate, location])
+}

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -11,10 +11,12 @@ export function useKeyboardShortcuts() {
       const target = e.target as HTMLElement
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return
       if (target.isContentEditable) return
+      if (target.closest('[role="dialog"]') || target.closest('.fixed')) return
 
       switch (e.key) {
         case 'n':
           // New event (Todo by default)
+          if (location.state?.background) return  // 이미 모달 열림
           navigate('/todos/new', { state: { background: location } })
           break
         case 'Escape':

--- a/web/src/pages/DoneTodosPage.tsx
+++ b/web/src/pages/DoneTodosPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import { useDoneTodosStore } from '../stores/doneTodosStore'
 import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useEventTagStore } from '../stores/eventTagStore'
@@ -25,6 +25,7 @@ export function DoneTodosPage() {
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const [confirmId, setConfirmId] = useState<string | null>(null)
+  const groups = useMemo(() => groupByDate(items), [items])
 
   useEffect(() => {
     reset()
@@ -60,7 +61,7 @@ export function DoneTodosPage() {
         <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">완료된 할 일이 없습니다</p>
       )}
 
-      {Array.from(groupByDate(items).entries()).map(([dateKey, groupItems]) => (
+      {Array.from(groups.entries()).map(([dateKey, groupItems]) => (
         <div key={dateKey}>
           <h3 className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 sticky top-0">
             {dateKey}

--- a/web/src/pages/DoneTodosPage.tsx
+++ b/web/src/pages/DoneTodosPage.tsx
@@ -4,6 +4,20 @@ import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { useToastStore } from '../stores/toastStore'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import type { DoneTodo } from '../models'
+
+function groupByDate(items: DoneTodo[]): Map<string, DoneTodo[]> {
+  const groups = new Map<string, DoneTodo[]>()
+  for (const item of items) {
+    const dateKey = item.done_at
+      ? new Date(item.done_at * 1000).toLocaleDateString('ko-KR')
+      : '날짜 없음'
+    const group = groups.get(dateKey) ?? []
+    group.push(item)
+    groups.set(dateKey, group)
+  }
+  return groups
+}
 
 export function DoneTodosPage() {
   const { items, hasMore, fetchNext, revert, remove, reset } = useDoneTodosStore()
@@ -40,44 +54,47 @@ export function DoneTodosPage() {
 
   return (
     <div className="mx-auto max-w-lg px-4 py-6">
-      <h1 className="mb-4 text-lg font-bold text-gray-900">완료된 할 일</h1>
+      <h1 className="mb-4 text-lg font-bold text-gray-900 dark:text-gray-100">완료된 할 일</h1>
 
       {items.length === 0 && hasMore === false && (
-        <p className="py-8 text-center text-sm text-gray-400">완료된 할 일이 없습니다</p>
+        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">완료된 할 일이 없습니다</p>
       )}
 
-      <ul className="divide-y divide-gray-100">
-        {items.map(item => {
-          const color = item.event_tag_id
-            ? (getColorForTagId(item.event_tag_id) ?? '#9ca3af')
-            : '#9ca3af'
-          const doneDate = item.done_at
-            ? new Date(item.done_at * 1000).toLocaleDateString('ko-KR')
-            : null
+      {Array.from(groupByDate(items).entries()).map(([dateKey, groupItems]) => (
+        <div key={dateKey}>
+          <h3 className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 sticky top-0">
+            {dateKey}
+          </h3>
+          <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+            {groupItems.map(item => {
+              const color = item.event_tag_id
+                ? (getColorForTagId(item.event_tag_id) ?? '#9ca3af')
+                : '#9ca3af'
 
-          return (
-            <li key={item.uuid} className="flex items-center gap-3 py-3">
-              <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm text-gray-900">{item.name}</p>
-                {doneDate && <p className="text-xs text-gray-400">{doneDate}</p>}
-              </div>
-              <button
-                className="rounded-md px-2 py-1 text-xs text-blue-500 hover:bg-blue-50"
-                onClick={() => handleRevert(item.uuid)}
-              >
-                되돌리기
-              </button>
-              <button
-                className="rounded-md px-2 py-1 text-xs text-red-400 hover:bg-red-50"
-                onClick={() => setConfirmId(item.uuid)}
-              >
-                삭제
-              </button>
-            </li>
-          )
-        })}
-      </ul>
+              return (
+                <li key={item.uuid} className="flex items-center gap-3 py-3">
+                  <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm text-gray-900 dark:text-gray-100">{item.name}</p>
+                  </div>
+                  <button
+                    className="rounded-md px-2 py-1 text-xs text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30"
+                    onClick={() => handleRevert(item.uuid)}
+                  >
+                    되돌리기
+                  </button>
+                  <button
+                    className="rounded-md px-2 py-1 text-xs text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30"
+                    onClick={() => setConfirmId(item.uuid)}
+                  >
+                    삭제
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ))}
 
       <div ref={sentinelRef} className="py-2 text-center text-xs text-gray-400">
         {!hasMore && items.length > 0 && '모두 표시됨'}

--- a/web/src/pages/MainPage.tsx
+++ b/web/src/pages/MainPage.tsx
@@ -8,8 +8,10 @@ import { ForemostEventBanner } from '../components/ForemostEventBanner'
 import { TypeSelectorPopup } from '../components/TypeSelectorPopup'
 import { useUiStore } from '../stores/uiStore'
 import { useForemostEventStore } from '../stores/foremostEventStore'
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 
 export function MainPage() {
+  useKeyboardShortcuts()
   const selectedDate = useUiStore(s => s.selectedDate)
   const foremostEvent = useForemostEventStore(s => s.foremostEvent)
   const [showTypeSelector, setShowTypeSelector] = useState(false)

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { useThemeStore } from '../stores/themeStore'
 import { useEventDefaultsStore } from '../stores/eventDefaultsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { useTimezoneStore } from '../stores/timezoneStore'
+import { useCalendarAppearanceStore } from '../stores/calendarAppearanceStore'
 import { settingApi } from '../api/settingApi'
 import { accountApi } from '../api/accountApi'
 import { ColorPalette } from '../components/ColorPalette'
@@ -50,6 +51,7 @@ export function SettingsPage() {
   const setTheme = useThemeStore(s => s.setTheme)
   const { defaultTagId, defaultNotificationSeconds, setDefaults } = useEventDefaultsStore()
   const tags = useEventTagStore(s => s.tags)
+  const { rowHeight, fontSize: calFontSize, showEventNames, setAppearance, resetToDefaults: resetAppearance } = useCalendarAppearanceStore()
   const timezoneState = useTimezoneStore()
   const { timezone, isCustom, setTimezone } = timezoneState
   const [_colors, setColors] = useState<DefaultTagColors | null>(null)
@@ -103,6 +105,54 @@ export function SettingsPage() {
             </button>
           ))}
         </div>
+      </section>
+
+      {/* 캘린더 외형 */}
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm space-y-4">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">캘린더 외형</h2>
+        <div>
+          <label className="mb-1 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+            <span>행 높이</span>
+            <span>{rowHeight}px</span>
+          </label>
+          <input
+            type="range"
+            min={50}
+            max={120}
+            value={rowHeight}
+            onChange={e => setAppearance({ rowHeight: Number(e.target.value) })}
+            className="w-full accent-blue-500"
+          />
+        </div>
+        <div>
+          <label className="mb-1 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+            <span>글꼴 크기</span>
+            <span>{calFontSize}px</span>
+          </label>
+          <input
+            type="range"
+            min={10}
+            max={18}
+            value={calFontSize}
+            onChange={e => setAppearance({ fontSize: Number(e.target.value) })}
+            className="w-full accent-blue-500"
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-gray-500 dark:text-gray-400">이벤트 이름 표시</span>
+          <button
+            onClick={() => setAppearance({ showEventNames: !showEventNames })}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${showEventNames ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+          >
+            <span className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${showEventNames ? 'translate-x-6' : 'translate-x-1'}`} />
+          </button>
+        </div>
+        <button
+          className="rounded-lg border border-gray-200 dark:border-gray-600 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          onClick={resetAppearance}
+        >
+          기본값 복원
+        </button>
       </section>
 
       {/* 기본 태그 색상 */}

--- a/web/src/stores/calendarAppearanceStore.ts
+++ b/web/src/stores/calendarAppearanceStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+
+const STORAGE_KEY = 'calendar_appearance'
+
+interface CalendarAppearance {
+  rowHeight: number      // px, default 70
+  fontSize: number       // px, default 13
+  showEventNames: boolean // show event names on bars, default true
+}
+
+const DEFAULTS: CalendarAppearance = { rowHeight: 70, fontSize: 13, showEventNames: true }
+
+function load(): CalendarAppearance {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored ? { ...DEFAULTS, ...JSON.parse(stored) } : DEFAULTS
+  } catch { return DEFAULTS }
+}
+
+interface CalendarAppearanceState extends CalendarAppearance {
+  setAppearance: (updates: Partial<CalendarAppearance>) => void
+  resetToDefaults: () => void
+}
+
+export const useCalendarAppearanceStore = create<CalendarAppearanceState>((set, get) => ({
+  ...load(),
+  setAppearance: (updates) => {
+    const next = { ...get(), ...updates }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      rowHeight: next.rowHeight,
+      fontSize: next.fontSize,
+      showEventNames: next.showEventNames,
+    }))
+    set(updates)
+  },
+  resetToDefaults: () => {
+    localStorage.removeItem(STORAGE_KEY)
+    set(DEFAULTS)
+  },
+}))


### PR DESCRIPTION
## Summary\n\n- Done Todos 완료일 기준 날짜별 그룹핑 (섹션 헤더 + sticky)\n- 캘린더 셀 이벤트 바: 데스크톱 컬러바+이름 / 모바일 dot 유지\n- 캘린더 외형 설정: 행 높이, 글꼴 크기 슬라이더, 이벤트 이름 토글\n- 키보드 단축키: n(새 이벤트), Escape(모달 닫기)\n\n## Test plan\n\n- [ ] Done Todos 페이지에서 날짜별 그룹 헤더 표시 확인\n- [ ] 데스크톱에서 캘린더 셀에 컬러 바 + 이벤트 이름 표시\n- [ ] 모바일에서 기존 dot 표시 유지\n- [ ] Settings에서 행 높이/글꼴 크기 슬라이더 조절 → 캘린더 반영\n- [ ] n 키 → 새 Todo 오버레이, Escape → 모달 닫기\n- [ ] 224 tests passed, build 성공\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)