### PR TITLE
fix(web): QA Medium 등급 16건 일괄 수정

### DIFF
--- a/web/src/api/apiClient.ts
+++ b/web/src/api/apiClient.ts
@@ -2,6 +2,10 @@ import { tokenProvider } from './tokenProvider'
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 
+export class AuthExpiredError extends Error {
+  constructor() { super('Session expired') }
+}
+
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
   const token = await tokenProvider.getToken()
   const response = await fetch(`${BASE_URL}${path}`, {
@@ -17,6 +21,7 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     if (response.status === 401) {
       const { useAuthStore } = await import('../stores/authStore')
       await useAuthStore.getState().signOut()
+      throw new AuthExpiredError()
     }
     throw new Error(`API error: ${response.status}`)
   }

--- a/web/src/calendar/calendarUtils.ts
+++ b/web/src/calendar/calendarUtils.ts
@@ -38,7 +38,7 @@ export function buildCalendarGrid(year: number, month: number, today: Date): Cal
   // 그리드 종료일: 마지막 주의 토요일
   // 마지막 날이 토요일이면 다음 달 첫 주를 추가로 보여줌
   const endOffset = lastDayOfWeek === 6 ? 7 : (6 - lastDayOfWeek)
-  const gridEnd = new Date(year, month + 1, lastOfMonth.getDate() - lastOfMonth.getDate() + endOffset)
+  const gridEnd = new Date(year, month + 1, endOffset)
 
   const totalDays = Math.round((gridEnd.getTime() - gridStart.getTime()) / (1000 * 60 * 60 * 24)) + 1
   const days: CalendarDay[] = []

--- a/web/src/components/AuthGuard.tsx
+++ b/web/src/components/AuthGuard.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '../stores/authStore'
 import { useEventTagStore } from '../stores/eventTagStore'
@@ -15,6 +15,7 @@ interface AuthGuardProps {
 export function AuthGuard({ children }: AuthGuardProps) {
   const { t } = useTranslation()
   const { account, loading } = useAuthStore()
+  const location = useLocation()
 
   useEffect(() => {
     if (account) {
@@ -38,7 +39,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
   }
 
   if (!account) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/login" state={{ from: location }} replace />
   }
 
   return <>{children}</>

--- a/web/src/components/DayEventList.tsx
+++ b/web/src/components/DayEventList.tsx
@@ -78,8 +78,17 @@ export function DayEventList({ selectedDate }: DayEventListProps) {
   const dateKey = formatDateKey(selectedDate)
   const allEvents = (eventsByDate.get(dateKey) ?? []).filter(ev => !isTagHidden(ev.event.event_tag_id))
 
+  const getTimestamp = (ev: CalendarEvent): number => {
+    const et = ev.type === 'todo' ? ev.event.event_time : ev.event.event_time
+    if (!et) return Infinity
+    if (et.time_type === 'at') return et.timestamp
+    return et.period_start
+  }
+
   const todos = allEvents.filter(e => e.type === 'todo')
   const schedules = allEvents.filter(e => e.type === 'schedule')
+  todos.sort((a, b) => getTimestamp(a) - getTimestamp(b))
+  schedules.sort((a, b) => getTimestamp(a) - getTimestamp(b))
   const sorted = [...todos, ...schedules]
 
   if (sorted.length === 0) {
@@ -92,8 +101,8 @@ export function DayEventList({ selectedDate }: DayEventListProps) {
 
   return (
     <ul className="divide-y divide-gray-100">
-      {sorted.map(calEvent => (
-        <li key={calEvent.event.uuid}>
+      {sorted.map((calEvent, i) => (
+        <li key={`${calEvent.event.uuid}-${i}`}>
           <EventItem
             calEvent={calEvent}
             onNavigate={() => navigate(`/events/${calEvent.event.uuid}?type=${calEvent.type}`, {

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -18,10 +18,10 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50">
-          <p className="text-lg font-semibold text-gray-800">{i18n.t('error.something_wrong')}</p>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 dark:bg-gray-900">
+          <p className="text-lg font-semibold text-gray-800 dark:text-gray-200">{i18n.t('error.something_wrong')}</p>
           <button
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
             onClick={() => window.location.reload()}
           >
             {i18n.t('error.refresh')}

--- a/web/src/components/EventTimePicker.tsx
+++ b/web/src/components/EventTimePicker.tsx
@@ -9,8 +9,10 @@ function tsToDatetimeLocal(ts: number): string {
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`
 }
 
-function datetimeLocalToTs(v: string): number {
-  return Math.floor(new Date(v).getTime() / 1000)
+function datetimeLocalToTs(v: string): number | null {
+  const ts = new Date(v).getTime()
+  if (isNaN(ts)) return null
+  return Math.floor(ts / 1000)
 }
 
 function tsToDateInput(ts: number): string {
@@ -19,8 +21,11 @@ function tsToDateInput(ts: number): string {
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`
 }
 
-function dateInputToTs(v: string): number {
-  return Math.floor(new Date(v + 'T00:00:00').getTime() / 1000)
+function dateInputToTs(v: string): number | null {
+  if (!v) return null
+  const ts = new Date(v + 'T00:00:00').getTime()
+  if (isNaN(ts)) return null
+  return Math.floor(ts / 1000)
 }
 
 function localSecondsFromGmt(): number {
@@ -102,7 +107,11 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
             type="datetime-local"
             className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
             value={tsToDatetimeLocal(internal.timestamp)}
-            onChange={e => handleValueChange({ time_type: 'at', timestamp: datetimeLocalToTs(e.target.value) })}
+            onChange={e => {
+              const ts = datetimeLocalToTs(e.target.value)
+              if (ts === null) return
+              handleValueChange({ time_type: 'at', timestamp: ts })
+            }}
           />
         </div>
       )}
@@ -118,7 +127,12 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
                 type="datetime-local"
                 className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
                 value={tsToDatetimeLocal(internal.period_start)}
-                onChange={e => handleValueChange({ ...internal, period_start: datetimeLocalToTs(e.target.value) })}
+                onChange={e => {
+                  const newStart = datetimeLocalToTs(e.target.value)
+                  if (newStart === null) return
+                  const newEnd = newStart > internal.period_end ? newStart : internal.period_end
+                  handleValueChange({ ...internal, period_start: newStart, period_end: newEnd })
+                }}
               />
             </div>
             <div>
@@ -129,13 +143,15 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
                 type="datetime-local"
                 className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
                 value={tsToDatetimeLocal(internal.period_end)}
-                onChange={e => handleValueChange({ ...internal, period_end: datetimeLocalToTs(e.target.value) })}
+                onChange={e => {
+                  const newEnd = datetimeLocalToTs(e.target.value)
+                  if (newEnd === null) return
+                  if (newEnd < internal.period_start) return
+                  handleValueChange({ ...internal, period_end: newEnd })
+                }}
               />
             </div>
           </div>
-          {internal.period_end < internal.period_start && (
-            <p className="text-xs text-red-500">종료 시각이 시작 시각보다 앞에 있습니다.</p>
-          )}
         </div>
       )}
 
@@ -149,7 +165,11 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
               type="date"
               className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
               value={tsToDateInput(internal.period_start + internal.seconds_from_gmt)}
-              onChange={e => handleValueChange({ ...internal, period_start: dateInputToTs(e.target.value) - internal.seconds_from_gmt })}
+              onChange={e => {
+                const ts = dateInputToTs(e.target.value)
+                if (ts === null) return
+                handleValueChange({ ...internal, period_start: ts - internal.seconds_from_gmt })
+              }}
             />
           </div>
           <div>
@@ -160,7 +180,11 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
               type="date"
               className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
               value={tsToDateInput(internal.period_end + internal.seconds_from_gmt)}
-              onChange={e => handleValueChange({ ...internal, period_end: dateInputToTs(e.target.value) - internal.seconds_from_gmt })}
+              onChange={e => {
+                const ts = dateInputToTs(e.target.value)
+                if (ts === null) return
+                handleValueChange({ ...internal, period_end: ts - internal.seconds_from_gmt })
+              }}
             />
           </div>
         </div>

--- a/web/src/components/EventTimePicker.tsx
+++ b/web/src/components/EventTimePicker.tsx
@@ -183,7 +183,9 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
               onChange={e => {
                 const ts = dateInputToTs(e.target.value)
                 if (ts === null) return
-                handleValueChange({ ...internal, period_end: ts - internal.seconds_from_gmt })
+                const newEnd = ts - internal.seconds_from_gmt
+                if (newEnd < internal.period_start) return
+                handleValueChange({ ...internal, period_end: newEnd })
               }}
             />
           </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -105,6 +105,7 @@
   "event.go_back": "Go Back",
   "event.detail_placeholder": "Add place, URL, or memo",
   "event.save_failed": "Failed to save event details",
+  "event.pin_failed": "Failed to pin event",
   "repeat.every_day": "Every {{n}} day(s)",
   "repeat.every_week": "Every {{n}} week(s)",
   "repeat.every_month": "Every {{n}} month(s)",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -105,6 +105,7 @@
   "event.go_back": "돌아가기",
   "event.detail_placeholder": "장소, URL, 메모를 추가하세요",
   "event.save_failed": "이벤트 상세 저장에 실패했습니다",
+  "event.pin_failed": "고정 설정에 실패했습니다",
   "repeat.every_day": "매 {{n}}일",
   "repeat.every_week": "매 {{n}}주",
   "repeat.every_month": "매 {{n}}개월",

--- a/web/src/pages/EventDetailPage.tsx
+++ b/web/src/pages/EventDetailPage.tsx
@@ -134,10 +134,14 @@ export function EventDetailPage() {
   }
 
   async function handleForemostToggle() {
-    if (isForemost) {
-      await removeForemost()
-    } else if (id) {
-      await setForemost(id, isTodo)
+    try {
+      if (isForemost) {
+        await removeForemost()
+      } else if (id) {
+        await setForemost(id, isTodo)
+      }
+    } catch {
+      useToastStore.getState().show(t('event.pin_failed'), 'error')
     }
   }
 

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,16 +1,18 @@
 import { useState } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation, Location } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '../stores/authStore'
 
 export function LoginPage() {
   const { t } = useTranslation()
   const { account, signInWithGoogle, signInWithApple } = useAuthStore()
+  const location = useLocation()
+  const from = (location.state as { from?: Location })?.from?.pathname || '/'
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   if (account) {
-    return <Navigate to="/" replace />
+    return <Navigate to={from} replace />
   }
 
   async function handleSignIn(action: () => Promise<void>) {
@@ -18,7 +20,11 @@ export function LoginPage() {
     setError(null)
     try {
       await action()
-    } catch {
+    } catch (e: unknown) {
+      if (e instanceof Error && 'code' in e && (e as { code: string }).code === 'auth/popup-closed-by-user') {
+        setLoading(false)
+        return
+      }
       setError(t('login.error'))
     } finally {
       setLoading(false)

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -62,6 +62,7 @@ export function SettingsPage() {
   const [_colors, setColors] = useState<DefaultTagColors | null>(null)
   const [editColors, setEditColors] = useState<DefaultTagColors | null>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   useEffect(() => {
     settingApi.getDefaultTagColors()
@@ -83,6 +84,7 @@ export function SettingsPage() {
   }
 
   const handleDeleteAccount = async () => {
+    setDeleting(true)
     try {
       await accountApi.deleteAccount()
       useToastStore.getState().show(t('settings.account_deleted'), 'success')
@@ -90,6 +92,8 @@ export function SettingsPage() {
     } catch (e) {
       console.warn('계정 삭제 실패:', e)
       useToastStore.getState().show(t('settings.account_delete_failed'), 'error')
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -314,8 +318,9 @@ export function SettingsPage() {
       <section className="rounded-xl border border-red-100 dark:border-red-900 bg-white dark:bg-gray-800 p-5 shadow-sm">
         <h2 className="mb-3 text-sm font-semibold text-red-500">{t('settings.danger')}</h2>
         <button
-          className="rounded-lg border border-red-200 dark:border-red-800 px-4 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30"
+          className="rounded-lg border border-red-200 dark:border-red-800 px-4 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={() => setShowDeleteConfirm(true)}
+          disabled={deleting}
         >
           {t('settings.delete_account')}
         </button>

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -26,16 +26,18 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>((set, get) => {
+  let initialAuthDone = false
   onAuthStateChanged(auth, async (firebaseUser) => {
     if (firebaseUser) {
-      const current = get().account
-      if (current && current.uid === firebaseUser.uid) {
-        set({ account: current, loading: false })
+      // 초기 인증 이후 동일 uid의 token refresh는 skip
+      if (initialAuthDone && get().account?.uid === firebaseUser.uid) {
+        set({ loading: false })
         return
       }
       try {
         const account = await apiClient.put<Account>('/v1/accounts/info', {})
         set({ account, loading: false })
+        initialAuthDone = true
       } catch (e) {
         console.warn('계정 등록 실패:', e)
         set({ account: null, loading: false })

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -25,9 +25,14 @@ interface AuthState {
   signOut: () => Promise<void>
 }
 
-export const useAuthStore = create<AuthState>((set) => {
+export const useAuthStore = create<AuthState>((set, get) => {
   onAuthStateChanged(auth, async (firebaseUser) => {
     if (firebaseUser) {
+      const current = get().account
+      if (current && current.uid === firebaseUser.uid) {
+        set({ account: current, loading: false })
+        return
+      }
       try {
         const account = await apiClient.put<Account>('/v1/accounts/info', {})
         set({ account, loading: false })

--- a/web/src/stores/calendarEventsStore.ts
+++ b/web/src/stores/calendarEventsStore.ts
@@ -22,9 +22,9 @@ export const useCalendarEventsStore = create<CalendarEventsState>((set, get) => 
   lastRange: null,
 
   fetchEventsForRange: async (lower: number, upper: number) => {
-    const { lastRange, eventsByDate } = get()
-    // 같은 범위 재요청 + 캐시 있음 → 스킵
-    if (lastRange && lastRange.lower === lower && lastRange.upper === upper && eventsByDate.size > 0) {
+    const { lastRange } = get()
+    // 같은 범위 재요청 → 스킵 (빈 달도 fetch 완료로 간주)
+    if (lastRange && lastRange.lower === lower && lastRange.upper === upper) {
       return
     }
     set({ loading: true, lastRange: { lower, upper } })

--- a/web/src/stores/calendarEventsStore.ts
+++ b/web/src/stores/calendarEventsStore.ts
@@ -27,17 +27,17 @@ export const useCalendarEventsStore = create<CalendarEventsState>((set, get) => 
     if (lastRange && lastRange.lower === lower && lastRange.upper === upper) {
       return
     }
-    set({ loading: true, lastRange: { lower, upper } })
+    set({ loading: true })
     try {
       const [todos, schedules] = await Promise.all([
         todoApi.getTodos(lower, upper),
         scheduleApi.getSchedules(lower, upper),
       ])
       const eventsByDate = groupEventsByDate(todos, schedules, lower, upper)
-      set({ eventsByDate, loading: false })
+      set({ eventsByDate, loading: false, lastRange: { lower, upper } })
     } catch (e) {
       console.warn('이벤트 로드 실패:', e)
-      set({ loading: false })
+      set({ loading: false, lastRange: null })
     }
   },
 

--- a/web/src/stores/eventTagStore.ts
+++ b/web/src/stores/eventTagStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand'
 import { eventTagApi } from '../api/eventTagApi'
 import { useCalendarEventsStore } from './calendarEventsStore'
+import { useCurrentTodosStore } from './currentTodosStore'
+import { useUncompletedTodosStore } from './uncompletedTodosStore'
 import type { EventTag } from '../models'
 
 interface EventTagState {
@@ -38,7 +40,12 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
   },
 
   updateTag: async (id: string, updates: { name?: string; color_hex?: string }) => {
-    const tag = await eventTagApi.updateTag(id, { name: updates.name ?? get().tags.get(id)?.name ?? '', color_hex: updates.color_hex })
+    const existing = get().tags.get(id)
+    if (!existing) throw new Error('Tag not found')
+    const tag = await eventTagApi.updateTag(id, {
+      name: updates.name ?? existing.name,
+      color_hex: updates.color_hex ?? existing.color_hex,
+    })
     set(s => { const tags = new Map(s.tags); tags.set(tag.uuid, tag); return { tags } })
     return tag
   },
@@ -52,6 +59,8 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
     await eventTagApi.deleteTagAndEvents(id)
     set(s => { const tags = new Map(s.tags); tags.delete(id); return { tags } })
     await useCalendarEventsStore.getState().refreshCurrentRange().catch(() => {})
+    useCurrentTodosStore.getState().fetch().catch(() => {})
+    useUncompletedTodosStore.getState().fetch().catch(() => {})
   },
 
   reset: () => set({ tags: new Map() }),

--- a/web/src/stores/holidayStore.ts
+++ b/web/src/stores/holidayStore.ts
@@ -31,9 +31,7 @@ export const useHolidayStore = create<HolidayState>((set, get) => ({
   setCountry: (country: HolidayCountry) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(country))
     set({ country, holidays: new Map(), loadedYears: new Set() })
-    // 현재 연도 공휴일 자동 fetch
-    const currentYear = new Date().getFullYear()
-    get().fetchHolidays(currentYear)
+    // 즉시 fetch하지 않음 — MonthCalendar의 useEffect가 현재 보고 있는 연도로 fetch 위임
   },
 
   fetchHolidays: async (year: number) => {

--- a/web/tests/api/apiClient.test.ts
+++ b/web/tests/api/apiClient.test.ts
@@ -54,15 +54,15 @@ describe('apiClient', () => {
     expect(result).toBeUndefined()
   })
 
-  it('401 응답 시 에러가 throw된다', async () => {
+  it('401 응답 시 AuthExpiredError가 throw된다', async () => {
     // given: fetch가 401 반환
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(null, { status: 401 })
     )
 
-    // when / then: 에러가 throw됨
-    const { apiClient } = await import('../../src/api/apiClient')
-    await expect(apiClient.get('/v1/test')).rejects.toThrow('API error: 401')
+    // when / then: AuthExpiredError가 throw됨
+    const { apiClient, AuthExpiredError } = await import('../../src/api/apiClient')
+    await expect(apiClient.get('/v1/test')).rejects.toThrow(AuthExpiredError)
   })
 
   it('서버가 4xx/5xx를 반환하면 에러를 던진다', async () => {

--- a/web/tests/pages/LoginPage.test.tsx
+++ b/web/tests/pages/LoginPage.test.tsx
@@ -1,11 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { LoginPage } from '../../src/pages/LoginPage'
 import { useAuthStore } from '../../src/stores/authStore'
 
 vi.mock('../../src/stores/authStore', () => ({
   useAuthStore: vi.fn(),
 }))
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <LoginPage />
+    </MemoryRouter>
+  )
+}
 
 describe('LoginPage', () => {
   const mockSignInWithGoogle = vi.fn()
@@ -16,24 +25,24 @@ describe('LoginPage', () => {
     vi.mocked(useAuthStore).mockReturnValue({
       signInWithGoogle: mockSignInWithGoogle,
       signInWithApple: mockSignInWithApple,
-      user: null,
+      account: null,
       loading: false,
     } as any)
   })
 
   it('Google 로그인 버튼이 표시된다', () => {
-    render(<LoginPage />)
+    renderLoginPage()
     expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
   })
 
   it('Apple 로그인 버튼이 표시된다', () => {
-    render(<LoginPage />)
+    renderLoginPage()
     expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
   })
 
   it('Google 버튼 클릭 시 Google 로그인을 시도한다', async () => {
     mockSignInWithGoogle.mockResolvedValue(undefined)
-    render(<LoginPage />)
+    renderLoginPage()
 
     fireEvent.click(screen.getByRole('button', { name: /google/i }))
 
@@ -42,7 +51,7 @@ describe('LoginPage', () => {
 
   it('Apple 버튼 클릭 시 Apple 로그인을 시도한다', async () => {
     mockSignInWithApple.mockResolvedValue(undefined)
-    render(<LoginPage />)
+    renderLoginPage()
 
     fireEvent.click(screen.getByRole('button', { name: /apple/i }))
 
@@ -51,7 +60,7 @@ describe('LoginPage', () => {
 
   it('로그인 시도 중에는 버튼이 비활성화된다', async () => {
     mockSignInWithGoogle.mockReturnValue(new Promise(() => {})) // never resolves
-    render(<LoginPage />)
+    renderLoginPage()
 
     fireEvent.click(screen.getByRole('button', { name: /google/i }))
 
@@ -62,12 +71,26 @@ describe('LoginPage', () => {
 
   it('로그인 실패 시 에러 메시지가 표시된다', async () => {
     mockSignInWithGoogle.mockRejectedValue(new Error('로그인 실패'))
-    render(<LoginPage />)
+    renderLoginPage()
 
     fireEvent.click(screen.getByRole('button', { name: /google/i }))
 
     await waitFor(() => {
       expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('팝업을 닫으면 에러 메시지가 표시되지 않는다', async () => {
+    const popupClosedError = Object.assign(new Error('auth/popup-closed-by-user'), {
+      code: 'auth/popup-closed-by-user',
+    })
+    mockSignInWithGoogle.mockRejectedValue(popupClosedError)
+    renderLoginPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /google/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).toBeNull()
     })
   })
 })

--- a/web/tests/stores/calendarEventsStore.test.ts
+++ b/web/tests/stores/calendarEventsStore.test.ts
@@ -15,7 +15,7 @@ const MARCH31_KEY = '2025-03-31'
 
 describe('calendarEventsStore', () => {
   beforeEach(() => {
-    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false })
+    useCalendarEventsStore.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
     vi.clearAllMocks()
   })
 


### PR DESCRIPTION
## Summary
QA 전수조사 Medium 등급 잔여 이슈 16건 일괄 수정 (Closes #131)

### Auth/API (M1-M4)
- authStore: onAuthStateChanged 중복 PUT 방지 (uid 비교)
- AuthGuard/LoginPage: 로그인 후 원래 경로 복원 (deep link 보존)
- LoginPage: popup-closed-by-user 에러 무시
- apiClient: 401 시 AuthExpiredError 구분

### 캘린더/이벤트 (M6, M7, M9-M11)
- calendarUtils: gridEnd dead code 정리
- calendarEventsStore: 빈 월 캐시 가드 수정 (반복 fetch 방지)
- holidayStore: setCountry 즉시 fetch 제거 (useEffect 위임)
- DayEventList: 그룹 내 시간순 정렬 + 반복 이벤트 key 충돌 해결

### 폼/입력 검증 (M14-M16)
- EventTimePicker: NaN timestamp 방지 + 종료<시작 자동 보정
- eventTagStore: updateTag null safety 강화

### 상태/UX (M17-M19, M22)
- eventTagStore: deleteTagAndEvents 후 currentTodos/uncompletedTodos 갱신
- SettingsPage: 계정 삭제 로딩 상태 (더블클릭 방지)
- EventDetailPage: foremost toggle 실패 토스트 추가
- ErrorBoundary: 다크모드 클래스 추가

## Test plan
- [x] Unit 테스트 244/244 통과
- [ ] 로그인 후 deep link 복원 확인
- [ ] 빈 월 네비게이션 시 반복 API 호출 없음 확인
- [ ] EventTimePicker 빈 입력 / 역순 시간 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)