### PR TITLE
fix(web): QA 전수조사 Critical 버그 5건 수정

### DIFF
--- a/web/src/calendar/MonthCalendar.tsx
+++ b/web/src/calendar/MonthCalendar.tsx
@@ -15,8 +15,10 @@ export default function MonthCalendar({ today: todayProp }: MonthCalendarProps) 
   const todayKey = todayProp
     ? `${todayProp.getFullYear()}-${todayProp.getMonth()}-${todayProp.getDate()}`
     : ''
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const today = useMemo(() => todayProp ?? new Date(), [todayKey])
+  const today = useMemo(() => {
+    if (!todayProp) return new Date()
+    return new Date(todayProp.getFullYear(), todayProp.getMonth(), todayProp.getDate())
+  }, [todayKey]) // todayProp 레퍼런스가 아닌 날짜값만 의존
   const [currentMonth, setCurrentMonth] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1))
   const fetchEventsForRange = useCalendarEventsStore(s => s.fetchEventsForRange)
   const fetchHolidays = useHolidayStore(s => s.fetchHolidays)

--- a/web/src/calendar/MonthCalendar.tsx
+++ b/web/src/calendar/MonthCalendar.tsx
@@ -11,7 +11,12 @@ interface MonthCalendarProps {
   today?: Date
 }
 
-export default function MonthCalendar({ today = new Date() }: MonthCalendarProps) {
+export default function MonthCalendar({ today: todayProp }: MonthCalendarProps) {
+  const todayKey = todayProp
+    ? `${todayProp.getFullYear()}-${todayProp.getMonth()}-${todayProp.getDate()}`
+    : ''
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const today = useMemo(() => todayProp ?? new Date(), [todayKey])
   const [currentMonth, setCurrentMonth] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1))
   const fetchEventsForRange = useCalendarEventsStore(s => s.fetchEventsForRange)
   const fetchHolidays = useHolidayStore(s => s.fetchHolidays)

--- a/web/src/components/CurrentTodoList.tsx
+++ b/web/src/components/CurrentTodoList.tsx
@@ -4,6 +4,7 @@ import { todoApi } from '../api/todoApi'
 import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
+import { useTagFilterStore } from '../stores/tagFilterStore'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import { skipRepeatingTodo, refreshAllTodoStores } from '../utils/todoActions'
@@ -12,6 +13,7 @@ import type { Todo } from '../models'
 export function CurrentTodoList() {
   const todos = useCurrentTodosStore(s => s.todos)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const { isTagHidden } = useTagFilterStore()
   const navigate = useNavigate()
   const location = useLocation()
   const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
@@ -68,7 +70,9 @@ export function CurrentTodoList() {
     }
   }
 
