### PR TITLE
[#143] fix: revertDoneTodo가 event_time 있는 done todo를 처리하지 못하던 문제

### DIFF
--- a/functions/services/doneTodoService.js
+++ b/functions/services/doneTodoService.js
@@ -49,7 +49,7 @@ class DoneTodoService {
     async #runRevertDoneTodo(userId, doneEventId) {
         const doneTodo = await this.doneTodoRepository.loadDoneTodo(doneEventId)
         const payload = this.#revertTodoPayload(doneTodo, userId)
-        const revertTodo = this.todoService.makeTodo(userId, payload)
+        const revertTodo = await this.todoService.makeTodo(userId, payload)
         await this.doneTodoRepository.removeDoneTodo(doneEventId)
         return revertTodo
     }
@@ -72,10 +72,10 @@ class DoneTodoService {
 
     #revertTodoPayload(done, userId) {
         return {
-            userId: userId, 
-            name: done.name, 
-            event_tag_id: done.event_tag_id, 
-            event_time: done.event_time, 
+            userId: userId,
+            name: done.name,
+            event_tag_id: done.event_tag_id,
+            event_time: done.event_time ? done.event_time.toJSON() : null,
             notification_options: done.notification_options
         }
     }

--- a/functions/test/doubles/stubRepositories.js
+++ b/functions/test/doubles/stubRepositories.js
@@ -61,6 +61,7 @@ class StubTodoRepository {
     }
 
     async makeNewTodo(payload) {
+        this.lastMakeTodoPayload = payload
         let params = JSON.parse(JSON.stringify(payload))
         if (this.shouldFailMakeTodo) {
             throw { message: 'failed' }

--- a/functions/test/e2e/doneTodo.e2e.js
+++ b/functions/test/e2e/doneTodo.e2e.js
@@ -83,8 +83,40 @@ describe('DoneTodo API', function () {
                 const doneRes = await authedClient().post(`/v2/todos/todo/${todoRes.data.uuid}/complete`, {
                     origin: todoRes.data
                 });
-                const res = await authedClient().post(`/v2/todos/dones/${doneRes.data.uuid}/revert`);
+                const res = await authedClient().post(`/v2/todos/dones/${doneRes.data.done.uuid}/revert`);
                 assert.strictEqual(res.status, 201);
+            });
+
+            it('preserves name and event_time when reverting a done todo with time info', async function () {
+                const todoRes = await authedClient().post('/v2/todos/todo', {
+                    name: 'V2 Revert with time',
+                    event_time: { time_type: 'at', timestamp: 1776351600 }
+                });
+                const todoId = todoRes.data.uuid;
+
+                const { uuid, ...originWithoutUuid } = todoRes.data;
+                const doneRes = await authedClient().post(`/v2/todos/todo/${todoId}/complete`, {
+                    origin: originWithoutUuid
+                });
+                const doneId = doneRes.data.done.uuid;
+
+                const revertRes = await authedClient().post(`/v2/todos/dones/${doneId}/revert`);
+
+                assert.strictEqual(
+                    revertRes.status,
+                    201,
+                    `revert should succeed, got status=${revertRes.status} data=${JSON.stringify(revertRes.data)}`
+                );
+                assert.strictEqual(revertRes.data.todo?.name, 'V2 Revert with time');
+                assert.deepStrictEqual(revertRes.data.todo?.event_time, {
+                    time_type: 'at',
+                    timestamp: 1776351600
+                });
+                assert.notStrictEqual(
+                    revertRes.data.todo?.is_current,
+                    true,
+                    'is_current should not be true when event_time is present'
+                );
             });
         });
 

--- a/functions/test/services/doneTodoService.test.js
+++ b/functions/test/services/doneTodoService.test.js
@@ -230,6 +230,29 @@ describe("DoneTodoService", () => {
             assert.deepEqual(spyDoneRepository.didRemovedDoneEventId, 'some')
         })
 
+        it('makeTodo payload event_time is plain object, not EventTime instance', async () => {
+            await service.revertDoneTodoV2('owner', 'some')
+            const eventTime = spyTodoRepository.lastMakeTodoPayload?.event_time
+            assert.notStrictEqual(eventTime, undefined, 'event_time should be present')
+            assert.notStrictEqual(eventTime, null, 'event_time should be non-null')
+            assert.strictEqual(
+                eventTime.constructor?.name,
+                'Object',
+                'event_time must be plain object so firestore can serialize it'
+            )
+        })
+
+        it('makeTodo rejection propagates without unhandled rejection', async () => {
+            spyTodoRepository.shouldFailMakeTodo = true
+
+            const caught = await service.revertDoneTodoV2('owner', 'some').then(
+                () => ({ ok: true }),
+                err => ({ ok: false, err })
+            )
+            assert.strictEqual(caught.ok, false, 'rejection should reach the caller')
+            assert.strictEqual(caught.err?.message, 'failed')
+        })
+
         // revert done todo fail
         it('failed', async () => {
             spyTodoRepository.shouldFailMakeTodo = true


### PR DESCRIPTION
closes #143

## 증상

웹 client에서 `POST /v2/todos/dones/{id}/revert` 호출 시:
- done todo에 **event_time이 있으면** → 함수 프로세스가 socket hang up으로 끊어짐 (`Request to function failed: Error: socket hang up`)
- event_time이 없는 todo의 revert는 정상 동작

## 원인 (firebase emulator 로그로 검증)

서버 측 두 지점이 합쳐서 발생.

### 1. firestore가 EventTime 클래스 인스턴스를 직렬화 못함

```
Couldn't serialize object of type "EventTime" (found in field "event_time").
Firestore doesn't support JavaScript objects with custom prototypes.
```

- `repositories/doneTodoEventRepository.js`의 `loadDoneTodo`가 done 문서를 `DoneTodo.fromData`로 wrap
- `models/DoneTodo.js:13` constructor가 `event_time`을 `EventTime` 클래스 인스턴스로 wrap
- `services/doneTodoService.js` `#revertTodoPayload`가 그 인스턴스를 그대로 makeTodo payload에 실어 넘김
- `repositories/todoRepository.js`의 `makeNewTodo`가 `collectionRef.add(payload)` 호출 → firestore admin SDK가 `isPlainObject` 체크 통과 못해 throw

event_time이 없는 케이스는 `EventTime.fromData(undefined) → null`로 흘러서 firestore가 null 정상 처리 → 통과.

### 2. makeTodo가 await 없이 호출되어 reject가 unhandled로 노출

```js
const revertTodo = this.todoService.makeTodo(userId, payload)  // ← await 없음
await this.doneTodoRepository.removeDoneTodo(doneEventId)
return revertTodo
```

위 1번 throw로 makeTodo Promise가 reject되는 시점에 `.catch`/`await` 핸들러가 붙어있지 않은 micro-task 윈도우가 존재. Node 15+ 기본 정책 `--unhandled-rejections=throw`로 함수 인스턴스가 죽음 → HTTP 응답을 보내기 전에 프로세스 종료 → 클라가 connection reset(socket hang up).

await만 붙여도 정상 500 응답은 떨어지지만 revert 자체는 여전히 firestore throw로 실패. 두 지점 모두 수정 필요.

## iOS는 왜 영향 없나

iOS는 done todo를 active로 되돌릴 때 cancel 경로를 사용 추정 (`/v1/todos/dones/cancel` → `restoreTodo`로 client origin을 plain object 그대로 set, EventTime 인스턴스 구간 거치지 않음). 웹이 revert v2를 처음 사용하면서 잠재되어 있던 서버 bug가 드러남.

웹 client는 별개로 origin payload에서 `uuid` 필드를 빼는 방향으로 이미 수정 완료 — 본 PR은 서버 측 수정.

## 변경

- `services/doneTodoService.js` `#revertTodoPayload` — `event_time`을 `done.event_time?.toJSON() ?? null`로 plain object 변환
- `services/doneTodoService.js` `#runRevertDoneTodo` — `makeTodo` 호출에 `await` 추가
- `test/services/doneTodoService.test.js` — `revertDoneTodoV2`가 makeTodo로 넘기는 payload의 `event_time`이 plain object인지 boundary 검증
- `test/doubles/stubRepositories.js` `StubTodoRepository` — `lastMakeTodoPayload` spy 추가
- `test/e2e/doneTodo.e2e.js` — v2 revert E2E: event_time 있는 done todo revert 시 응답 todo의 `name`, `event_time` 보존 검증. 기존 revert E2E의 `doneRes.data.uuid → doneRes.data.done.uuid` 경로 정정

## 테스트

- [x] 단위 테스트 514개 통과 (신규 케이스 포함)
- [x] E2E 테스트 62개 통과 (신규 케이스 포함, RED → GREEN 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)