### PR TITLE
[#51] Cloud Functions 2nd Gen 병렬 배포 + 요청 로거

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,6 @@
-// The cloud functions fore Firebase SDK to create Cloud functions and trigger
+// The cloud functions for Firebase SDK to create Cloud functions and trigger
 const functions = require("firebase-functions/v1");
+const { onRequest } = require("firebase-functions/v2/https");
 const express = require("express");
 require('express-async-errors');
 
@@ -75,13 +76,8 @@ app.use((err, req, res, next) => {
         .send(err)
 });
 
+// 1st Gen (기존 클라이언트 유지)
 exports.api = functions.https.onRequest(app);
 
-
-// // Create and Deploy Your First Cloud Functions
-// // https://firebase.google.com/docs/functions/write-firebase-functions
-//
-// exports.helloWorld = functions.https.onRequest((request, response) => {
-//   functions.logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+// 2nd Gen (신규 클라이언트용)
+exports.apiV2 = onRequest(app);

--- a/functions/index.js
+++ b/functions/index.js
@@ -80,7 +80,7 @@ const requestLogger = (gen) => (req, res, next) => {
     const start = Date.now();
     res.on('finish', () => {
         const duration = Date.now() - start;
-        const log = `[${gen}] ${req.method} ${req.path} ${res.statusCode} ${duration}ms`;
+        const log = `[${gen}] ${req.method} ${req.originalUrl} ${res.statusCode} ${duration}ms`;
         if (res.statusCode >= 500) {
             logger.error(log);
         } else if (res.statusCode >= 400) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -37,6 +37,8 @@ const holidayRouter = require('./routes/holidayRoutes');
 const syncRouter = require('./routes/dataSyncRoutes.js');
 const testRouter = require('./routes/testRoutes');
 
+const logger = require("firebase-functions/logger");
+
 const app = express();
 // app use middleware
 app.use(bodyParser.json());
@@ -71,13 +73,38 @@ app.use('/v1/setting', authValidator, setVersion('v1'), settingRouter);
 app.use('/v1/holiday', setVersion('v1'), holidayRouter);
 app.use('/v1/sync', authValidator, setVersion('v1'), syncRouter);
 // app.use('/v1/tests', v1TestRouter);
+
+// request logging
+const requestLogger = (gen) => (req, res, next) => {
+    req.functionsGen = gen;
+    const start = Date.now();
+    res.on('finish', () => {
+        const duration = Date.now() - start;
+        const log = `[${gen}] ${req.method} ${req.path} ${res.statusCode} ${duration}ms`;
+        if (res.statusCode >= 500) {
+            logger.error(log);
+        } else if (res.statusCode >= 400) {
+            logger.warn(log);
+        } else {
+            logger.info(log);
+        }
+    });
+    next();
+};
+
 app.use((err, req, res, next) => {
     res.status(err?.status ?? 500)
         .send(err)
 });
 
 // 1st Gen (기존 클라이언트 유지)
-exports.api = functions.https.onRequest(app);
+const appV1 = express();
+appV1.use(requestLogger('v1-gen'));
+appV1.use(app);
+exports.api = functions.https.onRequest(appV1);
 
 // 2nd Gen (신규 클라이언트용)
-exports.apiV2 = onRequest(app);
+const appV2 = express();
+appV2.use(requestLogger('v2-gen'));
+appV2.use(app);
+exports.apiV2 = onRequest(appV2);


### PR DESCRIPTION
## Summary
- 기존 1st Gen `api` 함수를 유지하면서 2nd Gen `apiV2` 함수를 병렬 추가
- 동일한 Express 앱을 공유하므로 코드 중복 없음
- Functions 세대 구분 요청 로거 추가 (`[v1-gen]` / `[v2-gen]` 태그)
  - 200-399: info, 400-499: warn, 500+: error
  - 민감정보(userId 등) 미기록

## 다음 단계
- [ ] 프로덕션 배포 후 apiV2 URL 확보
- [ ] Compute Engine 서비스 계정 Firestore 권한 확인
- [ ] 클라이언트(iOS/Web)에서 apiV2 URL로 전환
- [ ] v1-gen 사용 클라이언트 점유율 확인 후 1st Gen 제거

## Test plan
- [x] 단위 테스트 511개 통과
- [x] 에뮬레이터 E2E 테스트 60개 통과
- [x] 에뮬레이터에서 api, apiV2 둘 다 정상 로드 확인

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)