-  if (todos.length === 0) return null
+  const visibleTodos = todos.filter(t => !isTagHidden(t.event_tag_id))
+
+  if (visibleTodos.length === 0) return null
 
   return (
     <section>
@@ -76,7 +80,7 @@ export function CurrentTodoList() {
         Current
       </h3>
       <ul className="divide-y divide-gray-100">
-        {todos.map(todo => {
+        {visibleTodos.map(todo => {
           const color = todo.event_tag_id
             ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
             : '#9ca3af'

--- a/web/src/components/RepeatingPicker.tsx
+++ b/web/src/components/RepeatingPicker.tsx
@@ -352,6 +352,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                           const days = yearOption.dayOfWeek.includes(i)
                             ? yearOption.dayOfWeek.filter(x => x !== i)
                             : [...yearOption.dayOfWeek, i]
+                          if (days.length === 0) return
                           const opt: RepeatingOption = { ...yearOption, dayOfWeek: days }
                           setOption(opt)
                           emit(opt)

--- a/web/src/components/RepeatingPicker.tsx
+++ b/web/src/components/RepeatingPicker.tsx
@@ -17,7 +17,7 @@ function defaultOption(type: string, startTs: number): RepeatingOption {
     case 'every_month':
       return { optionType: 'every_month', interval: 1, monthDaySelection: { days: [d.getDate()] }, timeZone: TZ }
     case 'every_year':
-      return { optionType: 'every_year', interval: 1, months: [d.getMonth() + 1], weekOrdinals: [], dayOfWeek: [d.getDay()], timeZone: TZ }
+      return { optionType: 'every_year', interval: 1, months: [d.getMonth() + 1], weekOrdinals: [{ seq: 1, isLast: false }], dayOfWeek: [d.getDay()], timeZone: TZ }
     case 'every_year_some_day':
       return { optionType: 'every_year_some_day', interval: 1, month: d.getMonth() + 1, day: d.getDate(), timeZone: TZ }
     case 'lunar_calendar_every_year':
@@ -132,7 +132,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                 className="mt-1 w-20 rounded border border-gray-300 px-2 py-1 text-sm"
                 value={interval}
                 onChange={e => {
-                  const opt = { ...option, interval: Number(e.target.value) } as RepeatingOption
+                  const opt = { ...option, interval: Math.max(1, Number(e.target.value) || 1) } as RepeatingOption
                   setOption(opt)
                   emit(opt)
                 }}
@@ -152,8 +152,9 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                       aria-label={DAY_FULL_LABELS[i]}
                       checked={weekOption.dayOfWeek.includes(i)}
                       onChange={() => {
+                        const filtered = weekOption.dayOfWeek.filter(x => x !== i)
                         const days = weekOption.dayOfWeek.includes(i)
-                          ? weekOption.dayOfWeek.filter(x => x !== i)
+                          ? (filtered.length > 0 ? filtered : weekOption.dayOfWeek)
                           : [...weekOption.dayOfWeek, i]
                         const opt: RepeatingOption = { ...weekOption, dayOfWeek: days }
                         setOption(opt)

--- a/web/src/components/UncompletedTodoList.tsx
+++ b/web/src/components/UncompletedTodoList.tsx
@@ -4,6 +4,7 @@ import { todoApi } from '../api/todoApi'
 import { useUncompletedTodosStore } from '../stores/uncompletedTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useEventTagStore } from '../stores/eventTagStore'
+import { useTagFilterStore } from '../stores/tagFilterStore'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import { skipRepeatingTodo, refreshAllTodoStores } from '../utils/todoActions'
@@ -12,6 +13,7 @@ import type { Todo } from '../models'
 export function UncompletedTodoList() {
   const todos = useUncompletedTodosStore(s => s.todos)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const { isTagHidden } = useTagFilterStore()
   const navigate = useNavigate()
   const location = useLocation()
   const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
@@ -65,7 +67,9 @@ export function UncompletedTodoList() {
     }
   }
 
-  if (todos.length === 0) return null
+  const visibleTodos = todos.filter(t => !isTagHidden(t.event_tag_id))
+
+  if (visibleTodos.length === 0) return null
 
   return (
     <section>
@@ -73,7 +77,7 @@ export function UncompletedTodoList() {
         미완료
       </h3>
       <ul className="divide-y divide-gray-100">
-        {todos.map(todo => {
+        {visibleTodos.map(todo => {
           const color = todo.event_tag_id
             ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
             : '#9ca3af'

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -65,9 +65,9 @@ export const useAuthStore = create<AuthState>((set) => {
       useUncompletedTodosStore.getState().reset()
       const { useDoneTodosStore } = await import('./doneTodosStore')
       const { useGoogleCalendarStore } = await import('./googleCalendarStore')
+      const { useNotificationStore } = await import('./notificationStore')
       useDoneTodosStore.getState().reset()
       useGoogleCalendarStore.getState().reset()
-      const { useNotificationStore } = await import('./notificationStore')
       useNotificationStore.getState().reset()
     },
   }

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -63,6 +63,10 @@ export const useAuthStore = create<AuthState>((set) => {
       useForemostEventStore.getState().reset()
       useCalendarEventsStore.getState().reset()
       useUncompletedTodosStore.getState().reset()
+      const { useDoneTodosStore } = await import('./doneTodosStore')
+      const { useGoogleCalendarStore } = await import('./googleCalendarStore')
+      useDoneTodosStore.getState().reset()
+      useGoogleCalendarStore.getState().reset()
       const { useNotificationStore } = await import('./notificationStore')
       useNotificationStore.getState().reset()
     },

--- a/web/src/stores/calendarEventsStore.ts
+++ b/web/src/stores/calendarEventsStore.ts
@@ -85,12 +85,8 @@ export const useCalendarEventsStore = create<CalendarEventsState>((set, get) => 
   },
 
   replaceEvent: (uuid: string, next: CalendarEvent) => {
-    const { eventsByDate } = get()
-    const updated = new Map<string, CalendarEvent[]>()
-    for (const [key, events] of eventsByDate) {
-      updated.set(key, events.map(e => e.event.uuid === uuid ? next : e))
-    }
-    set({ eventsByDate: updated })
+    get().removeEvent(uuid)
+    get().addEvent(next)
   },
 
   reset: () => set({ eventsByDate: new Map(), loading: false, lastRange: null }),

--- a/web/src/utils/repeatingTimeCalculator.ts
+++ b/web/src/utils/repeatingTimeCalculator.ts
@@ -67,8 +67,8 @@ export function getStartTimestamp(time: EventTime): number {
 // --- internal helpers ---
 
 function dateToDayOfWeek(date: Date): number {
-  // Sunday=1, Monday=2, ..., Saturday=7
-  return date.getDay() + 1
+  // Sunday=0, Monday=1, ..., Saturday=6 (JS getDay convention)
+  return date.getDay()
 }
 
 function daysInMonth(year: number, month: number): number {
@@ -76,19 +76,18 @@ function daysInMonth(year: number, month: number): number {
 }
 
 function nthWeekdayOfMonth(year: number, month: number, weekday: number, nth: number): Date | null {
-  // weekday: 1(Sun)~7(Sat), nth: 1-based
-  const jsWeekday = weekday - 1 // convert to JS 0-6
+  // weekday: 0(Sun)~6(Sat) (JS getDay convention), nth: 1-based
   const firstDay = new Date(year, month - 1, 1)
-  let firstOccurrence = firstDay.getDate() + ((jsWeekday - firstDay.getDay() + 7) % 7)
+  let firstOccurrence = firstDay.getDate() + ((weekday - firstDay.getDay() + 7) % 7)
   const targetDate = firstOccurrence + (nth - 1) * 7
   if (targetDate > daysInMonth(year, month)) return null
   return new Date(year, month - 1, targetDate)
 }
 
 function lastWeekdayOfMonth(year: number, month: number, weekday: number): Date {
-  const jsWeekday = weekday - 1
+  // weekday: 0(Sun)~6(Sat) (JS getDay convention)
   const lastDay = new Date(year, month, 0)
-  const diff = (lastDay.getDay() - jsWeekday + 7) % 7
+  const diff = (lastDay.getDay() - weekday + 7) % 7
   return new Date(year, month - 1, lastDay.getDate() - diff)
 }
 

--- a/web/tests/pages/TagManagementPage.test.tsx
+++ b/web/tests/pages/TagManagementPage.test.tsx
@@ -112,13 +112,11 @@ describe('TagManagementPage', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     renderPage()
 
-    // when: 목록의 삭제 버튼 클릭 → 다이얼로그의 삭제 버튼 클릭
+    // when: 목록의 삭제 버튼 클릭 → 다이얼로그에서 "태그만 삭제" 클릭
     const deleteButtons = screen.getAllByRole('button', { name: '삭제' })
     await userEvent.click(deleteButtons[0]) // 목록의 삭제 버튼
-    const confirmDeleteButtons = screen.getAllByRole('button', { name: '삭제' })
-    // 다이얼로그의 삭제 버튼은 bg-red-500 스타일을 가진 것
-    const dialogDeleteBtn = confirmDeleteButtons.find(btn => btn.className.includes('bg-red-500'))!
-    await userEvent.click(dialogDeleteBtn)
+    const tagOnlyBtn = screen.getByRole('button', { name: '태그만 삭제' })
+    await userEvent.click(tagOnlyBtn)
 
     // then
     await waitFor(() => {

--- a/web/tests/utils/repeatingTimeCalculator.test.ts
+++ b/web/tests/utils/repeatingTimeCalculator.test.ts
@@ -77,12 +77,12 @@ describe('nextRepeatingTime - every_day', () => {
 
 describe('nextRepeatingTime - every_week', () => {
   it('같은 주 다음 요일이 있으면 그 요일로 이동한다', () => {
-    // given: 2024-01-15 (월요일=2) → 다음은 수요일(4)
+    // given: 2024-01-15 (월요일=1) → 다음은 수요일(3)
     const startTs = ts(2024, 1, 15, 9, 0, 0)
     const time: EventTime = { time_type: 'at', timestamp: startTs }
     const repeating: Repeating = {
       start: startTs,
-      option: { optionType: 'every_week', interval: 1, dayOfWeek: [2, 4, 6], timeZone: 'Asia/Seoul' },
+      option: { optionType: 'every_week', interval: 1, dayOfWeek: [1, 3, 5], timeZone: 'Asia/Seoul' },
     }
     // when
     const result = nextRepeatingTime(time, 1, repeating)
@@ -93,12 +93,12 @@ describe('nextRepeatingTime - every_week', () => {
   })
 
   it('같은 주 다음 요일이 없으면 interval주 후 첫 요일로 이동한다', () => {
-    // given: 2024-01-19 (금요일=6) → 같은 주 다음 없음 → 1주 후 월요일(2)
+    // given: 2024-01-19 (금요일=5) → 같은 주 다음 없음 → 1주 후 월요일(1)
     const startTs = ts(2024, 1, 19, 9, 0, 0)
     const time: EventTime = { time_type: 'at', timestamp: startTs }
     const repeating: Repeating = {
       start: startTs,
-      option: { optionType: 'every_week', interval: 1, dayOfWeek: [2, 4, 6], timeZone: 'Asia/Seoul' },
+      option: { optionType: 'every_week', interval: 1, dayOfWeek: [1, 3, 5], timeZone: 'Asia/Seoul' },
     }
     // when
     const result = nextRepeatingTime(time, 1, repeating)
@@ -169,7 +169,7 @@ describe('nextRepeatingTime - every_month (week)', () => {
       option: {
         optionType: 'every_month',
         interval: 1,
-        monthDaySelection: { weekOrdinals: [{ isLast: false, seq: 2 }], weekDays: [2] },
+        monthDaySelection: { weekOrdinals: [{ isLast: false, seq: 2 }], weekDays: [1] },
         timeZone: 'Asia/Seoul',
       },
     }
@@ -190,7 +190,7 @@ describe('nextRepeatingTime - every_month (week)', () => {
       option: {
         optionType: 'every_month',
         interval: 1,
-        monthDaySelection: { weekOrdinals: [{ isLast: true }], weekDays: [2] },
+        monthDaySelection: { weekOrdinals: [{ isLast: true }], weekDays: [1] },
         timeZone: 'Asia/Seoul',
       },
     }


### PR DESCRIPTION
## Summary
웹 전체 기능 QA 전수조사에서 발견된 Critical 등급 버그 5건 + 기존 테스트 실패 1건 수정

### 수정 내용

**반복 이벤트 계산 오류 (Closes #122)**
- `dateToDayOfWeek`: 1-7 → 0-6 규약 통일 (JS getDay와 일치)
- `nthWeekdayOfMonth`/`lastWeekdayOfMonth`: weekday 파라미터 0-6 기준 조정
- `every_year` 기본 weekOrdinals: `[]` → `[{ seq: 1, isLast: false }]`
- interval 최소값 1 강제, 주간 반복 최소 1일 선택 보장

**캘린더 성능 + 이벤트 위치 버그 (Closes #123, Closes #124)**
- MonthCalendar: `today` prop을 날짜 키 기반 useMemo로 안정화
- `calendarEventsStore.replaceEvent`: in-place 교체 → remove+add 패턴

**로그아웃 데이터 유출 + 태그 필터 불일치 (Closes #125, Closes #126)**
- `authStore.signOut`: `doneTodosStore`, `googleCalendarStore` reset 추가
- `CurrentTodoList`, `UncompletedTodoList`: `isTagHidden` 태그 필터 적용

**테스트 수정**
- `TagManagementPage.test.tsx`: 삭제 다이얼로그 UI 변경에 맞춰 셀렉터 수정

## Test plan
- [x] Unit 테스트 243/243 통과
- [x] repeatingTimeCalculator 17개 테스트 통과 (dayOfWeek 규약 변경 반영)
- [x] MonthCalendar 테스트 통과
- [x] calendarEventsStore 테스트 통과
- [ ] E2E 수동 검증: 반복 이벤트 생성 → 다음 발생일 확인
- [ ] E2E 수동 검증: 이벤트 날짜 수정 → 캘린더 위치 이동 확인
- [ ] E2E 수동 검증: 로그아웃 → 재로그인 → 이전 사용자 데이터 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)">## Summary
웹 전체 기능 QA 전수조사에서 발견된 Critical 등급 버그 5건 + 기존 테스트 실패 1건 수정

### 수정 내용

**반복 이벤트 계산 오류 (Closes #122)**
- `dateToDayOfWeek`: 1-7 → 0-6 규약 통일 (JS getDay와 일치)
- `nthWeekdayOfMonth`/`lastWeekdayOfMonth`: weekday 파라미터 0-6 기준 조정
- `every_year` 기본 weekOrdinals: `[]` → `[{ seq: 1, isLast: false }]`
- interval 최소값 1 강제, 주간 반복 최소 1일 선택 보장

**캘린더 성능 + 이벤트 위치 버그 (Closes #123, Closes #124)**
- MonthCalendar: `today` prop을 날짜 키 기반 useMemo로 안정화
- `calendarEventsStore.replaceEvent`: in-place 교체 → remove+add 패턴

**로그아웃 데이터 유출 + 태그 필터 불일치 (Closes #125, Closes #126)**
- `authStore.signOut`: `doneTodosStore`, `googleCalendarStore` reset 추가
- `CurrentTodoList`, `UncompletedTodoList`: `isTagHidden` 태그 필터 적용

**테스트 수정**
- `TagManagementPage.test.tsx`: 삭제 다이얼로그 UI 변경에 맞춰 셀렉터 수정

## Test plan
- [x] Unit 테스트 243/243 통과
- [x] repeatingTimeCalculator 17개 테스트 통과 (dayOfWeek 규약 변경 반영)
- [x] MonthCalendar 테스트 통과
- [x] calendarEventsStore 테스트 통과
- [ ] E2E 수동 검증: 반복 이벤트 생성 → 다음 발생일 확인
- [ ] E2E 수동 검증: 이벤트 날짜 수정 → 캘린더 위치 이동 확인
- [ ] E2E 수동 검증: 로그아웃 → 재로그인 → 이전 사용자 데이터 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)