### PR TITLE
docs: CLAUDE.md에 Common Pitfalls 섹션 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,12 @@ Domain model classes live in `models/`. Each has `toJSON()` for serialization (E
 
 Firestore `in` queries have a 30-item limit. Whenever loading events by IDs, services chunk arrays into slices of 30 and run `Promise.all` over the chunks. See `Utils/functions.js` for the `chunk` helper.
 
+### Common Pitfalls
+
+- **Firestore admin SDK는 plain object만 받음**: `collectionRef.add(data)` / `set(data)`에 모델 클래스 인스턴스(`EventTime`, `Repeating`, `DoneTodo` 등 — custom prototype을 가진 객체)를 직접 넘기면 `"Couldn't serialize object of type X. Firestore doesn't support JavaScript objects with custom prototypes"`로 throw. `loadXxx`로 읽어 wrap된 모델을 다시 firestore에 쓰는 흐름(예: revert)은 `.toJSON()`이나 destructure로 plain object 변환 후 전달. 발견 사례: PR #145 `services/doneTodoService.js #revertTodoPayload`.
+
+- **async 함수 안의 Promise는 반드시 await 또는 .catch**: 변수에 받기만 하고 await 없이 다른 await를 거치면, 그 Promise가 reject될 때 micro-task 윈도우에서 `unhandledRejection`으로 감지됨. Node 15+ 기본 정책 `--unhandled-rejections=throw`로 함수 인스턴스 종료 → HTTP 응답 못 보내고 클라가 socket hang up(connection reset). async 함수 안 모든 Promise는 명시적 await 또는 `.catch` 처리. 발견 사례: PR #145 `services/doneTodoService.js #runRevertDoneTodo`.
+
 ### Testing
 
 Tests use **Mocha + assert** (Node.js built-in). Test doubles live in `test/doubles/`:


### PR DESCRIPTION
## 배경

PR #144 (`#142`), PR #145 (`#143`) 작업 중 발견한 두 가지 firebase admin + Node.js 함정을 프로젝트 CLAUDE.md에 기록. 같은 이슈 재발 방지 + 신규 진입자가 한 번 읽고 인지하도록.

## 추가 항목

`Architecture Overview > Firestore Chunking Pattern` 다음에 새 섹션 `### Common Pitfalls` 생성:

1. **Firestore admin SDK는 plain object만 받음** — 모델 클래스 인스턴스(`EventTime`, `Repeating`, `DoneTodo` 등 custom prototype 객체)를 `collectionRef.add()`/`set()`에 직접 넘기면 `"Couldn't serialize object of type X. Firestore doesn't support JavaScript objects with custom prototypes"`로 throw. `loadXxx` → wrap → 다시 write 흐름(예: revert)에서는 `.toJSON()`이나 destructure로 plain 변환 boundary 명확히. 발견 사례 PR #145.

2. **async 함수 안의 Promise는 반드시 await 또는 .catch** — 변수에 받기만 하고 await 없이 다른 await를 거치면, reject 시 micro-task 윈도우에서 `unhandledRejection`으로 감지됨. Node 15+ 기본 `--unhandled-rejections=throw`로 함수 인스턴스 종료 → HTTP 응답 못 보내고 클라가 socket hang up. 발견 사례 PR #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)