### PR TITLE
[#169] fast-xml-builder 보안 취약점 패치 (Dependabot #88, #89)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -3532,9 +3532,9 @@
       "peer": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -3544,7 +3544,8 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -7664,6 +7665,22 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
Closes #169

## Summary

- `functions/package-lock.json` 의 transitive optional dep `fast-xml-builder` 를 1.1.5 → 1.2.0 으로 갱신
- caret range(`^1.1.5`) 내 갱신이므로 `package.json` 변경 없이 lock 만 수정
- Dependabot 두 alert 동시 해소
  - [#89](https://github.com/sudopark/TodoCalendar-Functions/security/dependabot/89) High — GHSA-5wm8-gmm8-39j9 / CVE-2026-44665 (attribute 인젝션, 1.1.7 패치)
  - [#88](https://github.com/sudopark/TodoCalendar-Functions/security/dependabot/88) Medium — GHSA-45c6-75p6-83cc / CVE-2026-44664 (comment regex 우회, 1.1.6 패치)
- 의존 경로: `firebase-admin@13.8.0 → @google-cloud/storage@7.19.0 → fast-xml-parser@5.7.2 → fast-xml-builder` (직접 사용 코드 없음)

## Test plan

- [x] `npm ls fast-xml-builder` → `1.2.0` 단일 트리 확인
- [x] `npm test` 514 passing
- [ ] 머지 후 dependabot alert #88, #89 자동 close 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)