### PR TITLE
[#142] fix: 단건 done todo 삭제 시 연관 done detail 정리 누락

### DIFF
--- a/functions/services/doneTodoService.js
+++ b/functions/services/doneTodoService.js
@@ -28,7 +28,8 @@ class DoneTodoService {
     }
 
     async removeDoneTodo(doneEventId) {
-        return this.doneTodoRepository.removeDoneTodo(doneEventId)
+        await this.doneTodoRepository.removeDoneTodo(doneEventId)
+        await this.eventDetailService.removeDoneTodoDetails([doneEventId])
     }
 
     async revertDoneTodo(userId, doneEventId) {

--- a/functions/test/e2e/doneTodo.e2e.js
+++ b/functions/test/e2e/doneTodo.e2e.js
@@ -87,5 +87,35 @@ describe('DoneTodo API', function () {
                 assert.strictEqual(res.status, 201);
             });
         });
+
+        describe('DELETE /v2/todos/dones/:id', function () {
+            it('should delete done todo and its associated detail', async function () {
+                const todoRes = await authedClient().post('/v2/todos/todo', {
+                    name: 'V2 Delete Done Todo with Detail'
+                });
+                const todoId = todoRes.data.uuid;
+
+                await authedClient().put(`/v1/event_details/${todoId}`, {
+                    memo: 'detail memo',
+                    place: { place_name: 'home' }
+                });
+
+                const doneRes = await authedClient().post(`/v2/todos/todo/${todoId}/complete`, {
+                    origin: todoRes.data
+                });
+                const doneId = doneRes.data.done.uuid;
+
+                const beforeDelete = await authedClient().get(`/v1/event_details/done/${doneId}`);
+                assert.strictEqual(beforeDelete.data.memo, 'detail memo', 'precondition: done detail should exist');
+
+                const deleteRes = await authedClient().delete(`/v2/todos/dones/${doneId}`);
+                assert.strictEqual(deleteRes.status, 200);
+                assert.strictEqual(deleteRes.data.status, 'ok');
+
+                const afterDelete = await authedClient().get(`/v1/event_details/done/${doneId}`);
+                assert.strictEqual(afterDelete.data.memo, undefined, 'done detail should be removed');
+                assert.strictEqual(afterDelete.data.place, undefined, 'done detail should be removed');
+            });
+        });
     });
 });

--- a/functions/test/services/doneTodoService.test.js
+++ b/functions/test/services/doneTodoService.test.js
@@ -170,8 +170,16 @@ describe("DoneTodoService", () => {
             await service.removeDoneTodo('id:3')
             const all = await service.loadDoneTodos('owner', 10)
             assert.deepEqual(
-                all.map(d => d.uuid), 
+                all.map(d => d.uuid),
                 ['id:9', 'id:8', 'id:7', 'id:6', 'id:5', 'id:4', 'id:2', 'id:1', 'id:0']
+            )
+        })
+
+        it('removes associated done detail too', async () => {
+            await service.removeDoneTodo('id:3')
+            assert.deepEqual(
+                stubDoneTodoDetailRepository.didRemoveDoneTodoDetailIds,
+                ['id:3']
             )
         })
 


### PR DESCRIPTION
closes #142

## 문제

`DELETE /todos/dones/{id}` 단건 삭제 경로가 done todo 문서만 지우고 `event_detail_done` 컬렉션의 연관 detail 문서를 그대로 두어 orphan으로 누적되던 문제.

## 비대칭이었던 부분

| 경로 | done todo 삭제 | 연관 detail 정리 |
| --- | --- | --- |
| `DELETE /todos/dones?past_than=...` (plural) | O | O — `removeDoneTodoDetails` |
| `POST /v2/todos/dones/{id}/revert` | O | O — `revertDoneTodoDetail` |
| **`DELETE /todos/dones/{id}` (단건)** | O | **X — 누락** |

plural delete와 v2 revert는 detail까지 일관되게 처리하는데 단건 DELETE만 detail을 남겨두고 있어 운영 비용 누적과 향후 detail 재사용 로직의 잠재적 부작용 우려.

## 변경

- `services/doneTodoService.js` `DoneTodoService.removeDoneTodo` — done todo 삭제 후 `eventDetailService.removeDoneTodoDetails([id])` 호출 추가. v1/v2 분기 없이 양 경로 모두 동일하게 적용
- `test/services/doneTodoService.test.js` — `removeDoneTodo`가 done detail 삭제도 함께 호출하는지 단위 테스트 추가
- `test/e2e/doneTodo.e2e.js` — v2 단건 DELETE E2E: detail이 있는 done todo를 삭제 후 done detail이 사라졌는지 검증

## 테스트

- [x] 단위 테스트 512개 통과
- [x] E2E 테스트 61개 통과 (신규 추가 케이스 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)