### PR TITLE
[#152] openAPI MVP — PR 1: 의존성 + 시크릿 분리 + 미들웨어 3종

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,5 +134,5 @@ test/e2e/
 `functions/secrets/` (gitignore 처리, `.env.test.example`만 예외 커밋):
 - `todocalendar-serviceAccountKey.json`: 프로덕션 Firebase Admin 인증서 (프로덕션에서만 필요)
 - `.env`: 프로덕션 환경변수 (`HOLIDAY_API_KEY`, `OPENAPI_PAT_MCP`, `SIGNING_SECRET` 등)
-- `.env.test`: 에뮬레이터/E2E 전용 환경변수. 프로덕션 `.env` 와 **값이 절대 같지 않게** dummy/random 으로 운용 (보안 분리). 에뮬레이터 모드에서 `index.js` 가 자동 로드. 누락 시 dotenv silent fail (CI 등은 직접 `process.env` 주입 가능)
-- `.env.test.example`: `.env.test` 템플릿. 새 시크릿 키 추가 시 같이 갱신.
+- `.env.test`: 에뮬레이터/E2E 전용 환경변수 (gitignored). 프로덕션 `.env` 와 **값이 절대 같지 않게** dummy/random 으로 운용 (보안 분리). 에뮬레이터 모드에서 `index.js` 가 자동 로드. 가장 빠른 셋업: `cp secrets/.env.test.example secrets/.env.test` 한 번이면 동작 (template 에 dummy 값이 박혀 있음). 값을 바꾸고 싶을 때만 직접 수정.
+- `.env.test.example`: `.env.test` 템플릿 (커밋 대상). 알려진 dummy hex pattern (`deadbeef.../cafebabe...`) 이 박혀 있어 그대로 복사만 해도 동작 가능. 새 시크릿 키 추가 시 함께 갱신 + dummy 값까지 같이 박을 것.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,8 @@ test/e2e/
 - `index.js`는 `FUNCTIONS_EMULATOR` 환경변수로 에뮬레이터/프로덕션 초기화를 분기
 
 **환경 분기 (`index.js`):**
-- 에뮬레이터 모드(`FUNCTIONS_EMULATOR=true`): `initializeApp()` — secrets 파일 불필요
-- 프로덕션 모드: 기존 서비스 계정 키 기반 초기화
+- 에뮬레이터 모드(`FUNCTIONS_EMULATOR=true`): `initializeApp()` (서비스 계정 키 불필요) + `secrets/.env.test` 로드
+- 프로덕션 모드: 서비스 계정 키 기반 초기화 + `secrets/.env` 로드
 
 **포트:** Auth(9099), Functions(5001), Firestore(8080)
 
@@ -131,4 +131,8 @@ test/e2e/
 
 ### Secrets
 
-`functions/secrets/` contains `todocalendar-serviceAccountKey.json` and `.env`. These files are not committed and must be present locally to run the app (not needed for emulator mode).
+`functions/secrets/` (gitignore 처리, `.env.test.example`만 예외 커밋):
+- `todocalendar-serviceAccountKey.json`: 프로덕션 Firebase Admin 인증서 (프로덕션에서만 필요)
+- `.env`: 프로덕션 환경변수 (`HOLIDAY_API_KEY`, `OPENAPI_PAT_MCP`, `SIGNING_SECRET` 등)
+- `.env.test`: 에뮬레이터/E2E 전용 환경변수. 프로덕션 `.env` 와 **값이 절대 같지 않게** dummy/random 으로 운용 (보안 분리). 에뮬레이터 모드에서 `index.js` 가 자동 로드. 누락 시 dotenv silent fail (CI 등은 직접 `process.env` 주입 가능)
+- `.env.test.example`: `.env.test` 템플릿. 새 시크릿 키 추가 시 같이 갱신.

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
-secrets/
+secrets/*
+!secrets/.env.test.example
 .DS_Store

--- a/functions/index.js
+++ b/functions/index.js
@@ -14,6 +14,7 @@ const { getFirestore } = require('firebase-admin/firestore');
 
 const isEmulator = process.env.FUNCTIONS_EMULATOR === 'true';
 if (isEmulator) {
+    require('dotenv').config({ path: './secrets/.env.test' });
     initializeApp();
 } else {
     const serviceAccount = require('./secrets/todocalendar-serviceAccountKey.json');

--- a/functions/middlewares/openapi/patAuth.js
+++ b/functions/middlewares/openapi/patAuth.js
@@ -1,0 +1,49 @@
+const crypto = require('crypto');
+const Errors = require('../../models/Errors');
+
+const KNOWN_SERVICES = ['mcp'];
+
+function envSecretFor(service) {
+    return process.env[`OPENAPI_PAT_${service.toUpperCase()}`];
+}
+
+function safeEqual(a, b) {
+    const ab = Buffer.from(a, 'utf8');
+    const bb = Buffer.from(b, 'utf8');
+    if (ab.length !== bb.length) return false;
+    return crypto.timingSafeEqual(ab, bb);
+}
+
+function patAuth(req, res, next) {
+    const auth = req.headers && req.headers.authorization;
+    if (typeof auth !== 'string' || !auth.startsWith('Bearer ')) {
+        throw new Errors.Base(401, 'InvalidCredentials', 'Invalid credentials');
+    }
+
+    const token = auth.slice('Bearer '.length).trim();
+    const sep = token.indexOf('_');
+    if (sep <= 0 || sep === token.length - 1) {
+        throw new Errors.Base(401, 'InvalidCredentials', 'Invalid credentials');
+    }
+
+    const service = token.slice(0, sep);
+    const secret = token.slice(sep + 1);
+
+    if (!KNOWN_SERVICES.includes(service)) {
+        throw new Errors.Base(401, 'InvalidCredentials', 'Invalid credentials');
+    }
+
+    const expected = envSecretFor(service);
+    if (!expected) {
+        throw new Errors.Base(500, 'ServerMisconfigured', 'PAT secret not configured');
+    }
+
+    if (!safeEqual(secret, expected)) {
+        throw new Errors.Base(401, 'InvalidCredentials', 'Invalid credentials');
+    }
+
+    req.callerId = service;
+    next();
+}
+
+module.exports = patAuth;

--- a/functions/middlewares/openapi/requireScope.js
+++ b/functions/middlewares/openapi/requireScope.js
@@ -1,0 +1,21 @@
+const Errors = require('../../models/Errors');
+
+function requireScope(required) {
+    if (!Array.isArray(required)) {
+        throw new TypeError('requireScope: required must be an array of scope strings');
+    }
+    return function (req, res, next) {
+        if (required.length === 0) {
+            next();
+            return;
+        }
+        const owned = Array.isArray(req.openScope) ? req.openScope : [];
+        const missing = required.find((s) => !owned.includes(s));
+        if (missing !== undefined) {
+            throw new Errors.Base(403, 'InsufficientScope', 'Insufficient scope');
+        }
+        next();
+    };
+}
+
+module.exports = requireScope;

--- a/functions/middlewares/openapi/signedUserAuth.js
+++ b/functions/middlewares/openapi/signedUserAuth.js
@@ -1,0 +1,31 @@
+const jwt = require('jsonwebtoken');
+const Errors = require('../../models/Errors');
+
+function signedUserAuth(req, res, next) {
+    const token = req.headers && req.headers['x-open-user-token'];
+    if (typeof token !== 'string' || token.length === 0) {
+        throw new Errors.Base(401, 'InvalidCredentials', 'Invalid token');
+    }
+
+    const secret = process.env.SIGNING_SECRET;
+    if (!secret) {
+        throw new Errors.Base(500, 'ServerMisconfigured', 'JWT signing secret not configured');
+    }
+
+    let payload;
+    try {
+        payload = jwt.verify(token, secret, { algorithms: ['HS256'] });
+    } catch (err) {
+        throw new Errors.Base(401, 'InvalidCredentials', 'Invalid token');
+    }
+
+    if (!payload || typeof payload.sub !== 'string' || payload.sub.length === 0) {
+        throw new Errors.Base(401, 'InvalidCredentials', 'Invalid token');
+    }
+
+    req.openUserId = payload.sub;
+    req.openScope = Array.isArray(payload.scope) ? payload.scope : [];
+    next();
+}
+
+module.exports = signedUserAuth;

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,6 +12,7 @@
         "express-async-errors": "^3.1.1",
         "firebase-admin": "^13.6.0",
         "firebase-functions": "^7.0.2",
+        "jsonwebtoken": "^9.0.2",
         "swagger-ui-express": "^5.0.1",
         "yamljs": "^0.3.0"
       },

--- a/functions/package.json
+++ b/functions/package.json
@@ -24,6 +24,7 @@
     "express-async-errors": "^3.1.1",
     "firebase-admin": "^13.6.0",
     "firebase-functions": "^7.0.2",
+    "jsonwebtoken": "^9.0.2",
     "swagger-ui-express": "^5.0.1",
     "yamljs": "^0.3.0"
   },

--- a/functions/secrets/.env.test.example
+++ b/functions/secrets/.env.test.example
@@ -1,14 +1,19 @@
-# 에뮬레이터/E2E 테스트 전용 환경변수 템플릿
-# 실제 사용 시 secrets/.env.test 파일을 만들어 아래 키들을 채운다.
-# 프로덕션 secrets/.env 의 값과 절대 동일하지 않게 — dummy/random 값으로만 운용한다.
+# 에뮬레이터/E2E 테스트 전용 환경변수 템플릿 (커밋 대상)
+# 사용 방법: 이 파일을 그대로 복사하면 즉시 동작.
+#   cp secrets/.env.test.example secrets/.env.test
+# 값을 바꾸고 싶다면 secrets/.env.test 를 직접 수정 (gitignored).
+#
+# 모든 값은 명백한 dummy hex pattern (deadbeef / cafebabe ...). 운영 secrets/.env 와
+# 절대 같지 않게 — 운영 키와 분리 운용 (보안 원칙).
 
-# Holiday API (Google Calendar API key) — 테스트에서는 임의 dummy 가능 (외부 호출 시 500 허용)
-HOLIDAY_API_KEY=
+# Holiday API key (외부 Google Calendar API 호출용).
+# 외부 API 가 dummy 를 거절하므로 holiday endpoint 는 e2e 에서 500 허용 처리됨.
+HOLIDAY_API_KEY=dummy-not-a-real-google-api-key
 
-# openAPI PAT (서비스 식별) — Authorization Bearer 헤더로 사용. 형식: <prefix>_<random>
-# MVP는 mcp prefix 한 종류만 운용.
-OPENAPI_PAT_MCP=
+# openAPI PAT (호출 서비스 식별). 형식: <prefix>_<random hex>.
+# MVP 는 mcp prefix 한 종류만 화이트리스트 (functions/middlewares/openapi/patAuth.js).
+OPENAPI_PAT_MCP=mcp_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 
-# openAPI 사용자 JWT 서명키 (HS256) — aiFrontAPI 가 발급, openAPI 가 검증.
-# 테스트는 32바이트 이상 random hex 권장.
-SIGNING_SECRET=
+# openAPI 사용자 JWT 서명키 (HS256). aiFrontAPI 가 발급, openAPI 가 검증.
+# 32바이트 이상 random hex 권장 (운영에서는 반드시 별도 random 값으로 교체).
+SIGNING_SECRET=cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe

--- a/functions/secrets/.env.test.example
+++ b/functions/secrets/.env.test.example
@@ -1,0 +1,14 @@
+# 에뮬레이터/E2E 테스트 전용 환경변수 템플릿
+# 실제 사용 시 secrets/.env.test 파일을 만들어 아래 키들을 채운다.
+# 프로덕션 secrets/.env 의 값과 절대 동일하지 않게 — dummy/random 값으로만 운용한다.
+
+# Holiday API (Google Calendar API key) — 테스트에서는 임의 dummy 가능 (외부 호출 시 500 허용)
+HOLIDAY_API_KEY=
+
+# openAPI PAT (서비스 식별) — Authorization Bearer 헤더로 사용. 형식: <prefix>_<random>
+# MVP는 mcp prefix 한 종류만 운용.
+OPENAPI_PAT_MCP=
+
+# openAPI 사용자 JWT 서명키 (HS256) — aiFrontAPI 가 발급, openAPI 가 검증.
+# 테스트는 32바이트 이상 random hex 권장.
+SIGNING_SECRET=

--- a/functions/test/middlewares/openapi/patAuth.test.js
+++ b/functions/test/middlewares/openapi/patAuth.test.js
@@ -1,0 +1,79 @@
+const assert = require('assert');
+const patAuth = require('../../../middlewares/openapi/patAuth');
+const Errors = require('../../../models/Errors');
+
+describe('middlewares/openapi/patAuth', () => {
+
+    const SECRET = 'a'.repeat(32);
+
+    let req;
+    let res;
+    let nextCalled;
+
+    beforeEach(() => {
+        req = { headers: {} };
+        res = {};
+        nextCalled = false;
+        process.env.OPENAPI_PAT_MCP = SECRET;
+    });
+
+    afterEach(() => {
+        delete process.env.OPENAPI_PAT_MCP;
+    });
+
+    const next = () => { nextCalled = true; };
+
+    function expectFail(status, code) {
+        try {
+            patAuth(req, res, next);
+            assert.fail('should throw');
+        } catch (err) {
+            assert.ok(err instanceof Errors.Base, `expected Errors.Base, got ${err && err.constructor.name}`);
+            assert.strictEqual(err.status, status);
+            assert.strictEqual(err.code, code);
+        }
+        assert.strictEqual(nextCalled, false);
+    }
+
+    it('정상 PAT → next 호출 + req.callerId 세팅', () => {
+        req.headers.authorization = `Bearer mcp_${SECRET}`;
+        patAuth(req, res, next);
+        assert.strictEqual(nextCalled, true);
+        assert.strictEqual(req.callerId, 'mcp');
+    });
+
+    it('Authorization 헤더 누락 → 401', () => {
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('Bearer 접두 없음 → 401', () => {
+        req.headers.authorization = `mcp_${SECRET}`;
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('토큰에 _ 구분자 없음 → 401', () => {
+        req.headers.authorization = `Bearer mcpsecret`;
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('KNOWN_SERVICES 화이트리스트에 없는 service → 401', () => {
+        req.headers.authorization = `Bearer foo_${SECRET}`;
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('환경변수 미등록 → 500 ServerMisconfigured', () => {
+        delete process.env.OPENAPI_PAT_MCP;
+        req.headers.authorization = `Bearer mcp_${SECRET}`;
+        expectFail(500, 'ServerMisconfigured');
+    });
+
+    it('시크릿 불일치 (같은 길이) → 401', () => {
+        req.headers.authorization = `Bearer mcp_${'b'.repeat(32)}`;
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('시크릿 길이 다름 → 401', () => {
+        req.headers.authorization = `Bearer mcp_short`;
+        expectFail(401, 'InvalidCredentials');
+    });
+});

--- a/functions/test/middlewares/openapi/requireScope.test.js
+++ b/functions/test/middlewares/openapi/requireScope.test.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const requireScope = require('../../../middlewares/openapi/requireScope');
+const Errors = require('../../../models/Errors');
+
+describe('middlewares/openapi/requireScope', () => {
+
+    let req;
+    let res;
+    let nextCalled;
+
+    beforeEach(() => {
+        req = {};
+        res = {};
+        nextCalled = false;
+    });
+
+    const next = () => { nextCalled = true; };
+
+    function expectForbidden(mw) {
+        try {
+            mw(req, res, next);
+            assert.fail('should throw');
+        } catch (err) {
+            assert.ok(err instanceof Errors.Base, `expected Errors.Base, got ${err && err.constructor.name}`);
+            assert.strictEqual(err.status, 403);
+            assert.strictEqual(err.code, 'InsufficientScope');
+        }
+        assert.strictEqual(nextCalled, false);
+    }
+
+    it('필요 scope 모두 보유 → next', () => {
+        req.openScope = ['read:calendar', 'write:calendar'];
+        const mw = requireScope(['read:calendar']);
+        mw(req, res, next);
+        assert.strictEqual(nextCalled, true);
+    });
+
+    it('필요 scope 일부 누락 → 403', () => {
+        req.openScope = ['read:calendar'];
+        expectForbidden(requireScope(['read:calendar', 'write:calendar']));
+    });
+
+    it('필요 scope 전부 누락 → 403', () => {
+        req.openScope = ['other:scope'];
+        expectForbidden(requireScope(['read:calendar']));
+    });
+
+    it('req.openScope 자체가 undefined → 403', () => {
+        expectForbidden(requireScope(['read:calendar']));
+    });
+
+    it('required = [] → next (요구 없음)', () => {
+        req.openScope = [];
+        const mw = requireScope([]);
+        mw(req, res, next);
+        assert.strictEqual(nextCalled, true);
+    });
+
+    it('비배열 required (개발자 실수) → factory 시점에 TypeError', () => {
+        assert.throws(() => requireScope('read:calendar'), TypeError);
+        assert.throws(() => requireScope(undefined), TypeError);
+        assert.throws(() => requireScope(null), TypeError);
+    });
+});

--- a/functions/test/middlewares/openapi/signedUserAuth.test.js
+++ b/functions/test/middlewares/openapi/signedUserAuth.test.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+const jwt = require('jsonwebtoken');
+const signedUserAuth = require('../../../middlewares/openapi/signedUserAuth');
+const Errors = require('../../../models/Errors');
+
+describe('middlewares/openapi/signedUserAuth', () => {
+
+    const SECRET = 'test-signing-secret-for-openapi-32bytes';
+
+    let req;
+    let res;
+    let nextCalled;
+
+    beforeEach(() => {
+        req = { headers: {} };
+        res = {};
+        nextCalled = false;
+        process.env.SIGNING_SECRET = SECRET;
+    });
+
+    afterEach(() => {
+        delete process.env.SIGNING_SECRET;
+    });
+
+    const next = () => { nextCalled = true; };
+
+    function expectFail(status, code) {
+        try {
+            signedUserAuth(req, res, next);
+            assert.fail('should throw');
+        } catch (err) {
+            assert.ok(err instanceof Errors.Base, `expected Errors.Base, got ${err && err.constructor.name}`);
+            assert.strictEqual(err.status, status);
+            assert.strictEqual(err.code, code);
+        }
+        assert.strictEqual(nextCalled, false);
+    }
+
+    function makeToken({
+        sub = 'user-1',
+        scope = ['read:calendar'],
+        secret = SECRET,
+        expiresIn = '5m',
+    } = {}) {
+        return jwt.sign({ sub, scope }, secret, { algorithm: 'HS256', expiresIn });
+    }
+
+    it('정상 → next 호출 + req.openUserId/openScope 세팅', () => {
+        req.headers['x-open-user-token'] = makeToken();
+        signedUserAuth(req, res, next);
+        assert.strictEqual(nextCalled, true);
+        assert.strictEqual(req.openUserId, 'user-1');
+        assert.deepStrictEqual(req.openScope, ['read:calendar']);
+    });
+
+    it('헤더 누락 → 401', () => {
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('서명 변조 (다른 secret) → 401', () => {
+        req.headers['x-open-user-token'] = makeToken({ secret: 'different-secret' });
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('만료된 토큰 → 401', () => {
+        req.headers['x-open-user-token'] = makeToken({ expiresIn: '-1s' });
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('sub 누락 → 401', () => {
+        req.headers['x-open-user-token'] = jwt.sign(
+            { scope: ['read:calendar'] },
+            SECRET,
+            { algorithm: 'HS256', expiresIn: '5m' }
+        );
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('SIGNING_SECRET 미설정 → 500 ServerMisconfigured', () => {
+        delete process.env.SIGNING_SECRET;
+        req.headers['x-open-user-token'] = 'any.token.string';
+        expectFail(500, 'ServerMisconfigured');
+    });
+
+    it('scope 누락된 토큰 → req.openScope = []', () => {
+        req.headers['x-open-user-token'] = jwt.sign(
+            { sub: 'user-1' },
+            SECRET,
+            { algorithm: 'HS256', expiresIn: '5m' }
+        );
+        signedUserAuth(req, res, next);
+        assert.strictEqual(nextCalled, true);
+        assert.strictEqual(req.openUserId, 'user-1');
+        assert.deepStrictEqual(req.openScope, []);
+    });
+
+    it('알 수 없는 발급자(iss claim 다른 값)도 통과 — openAPI 는 발급자 무관, 비밀키 서명만 검증', () => {
+        req.headers['x-open-user-token'] = jwt.sign(
+            { sub: 'user-1', scope: ['read:calendar'] },
+            SECRET,
+            { algorithm: 'HS256', issuer: 'some-other-issuer', expiresIn: '5m' }
+        );
+        signedUserAuth(req, res, next);
+        assert.strictEqual(nextCalled, true);
+        assert.strictEqual(req.openUserId, 'user-1');
+    });
+});


### PR DESCRIPTION
## Summary
이슈 #152 (openAPI MVP) 분할 작업 중 **PR 1 / 3** — `/v2/open/*` 엔드포인트가 통과해야 할 인증/인가 미들웨어 토대.

이번 작업의 큰 그림: 외부 서비스(MCP, AI 클라이언트 등) 가 우리 백엔드에 접근하기 위한 새 REST API 묶음을 연다. 호출은 두 단계 인증 + 한 단계 인가를 거친다 — (1) PAT 로 **어느 서비스가 호출했는가** 식별, (2) HS256 JWT 로 **누구를 대신해 호출하는가** 식별, (3) scope 로 **그 작업을 할 권한이 있는가** 인가.

이 PR 은 그 세 미들웨어와 운영 시크릿 분리만 다룬다. 라우트/컨트롤러/`/v2/open/*` mount 는 PR 2 에서 진행.

## Commits
- `7e69606` JWT 라이브러리 도입과 에뮬레이터/프로덕션 시크릿 분리
- `6aff388` 호출 서비스 식별용 PAT(정적 토큰) 검증 미들웨어
- `6583e8a` 호출 사용자 식별용 JWT(HS256) 검증 미들웨어
- `f5b8a93` 권한 범위(scope) 인가 미들웨어(팩토리)
- `859c75d` `.env.test.example` 에 dummy 값 박아두기 (cp 한 번으로 동작)

## 보안 결정 메모
- **PAT 비교**: `crypto.timingSafeEqual` 로 항상 일정한 시간에 비교 (timing attack 방어). 길이 다르면 throw 하므로 그 앞에 길이 가드. 모든 실패 응답을 동일 코드/메시지로 통일 (PAT 형식 추측 차단).
- **JWT 검증**: `algorithms: ['HS256']` 화이트리스트 명시 (algorithm confusion 공격 방어). **issuer 는 검증하지 않음** — openAPI 는 공유 비밀키 서명만 신뢰 근거로 삼고, 토큰을 누가 발급했는지 (aiFrontAPI / 외부 OAuth 브릿지) 알 필요/권한 없음. 발급자별 분기는 토큰을 발급/재서명하는 상위 계층의 책임.
- **시크릿 미설정**: 401 이 아닌 500 'ServerMisconfigured' (운영자 설정 누락은 클라이언트 잘못이 아니므로 분리).
- **에뮬레이터 시크릿 분리**: `secrets/.env`(프로덕션) 와 `secrets/.env.test`(에뮬레이터/E2E) 별도 운용. 후자는 운영과 절대 같지 않은 dummy/random. 템플릿 `.env.test.example` 만 추적 (`secrets/*` ignore + negation 패턴), 알려진 dummy hex pattern 박혀 있어 cp 한 번이면 즉시 동작.
- **인가 미들웨어 부팅 시점 검증**: `requireScope` 가 비배열 인자로 호출되면 팩토리 시점에 TypeError 로 부팅 실패 — 잘못된 사용을 런타임이 아닌 부팅 시점에 발견.

## 리뷰 반영 (사용자 + 자기-검토)
- `patAuth` 의 `fail()` 헬퍼를 직접 throw 패턴으로 통일 (signedUserAuth 와 일치, 흐름 명확성).
- `requireScope` 의 비배열 `required` → 팩토리 시점 TypeError (잘못된 사용 조기 발견).
- `.env.test.example` 키 비움 → dummy hex pattern 박음 (cp 한 번이면 동작).
- **`patAuth` 명명 정리**: `prefix` → `service` (변수/상수). `KNOWN_SERVICES` 화이트리스트.
- **`signedUserAuth` issuer 검증 제거**: openAPI 는 발급자 정체성을 알 필요/권한 없음. spec 에 명시돼 있던 이슈어 화이트리스트는 잘못된 결정이었고 정정. ai-design / spec 문서 정합성 갱신은 별도 작업으로 처리 예정.

## Test plan
- [x] `npm test` 회귀 없음 — 536 passing (기존 514 + 신규 22)
- [x] `patAuth` 단위 8 케이스
- [x] `signedUserAuth` 단위 8 케이스 (iss 불일치 케이스 제거 / 발급자 무관 케이스 추가)
- [x] `requireScope` 단위 6 케이스
- [ ] 통합 동작은 PR 2 (라우트 mount) 이후 E2E (PR 3) 에서 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)