### PR TITLE
[#152] openAPI MVP — controllers/routes mount (PR 2/3)

### DIFF
--- a/docs/ai-design/03-service-api.md
+++ b/docs/ai-design/03-service-api.md
@@ -58,6 +58,12 @@ functions/
 - [ ] userId 위변조 방지 (서명 검증 필수)
 - [ ] Rate Limit (PAT별, userId별)
 
+#### 3.1.4 알려진 한계 (MVP) — 후속 과제 #173
+- 일부 단건 조회/수정/삭제 엔드포인트가 자원 owner 검증을 하지 않음. 기존 v1/v2 controller 를 그대로 옮긴 결과로, 호출자가 다른 사용자의 식별자(todoId/eventId/doneId/event_detail eventId)만 알면 그 자원에 접근 가능. 내부 클라이언트(앱)는 자기 데이터만 다루니 무방했지만 외부 호출자 환경에서는 닫아야 함.
+- 영향 메서드: `findTodo`, `getEvent`, `loadDoneTodo`, `removeDoneTodo`, `excludeRepeating`, `eventDetail.{findData/putData/removeData}`. 특히 `removeDoneTodo`·event_detail 계열은 service 시그니처 자체가 userId 를 안 받아서 가장 위험.
+- MVP 단계는 호출자(MCP, aiFrontAPI) 가 신뢰 가능한 내부 컴포넌트라 외부 노출 전까지 허용. 사용자 PAT 같은 외부 발급 자격증명이 도입되기 전에 반드시 닫는다.
+- 후속 과제는 #173 — service 응답 모양 전수조사 → owner 검증 정책 정해서 일괄 적용 + E2E 케이스 추가.
+
 ### 3.2 aiFrontAPI 추가
 
 #### 3.2.1 엔드포인트

--- a/functions/controllers/openapi/doneTodoOpenController.js
+++ b/functions/controllers/openapi/doneTodoOpenController.js
@@ -1,0 +1,82 @@
+
+const Errors = require('../../models/Errors');
+
+class DoneTodoOpenController {
+
+    constructor(doneTodoService) {
+        this.doneTodoService = doneTodoService;
+    }
+
+    async getDoneTodos(req, res) {
+        const userId = req.openUserId;
+        const size = parseInt(req.query.size);
+        const cursor = parseFloat(req.query.cursor);
+        if (!userId || !size) {
+            throw new Errors.BadRequest('user id or size is missing.');
+        }
+        try {
+            const page = await this.doneTodoService.loadDoneTodos(userId, size, cursor);
+            res.status(200).send(page);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async getDoneTodo(req, res) {
+        const doneEventId = req.params.id;
+        if (!doneEventId) {
+            throw new Errors.BadRequest('done todo id is missing.');
+        }
+        try {
+            const done = await this.doneTodoService.loadDoneTodo(doneEventId);
+            res.status(200).send(done);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async putDoneTodo(req, res) {
+        const userId = req.openUserId;
+        const doneEventId = req.params.id;
+        const { body } = req;
+        if (!userId || !doneEventId) {
+            throw new Errors.BadRequest('user id or doneEventId is missing.');
+        }
+        try {
+            const done = await this.doneTodoService.putDoneTodo(userId, doneEventId, body);
+            res.status(200).send(done);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async deleteDoneTodo(req, res) {
+        const userId = req.openUserId;
+        const doneEventId = req.params.id;
+        if (!userId || !doneEventId) {
+            throw new Errors.BadRequest('user id or doneEventId is missing.');
+        }
+        try {
+            await this.doneTodoService.removeDoneTodo(doneEventId);
+            res.status(200).send({ status: 'ok' });
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async revertDoneTodo(req, res) {
+        const userId = req.openUserId;
+        const doneEventId = req.params.id;
+        if (!userId || !doneEventId) {
+            throw new Errors.BadRequest('user id or doneEventId is missing.');
+        }
+        try {
+            const result = await this.doneTodoService.revertDoneTodoV2(userId, doneEventId);
+            res.status(201).send(result);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+}
+
+module.exports = DoneTodoOpenController;

--- a/functions/controllers/openapi/eventDetailOpenController.js
+++ b/functions/controllers/openapi/eventDetailOpenController.js
@@ -1,0 +1,59 @@
+
+const Errors = require('../../models/Errors');
+
+class EventDetailOpenController {
+
+    constructor(eventDetailDataService) {
+        this.eventDetailDataService = eventDetailDataService;
+    }
+
+    async putData(req, res) {
+        const eventId = req.params.id;
+        const isDoneDetail = req.isDoneDetail === true;
+        const { body } = req;
+        if (!eventId) {
+            throw new Errors.BadRequest('event id is missing.');
+        }
+        const payload = {
+            place: body.place,
+            url: body.url,
+            memo: body.memo
+        };
+        try {
+            const data = await this.eventDetailDataService.putData(eventId, payload, isDoneDetail);
+            res.status(201).send(data);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async getData(req, res) {
+        const eventId = req.params.id;
+        const isDoneDetail = req.isDoneDetail === true;
+        if (!eventId) {
+            throw new Errors.BadRequest('event id is missing.');
+        }
+        try {
+            const data = await this.eventDetailDataService.findData(eventId, isDoneDetail);
+            res.status(200).send(data);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async deleteData(req, res) {
+        const eventId = req.params.id;
+        const isDoneDetail = req.isDoneDetail === true;
+        if (!eventId) {
+            throw new Errors.BadRequest('event id is missing.');
+        }
+        try {
+            await this.eventDetailDataService.removeData(eventId, isDoneDetail);
+            res.status(200).send({ status: 'ok' });
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+}
+
+module.exports = EventDetailOpenController;

--- a/functions/controllers/openapi/scheduleOpenController.js
+++ b/functions/controllers/openapi/scheduleOpenController.js
@@ -1,0 +1,179 @@
+
+const Errors = require('../../models/Errors');
+
+class ScheduleOpenController {
+
+    constructor(scheduleEventService) {
+        this.scheduleEventService = scheduleEventService;
+    }
+
+    async getEvent(req, res) {
+        const eventId = req.params.id;
+        if (!eventId) {
+            throw new Errors.BadRequest('event id is missing.');
+        }
+        try {
+            const event = await this.scheduleEventService.getEvent(eventId);
+            res.status(200).send(event);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async getEvents(req, res) {
+        const userId = req.openUserId;
+        const lower = req.query.lower;
+        const upper = req.query.upper;
+        if (!userId || !lower || !upper) {
+            throw new Errors.BadRequest('user id, lower or upper is missing.');
+        }
+        try {
+            const events = await this.scheduleEventService.findEvents(userId, lower, upper);
+            res.status(200).send(events);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async makeEvent(req, res) {
+        const { body } = req;
+        const userId = req.openUserId;
+        if (!body.name || !userId || !body.event_time) {
+            throw new Errors.BadRequest('schedule event name, event_time or user id is missing.');
+        }
+        const payload = {
+            userId,
+            name: body.name,
+            event_tag_id: body.event_tag_id,
+            event_time: body.event_time,
+            repeating: body.repeating,
+            notification_options: body.notification_options,
+            show_turns: body.show_turns
+        };
+        try {
+            const newEvent = await this.scheduleEventService.makeEvent(userId, payload);
+            res.status(201).send(newEvent);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async putEvent(req, res) {
+        const { body } = req;
+        const eventId = req.params.id;
+        const userId = req.openUserId;
+        if (!body.name || !eventId || !userId || !body.event_time) {
+            throw new Errors.BadRequest('schedule name, user id, event_time or eventId is missing.');
+        }
+        try {
+            const payload = { userId, ...body };
+            const event = await this.scheduleEventService.putEvent(userId, eventId, payload);
+            res.status(201).send(event);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async patchEvent(req, res) {
+        const { body } = req;
+        const eventId = req.params.id;
+        const userId = req.openUserId;
+        if (!eventId || !userId) {
+            throw new Errors.BadRequest('event id or user id is missing.');
+        }
+        try {
+            const updated = await this.scheduleEventService.updateEvent(userId, eventId, body);
+            res.status(201).send(updated);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async removeEvent(req, res) {
+        const eventId = req.params.id;
+        const userId = req.openUserId;
+        if (!eventId || !userId) {
+            throw new Errors.BadRequest('event id or user id is missing.');
+        }
+        try {
+            await this.scheduleEventService.removeEvent(userId, eventId);
+            res.status(201).send({ status: 'ok' });
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async makeNewEventWithExcludeFromRepeating(req, res) {
+        const eventId = req.params.id;
+        const userId = req.openUserId;
+        const newPayload = req.body.new;
+        const excludeTime = req.body.exclude_repeatings;
+        if (!eventId || !userId) {
+            throw new Errors.BadRequest('user id or eventId is missing.');
+        }
+        if (!(newPayload?.name) || !(newPayload?.event_time) || !excludeTime) {
+            throw new Errors.BadRequest('new payload event name, event_time or excludeTime is missing.');
+        }
+        const payload = {
+            userId,
+            name: newPayload.name,
+            event_tag_id: newPayload.event_tag_id,
+            event_time: newPayload.event_time,
+            repeating: newPayload.repeating,
+            notification_options: newPayload.notification_options,
+            show_turns: newPayload.show_turns
+        };
+        try {
+            const result = await this.scheduleEventService.makeNewEventWithExcludeFromRepeating(
+                userId, eventId, excludeTime, payload
+            );
+            res.status(201).send(result);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async branchRepeatingEvent(req, res) {
+        const eventId = req.params.id;
+        const userId = req.openUserId;
+        const endTime = req.body.end_time;
+        const newPayload = req.body.new;
+        if (!eventId || !userId) {
+            throw new Errors.BadRequest('user id or eventId is missing.');
+        }
+        if (!endTime || !(newPayload?.name) || !(newPayload?.event_time)) {
+            throw new Errors.BadRequest('new payload event name, event_time or endTime is missing.');
+        }
+        const payload = {
+            userId,
+            name: newPayload.name,
+            event_tag_id: newPayload.event_tag_id,
+            event_time: newPayload.event_time,
+            repeating: newPayload.repeating,
+            notification_options: newPayload.notification_options,
+            show_turns: newPayload.show_turns
+        };
+        try {
+            const result = await this.scheduleEventService.branchNewRepeatingEvent(userId, eventId, endTime, payload);
+            res.status(201).send(result);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async excludeRepeatingTime(req, res) {
+        const eventId = req.params.id;
+        const excludeTime = req.body.exclude_repeatings;
+        if (!eventId || !excludeTime) {
+            throw new Errors.BadRequest('eventId or excludeTime is missing.');
+        }
+        try {
+            const result = await this.scheduleEventService.excludeRepeating(eventId, excludeTime);
+            res.status(200).send(result);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+}
+
+module.exports = ScheduleOpenController;

--- a/functions/controllers/openapi/tagOpenController.js
+++ b/functions/controllers/openapi/tagOpenController.js
@@ -1,0 +1,77 @@
+
+const Errors = require('../../models/Errors');
+
+class TagOpenController {
+
+    constructor(eventTagService) {
+        this.eventTagService = eventTagService;
+    }
+
+    async getAllTags(req, res) {
+        const userId = req.openUserId;
+        if (!userId) {
+            throw new Errors.BadRequest('user id is missing.');
+        }
+        try {
+            const tags = await this.eventTagService.findAllTags(userId);
+            res.status(200).send(tags);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async postEventTag(req, res) {
+        const { body } = req;
+        const userId = req.openUserId;
+        if (!userId || !body.name) {
+            throw new Errors.BadRequest('user id or tag name is missing.');
+        }
+        const payload = {
+            name: body.name,
+            userId,
+            color_hex: body.color_hex
+        };
+        try {
+            const tag = await this.eventTagService.makeTag(payload);
+            res.status(201).send(tag);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async putEventTag(req, res) {
+        const { body } = req;
+        const tagId = req.params.id;
+        const userId = req.openUserId;
+        if (!tagId || !body.name || !userId) {
+            throw new Errors.BadRequest('tag id, user id or tag name is missing.');
+        }
+        const payload = {
+            name: body.name,
+            color_hex: body.color_hex,
+            userId
+        };
+        try {
+            const tag = await this.eventTagService.putTag(tagId, payload, body.skipCheckDuplicationName);
+            res.status(201).send(tag);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async deleteTag(req, res) {
+        const tagId = req.params.id;
+        const userId = req.openUserId;
+        if (!tagId || !userId) {
+            throw new Errors.BadRequest('tag id or userId is missing.');
+        }
+        try {
+            await this.eventTagService.removeTag(userId, tagId);
+            res.status(200).send({ status: 'ok' });
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+}
+
+module.exports = TagOpenController;

--- a/functions/controllers/openapi/todoOpenController.js
+++ b/functions/controllers/openapi/todoOpenController.js
@@ -1,0 +1,159 @@
+
+const Errors = require('../../models/Errors');
+
+class TodoOpenController {
+
+    constructor(todoService) {
+        this.todoService = todoService;
+    }
+
+    async getUncompletedTodos(req, res) {
+        const userId = req.openUserId;
+        const refTime = req.query.refTime;
+        if (!userId || !refTime) {
+            throw new Errors.BadRequest('user id or refTime is missing.');
+        }
+        try {
+            const todos = await this.todoService.findUncompletedTodos(userId, refTime);
+            res.status(200).send(todos);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async getTodo(req, res) {
+        const todoId = req.params.id;
+        if (!todoId) {
+            throw new Errors.BadRequest('todo id is missing.');
+        }
+        try {
+            const todo = await this.todoService.findTodo(todoId);
+            res.status(200).send(todo);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async getTodos(req, res) {
+        const userId = req.openUserId;
+        const lower = req.query.lower;
+        const upper = req.query.upper;
+        if (!userId) {
+            throw new Errors.BadRequest('user id is missing.');
+        }
+        try {
+            if (lower && upper) {
+                const todos = await this.todoService.findTodos(userId, lower, upper);
+                res.status(200).send(todos);
+            } else {
+                const currents = await this.todoService.findCurrentTodo(userId);
+                res.status(200).send(currents);
+            }
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async makeTodo(req, res) {
+        const { body } = req;
+        const userId = req.openUserId;
+        if (!body.name || !userId) {
+            throw new Errors.BadRequest('todo name or user id is missing.');
+        }
+        const payload = {
+            userId,
+            name: body.name,
+            event_tag_id: body.event_tag_id,
+            event_time: body.event_time,
+            repeating: body.repeating,
+            notification_options: body.notification_options
+        };
+        try {
+            const newTodo = await this.todoService.makeTodo(userId, payload);
+            res.status(201).send(newTodo);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async putTodo(req, res) {
+        const { body } = req;
+        const todoId = req.params.id;
+        const userId = req.openUserId;
+        if (!body.name || !todoId || !userId) {
+            throw new Errors.BadRequest('todo name, user id or todoId is missing.');
+        }
+        try {
+            const payload = { userId, ...body };
+            const todo = await this.todoService.putTodo(userId, todoId, payload);
+            res.status(201).send(todo);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async patchTodo(req, res) {
+        const { body } = req;
+        const todoId = req.params.id;
+        const userId = req.openUserId;
+        if (!todoId || !userId) {
+            throw new Errors.BadRequest('user id or todoId is missing.');
+        }
+        try {
+            const todo = await this.todoService.updateTodo(userId, todoId, body);
+            res.status(201).send(todo);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async removeTodo(req, res) {
+        const todoId = req.params.id;
+        const userId = req.openUserId;
+        if (!todoId || !userId) {
+            throw new Errors.BadRequest('todoId or userId is missing.');
+        }
+        try {
+            await this.todoService.removeTodo(userId, todoId);
+            res.status(200).send({ status: 'ok' });
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async completeTodo(req, res) {
+        const userId = req.openUserId;
+        const originId = req.params.id;
+        const origin = req.body.origin;
+        const nextEventTime = req.body.next_event_time;
+        if (!userId || !originId || !origin) {
+            throw new Errors.BadRequest('userId, originId or origin is missing.');
+        }
+        try {
+            const donePayload = { userId, ...origin };
+            const result = await this.todoService.completeTodo(userId, originId, donePayload, nextEventTime);
+            res.status(201).send(result);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async replaceRepeatingTodo(req, res) {
+        const userId = req.openUserId;
+        const originId = req.params.id;
+        const newPayload = req.body.new;
+        const originNextEventTime = req.body.origin_next_event_time;
+        if (!userId || !originId || !newPayload) {
+            throw new Errors.BadRequest('userId, originId or new payload is missing.');
+        }
+        try {
+            const payload = { userId, ...newPayload };
+            const result = await this.todoService.replaceRepeatingTodo(userId, originId, payload, originNextEventTime);
+            res.status(201).send(result);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+}
+
+module.exports = TodoOpenController;

--- a/functions/index.js
+++ b/functions/index.js
@@ -38,6 +38,14 @@ const holidayRouter = require('./routes/holidayRoutes');
 const syncRouter = require('./routes/dataSyncRoutes.js');
 const testRouter = require('./routes/testRoutes');
 
+const todoOpenRouter = require('./routes/openapi/todoOpenRoutes');
+const doneTodoOpenRouter = require('./routes/openapi/doneTodoOpenRoutes');
+const scheduleOpenRouter = require('./routes/openapi/scheduleOpenRoutes');
+const tagOpenRouter = require('./routes/openapi/tagOpenRoutes');
+const eventDetailOpenRouter = require('./routes/openapi/eventDetailOpenRoutes');
+const patAuth = require('./middlewares/openapi/patAuth');
+const signedUserAuth = require('./middlewares/openapi/signedUserAuth');
+
 const logger = require("firebase-functions/logger");
 
 const app = express();
@@ -74,6 +82,15 @@ app.use('/v1/setting', authValidator, setVersion('v1'), settingRouter);
 app.use('/v1/holiday', setVersion('v1'), holidayRouter);
 app.use('/v1/sync', authValidator, setVersion('v1'), syncRouter);
 // app.use('/v1/tests', v1TestRouter);
+
+// openAPI (/v2/open/*) — PAT (서비스 식별) + signed user JWT (사용자 식별) + scope 인가
+// dones 가 todos 보다 먼저 mount: '/v2/open/todos/dones/...' 가 '/v2/open/todos' 의 prefix 매칭으로 흡수되지 않게.
+const openApiAuth = [patAuth, signedUserAuth, setVersion('v2')];
+app.use('/v2/open/todos/dones', openApiAuth, doneTodoOpenRouter);
+app.use('/v2/open/todos', openApiAuth, todoOpenRouter);
+app.use('/v2/open/schedules', openApiAuth, scheduleOpenRouter);
+app.use('/v2/open/tags', openApiAuth, tagOpenRouter);
+app.use('/v2/open/event_details', openApiAuth, eventDetailOpenRouter);
 
 // request logging
 const requestLogger = (gen) => (req, res, next) => {

--- a/functions/routes/openapi/doneTodoOpenRoutes.js
+++ b/functions/routes/openapi/doneTodoOpenRoutes.js
@@ -1,0 +1,66 @@
+
+const express = require('express');
+const router = express.Router();
+
+const DoneTodoOpenController = require('../../controllers/openapi/doneTodoOpenController');
+const DoneTodoRepository = require('../../repositories/doneTodoEventRepository');
+const DoneTodoService = require('../../services/doneTodoService');
+const TodoService = require('../../services/todoEventService');
+const TodoRepository = require('../../repositories/todoRepository');
+const EventTimeRangeService = require('../../services/eventTimeRangeService');
+const EventTimeRepository = require('../../repositories/eventTimeRangeRepository');
+const SyncTimeRepository = require('../../repositories/syncTimestampRepository');
+const ChangeLogRepository = require('../../repositories/dataChangeLogRepository');
+const ChangeLogRecordService = require('../../services/dataChangeLogRecordService');
+const EventDetailService = require('../../services/eventDetailService');
+const EventDetailRepository = require('../../repositories/eventDetailRepository');
+const requireScope = require('../../middlewares/openapi/requireScope');
+
+const doneTodoRepository = new DoneTodoRepository();
+const todoRepository = new TodoRepository();
+const eventTimeRangeService = new EventTimeRangeService(new EventTimeRepository());
+const changeLogRecordService = new ChangeLogRecordService(
+    new SyncTimeRepository(),
+    new ChangeLogRepository()
+);
+const todoService = new TodoService({
+    todoRepository,
+    eventTimeRangeService,
+    doneTodoRepository,
+    changeLogRecordService
+});
+const eventDetailService = new EventDetailService(
+    new EventDetailRepository(false),
+    new EventDetailRepository(true)
+);
+const doneTodoService = new DoneTodoService(
+    doneTodoRepository,
+    todoService,
+    eventDetailService
+);
+const controller = new DoneTodoOpenController(doneTodoService);
+
+const READ = requireScope(['read:calendar']);
+const WRITE = requireScope(['write:calendar']);
+
+router.get('/', READ, async (req, res) => {
+    await controller.getDoneTodos(req, res);
+});
+
+router.get('/:id', READ, async (req, res) => {
+    await controller.getDoneTodo(req, res);
+});
+
+router.put('/:id', WRITE, async (req, res) => {
+    await controller.putDoneTodo(req, res);
+});
+
+router.delete('/:id', WRITE, async (req, res) => {
+    await controller.deleteDoneTodo(req, res);
+});
+
+router.post('/:id/revert', WRITE, async (req, res) => {
+    await controller.revertDoneTodo(req, res);
+});
+
+module.exports = router;

--- a/functions/routes/openapi/eventDetailOpenRoutes.js
+++ b/functions/routes/openapi/eventDetailOpenRoutes.js
@@ -1,0 +1,47 @@
+
+const express = require('express');
+const router = express.Router();
+
+const EventDetailOpenController = require('../../controllers/openapi/eventDetailOpenController');
+const EventDetailDataService = require('../../services/eventDetailService');
+const EventDetailDataRepository = require('../../repositories/eventDetailRepository');
+const requireScope = require('../../middlewares/openapi/requireScope');
+
+const controller = new EventDetailOpenController(
+    new EventDetailDataService(
+        new EventDetailDataRepository(false),
+        new EventDetailDataRepository(true)
+    )
+);
+
+const READ = requireScope(['read:calendar']);
+const WRITE = requireScope(['write:calendar']);
+
+router.get('/done/:id', READ, async (req, res) => {
+    req.isDoneDetail = true;
+    await controller.getData(req, res);
+});
+
+router.put('/done/:id', WRITE, async (req, res) => {
+    req.isDoneDetail = true;
+    await controller.putData(req, res);
+});
+
+router.delete('/done/:id', WRITE, async (req, res) => {
+    req.isDoneDetail = true;
+    await controller.deleteData(req, res);
+});
+
+router.get('/:id', READ, async (req, res) => {
+    await controller.getData(req, res);
+});
+
+router.put('/:id', WRITE, async (req, res) => {
+    await controller.putData(req, res);
+});
+
+router.delete('/:id', WRITE, async (req, res) => {
+    await controller.deleteData(req, res);
+});
+
+module.exports = router;

--- a/functions/routes/openapi/scheduleOpenRoutes.js
+++ b/functions/routes/openapi/scheduleOpenRoutes.js
@@ -1,0 +1,74 @@
+
+const express = require('express');
+const router = express.Router();
+
+const ScheduleOpenController = require('../../controllers/openapi/scheduleOpenController');
+const ScheduleEventService = require('../../services/scheduleEventService');
+const EventTimeRangeService = require('../../services/eventTimeRangeService');
+const ScheduleRepository = require('../../repositories/scheduleEventRepository');
+const EventTimeRepository = require('../../repositories/eventTimeRangeRepository');
+const SyncTimeRepository = require('../../repositories/syncTimestampRepository');
+const ChangeLogRepository = require('../../repositories/dataChangeLogRepository');
+const ChangeLogRecordService = require('../../services/dataChangeLogRecordService');
+const EventDetailRepository = require('../../repositories/eventDetailRepository');
+const EventDetailService = require('../../services/eventDetailService');
+const requireScope = require('../../middlewares/openapi/requireScope');
+
+const scheduleRepository = new ScheduleRepository();
+const eventTimeRangeService = new EventTimeRangeService(new EventTimeRepository());
+const changeLogRecordService = new ChangeLogRecordService(
+    new SyncTimeRepository(),
+    new ChangeLogRepository()
+);
+const eventDetailService = new EventDetailService(
+    new EventDetailRepository(false),
+    new EventDetailRepository(true)
+);
+const scheduleEventService = new ScheduleEventService(
+    scheduleRepository,
+    eventTimeRangeService,
+    changeLogRecordService,
+    eventDetailService
+);
+const controller = new ScheduleOpenController(scheduleEventService);
+
+const READ = requireScope(['read:calendar']);
+const WRITE = requireScope(['write:calendar']);
+
+router.get('/', READ, async (req, res) => {
+    await controller.getEvents(req, res);
+});
+
+router.get('/:id', READ, async (req, res) => {
+    await controller.getEvent(req, res);
+});
+
+router.post('/', WRITE, async (req, res) => {
+    await controller.makeEvent(req, res);
+});
+
+router.put('/:id', WRITE, async (req, res) => {
+    await controller.putEvent(req, res);
+});
+
+router.patch('/:id/exclude', WRITE, async (req, res) => {
+    await controller.excludeRepeatingTime(req, res);
+});
+
+router.patch('/:id', WRITE, async (req, res) => {
+    await controller.patchEvent(req, res);
+});
+
+router.delete('/:id', WRITE, async (req, res) => {
+    await controller.removeEvent(req, res);
+});
+
+router.post('/:id/exclude', WRITE, async (req, res) => {
+    await controller.makeNewEventWithExcludeFromRepeating(req, res);
+});
+
+router.post('/:id/branch_repeating', WRITE, async (req, res) => {
+    await controller.branchRepeatingEvent(req, res);
+});
+
+module.exports = router;

--- a/functions/routes/openapi/tagOpenRoutes.js
+++ b/functions/routes/openapi/tagOpenRoutes.js
@@ -1,0 +1,42 @@
+
+const express = require('express');
+const router = express.Router();
+
+const TagOpenController = require('../../controllers/openapi/tagOpenController');
+const EventTagRepository = require('../../repositories/eventTagRepository');
+const EventTagService = require('../../services/eventTagService');
+const SyncTimestampRepository = require('../../repositories/syncTimestampRepository');
+const ChangeLogRepository = require('../../repositories/dataChangeLogRepository');
+const ChangeLogRecordService = require('../../services/dataChangeLogRecordService');
+const requireScope = require('../../middlewares/openapi/requireScope');
+
+const changeLogRecordService = new ChangeLogRecordService(
+    new SyncTimestampRepository(),
+    new ChangeLogRepository()
+);
+const eventTagService = new EventTagService(
+    new EventTagRepository(),
+    changeLogRecordService
+);
+const controller = new TagOpenController(eventTagService);
+
+const READ = requireScope(['read:calendar']);
+const WRITE = requireScope(['write:calendar']);
+
+router.get('/', READ, async (req, res) => {
+    await controller.getAllTags(req, res);
+});
+
+router.post('/', WRITE, async (req, res) => {
+    await controller.postEventTag(req, res);
+});
+
+router.put('/:id', WRITE, async (req, res) => {
+    await controller.putEventTag(req, res);
+});
+
+router.delete('/:id', WRITE, async (req, res) => {
+    await controller.deleteTag(req, res);
+});
+
+module.exports = router;

--- a/functions/routes/openapi/todoOpenRoutes.js
+++ b/functions/routes/openapi/todoOpenRoutes.js
@@ -1,0 +1,78 @@
+
+const express = require('express');
+const router = express.Router();
+
+const TodoOpenController = require('../../controllers/openapi/todoOpenController');
+const TodoService = require('../../services/todoEventService');
+const EventTimeRangeService = require('../../services/eventTimeRangeService');
+const TodoRepository = require('../../repositories/todoRepository');
+const EventTimeRepository = require('../../repositories/eventTimeRangeRepository');
+const DoneTodoEventRepository = require('../../repositories/doneTodoEventRepository');
+const SyncTimeRepository = require('../../repositories/syncTimestampRepository');
+const ChangeLogRepository = require('../../repositories/dataChangeLogRepository');
+const ChangeLogRecordService = require('../../services/dataChangeLogRecordService');
+const EventDetailDataService = require('../../services/eventDetailService');
+const EventDetailDataRepository = require('../../repositories/eventDetailRepository');
+const requireScope = require('../../middlewares/openapi/requireScope');
+
+const todoRepository = new TodoRepository();
+const eventTimeRepository = new EventTimeRepository();
+const doneTodoRepository = new DoneTodoEventRepository();
+const eventTimeRangeService = new EventTimeRangeService(eventTimeRepository);
+const changeLogRecordService = new ChangeLogRecordService(
+    new SyncTimeRepository(),
+    new ChangeLogRepository()
+);
+const eventDetailDataService = new EventDetailDataService(
+    new EventDetailDataRepository(false),
+    new EventDetailDataRepository(true)
+);
+const todoService = new TodoService({
+    todoRepository,
+    eventTimeRangeService,
+    doneTodoRepository,
+    changeLogRecordService,
+    eventDetailDataService
+});
+const controller = new TodoOpenController(todoService);
+
+const READ = requireScope(['read:calendar']);
+const WRITE = requireScope(['write:calendar']);
+
+router.get('/uncompleted', READ, async (req, res) => {
+    await controller.getUncompletedTodos(req, res);
+});
+
+router.get('/:id', READ, async (req, res) => {
+    await controller.getTodo(req, res);
+});
+
+router.get('/', READ, async (req, res) => {
+    await controller.getTodos(req, res);
+});
+
+router.post('/', WRITE, async (req, res) => {
+    await controller.makeTodo(req, res);
+});
+
+router.put('/:id', WRITE, async (req, res) => {
+    await controller.putTodo(req, res);
+});
+
+router.patch('/:id', WRITE, async (req, res) => {
+    await controller.patchTodo(req, res);
+});
+
+router.delete('/:id', WRITE, async (req, res) => {
+    await controller.removeTodo(req, res);
+});
+
+router.post('/:id/complete', WRITE, async (req, res) => {
+    await controller.completeTodo(req, res);
+});
+
+router.post('/:id/replace', WRITE, async (req, res) => {
+    await controller.replaceRepeatingTodo(req, res);
+});
+
+module.exports = router;

--- a/functions/test/controllers/openapi/doneTodoOpenController.test.js
+++ b/functions/test/controllers/openapi/doneTodoOpenController.test.js
@@ -1,0 +1,164 @@
+
+const assert = require('assert');
+const DoneTodoOpenController = require('../../../controllers/openapi/doneTodoOpenController');
+const Errors = require('../../../models/Errors');
+const StubServices = require('../../doubles/stubServices');
+const makeRes = StubServices.makeRes;
+
+
+describe('DoneTodoOpenController', () => {
+
+    let stubService;
+    let controller;
+
+    beforeEach(() => {
+        stubService = new StubServices.DoneTodo();
+        controller = new DoneTodoOpenController(stubService);
+    });
+
+
+    describe('getDoneTodos', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, query: { size: '10' } };
+            const res = makeRes();
+            await assert.rejects(controller.getDoneTodos(req, res), Errors.BadRequest);
+        });
+
+        it('size 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', query: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getDoneTodos(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { openUserId: 'uid', query: { size: '10', cursor: '0' } };
+            const res = makeRes();
+            await controller.getDoneTodos(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', query: { size: '10' } };
+            const res = makeRes();
+            await assert.rejects(controller.getDoneTodos(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('getDoneTodo', () => {
+
+        it('id 없으면 BadRequest', async () => {
+            const req = { params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getDoneTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { params: { id: 'done1' } };
+            const res = makeRes();
+            await controller.getDoneTodo(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { params: { id: 'done1' } };
+            const res = makeRes();
+            await assert.rejects(controller.getDoneTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('putDoneTodo', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'done1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.putDoneTodo(req, res), Errors.BadRequest);
+        });
+
+        it('doneEventId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.putDoneTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { openUserId: 'uid', params: { id: 'done1' }, body: { name: 'updated' } };
+            const res = makeRes();
+            await controller.putDoneTodo(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'done1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.putDoneTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('deleteDoneTodo', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'done1' } };
+            const res = makeRes();
+            await assert.rejects(controller.deleteDoneTodo(req, res), Errors.BadRequest);
+        });
+
+        it('doneEventId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.deleteDoneTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200 {status:ok}', async () => {
+            const req = { openUserId: 'uid', params: { id: 'done1' } };
+            const res = makeRes();
+            await controller.deleteDoneTodo(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, { status: 'ok' });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'done1' } };
+            const res = makeRes();
+            await assert.rejects(controller.deleteDoneTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('revertDoneTodo', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'done1' } };
+            const res = makeRes();
+            await assert.rejects(controller.revertDoneTodo(req, res), Errors.BadRequest);
+        });
+
+        it('doneEventId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.revertDoneTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201 (revertDoneTodoV2 사용)', async () => {
+            const req = { openUserId: 'uid', params: { id: 'done1' } };
+            const res = makeRes();
+            await controller.revertDoneTodo(req, res);
+            assert.equal(res.statusCode, 201);
+            assert.deepEqual(res.body, { todo: { uuid: 'reverted' }, detail: null });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'done1' } };
+            const res = makeRes();
+            await assert.rejects(controller.revertDoneTodo(req, res), Errors.Application);
+        });
+    });
+});

--- a/functions/test/controllers/openapi/eventDetailOpenController.test.js
+++ b/functions/test/controllers/openapi/eventDetailOpenController.test.js
@@ -1,0 +1,121 @@
+
+const assert = require('assert');
+const EventDetailOpenController = require('../../../controllers/openapi/eventDetailOpenController');
+const Errors = require('../../../models/Errors');
+const StubServices = require('../../doubles/stubServices');
+const makeRes = StubServices.makeRes;
+
+
+describe('EventDetailOpenController', () => {
+
+    let stubService;
+    let controller;
+
+    beforeEach(() => {
+        stubService = new StubServices.EventDetailData();
+        controller = new EventDetailOpenController(stubService);
+    });
+
+
+    describe('getData', () => {
+
+        it('id 없으면 BadRequest', async () => {
+            const req = { params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getData(req, res), Errors.BadRequest);
+        });
+
+        it('정상(active) → 200, isDone=false 로 service 호출', async () => {
+            const req = { params: { id: 'evt1' } };
+            const res = makeRes();
+            await controller.getData(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('정상(done) → 200, isDone=true 로 service 호출', async () => {
+            let called = null;
+            stubService.findData = async (id, isDone) => { called = { id, isDone }; return stubService.dataResult; };
+            const req = { params: { id: 'done1' }, isDoneDetail: true };
+            const res = makeRes();
+            await controller.getData(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(called, { id: 'done1', isDone: true });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { params: { id: 'evt1' } };
+            const res = makeRes();
+            await assert.rejects(controller.getData(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('putData', () => {
+
+        it('id 없으면 BadRequest', async () => {
+            const req = { params: {}, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.putData(req, res), Errors.BadRequest);
+        });
+
+        it('정상(active) → 201', async () => {
+            const req = { params: { id: 'evt1' }, body: { memo: 'x' } };
+            const res = makeRes();
+            await controller.putData(req, res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('정상(done) → 201, isDone=true 로 service 호출', async () => {
+            let called = null;
+            stubService.putData = async (id, payload, isDone) => { called = { id, payload, isDone }; return stubService.dataResult; };
+            const req = { params: { id: 'done1' }, body: { memo: 'x' }, isDoneDetail: true };
+            const res = makeRes();
+            await controller.putData(req, res);
+            assert.equal(res.statusCode, 201);
+            assert.equal(called.isDone, true);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { params: { id: 'evt1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.putData(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('deleteData', () => {
+
+        it('id 없으면 BadRequest', async () => {
+            const req = { params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.deleteData(req, res), Errors.BadRequest);
+        });
+
+        it('정상(active) → 200 {status:ok}', async () => {
+            const req = { params: { id: 'evt1' } };
+            const res = makeRes();
+            await controller.deleteData(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, { status: 'ok' });
+        });
+
+        it('정상(done) → 200, isDone=true 로 service 호출', async () => {
+            let called = null;
+            stubService.removeData = async (id, isDone) => { called = { id, isDone }; };
+            const req = { params: { id: 'done1' }, isDoneDetail: true };
+            const res = makeRes();
+            await controller.deleteData(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.equal(called.isDone, true);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { params: { id: 'evt1' } };
+            const res = makeRes();
+            await assert.rejects(controller.deleteData(req, res), Errors.Application);
+        });
+    });
+});

--- a/functions/test/controllers/openapi/scheduleOpenController.test.js
+++ b/functions/test/controllers/openapi/scheduleOpenController.test.js
@@ -1,0 +1,340 @@
+
+const assert = require('assert');
+const ScheduleOpenController = require('../../../controllers/openapi/scheduleOpenController');
+const Errors = require('../../../models/Errors');
+const StubServices = require('../../doubles/stubServices');
+const makeRes = StubServices.makeRes;
+
+
+describe('ScheduleOpenController', () => {
+
+    let stubService;
+    let controller;
+
+    beforeEach(() => {
+        stubService = new StubServices.ScheduleEvent();
+        controller = new ScheduleOpenController(stubService);
+    });
+
+
+    describe('getEvent', () => {
+
+        it('id 없으면 BadRequest', async () => {
+            const req = { params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { params: { id: 'evt1' } };
+            const res = makeRes();
+            await controller.getEvent(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { params: { id: 'evt1' } };
+            const res = makeRes();
+            await assert.rejects(controller.getEvent(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('getEvents', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, query: { lower: '1', upper: '2' } };
+            const res = makeRes();
+            await assert.rejects(controller.getEvents(req, res), Errors.BadRequest);
+        });
+
+        it('lower 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', query: { upper: '2' } };
+            const res = makeRes();
+            await assert.rejects(controller.getEvents(req, res), Errors.BadRequest);
+        });
+
+        it('upper 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', query: { lower: '1' } };
+            const res = makeRes();
+            await assert.rejects(controller.getEvents(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { openUserId: 'uid', query: { lower: '1', upper: '2' } };
+            const res = makeRes();
+            await controller.getEvents(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', query: { lower: '1', upper: '2' } };
+            const res = makeRes();
+            await assert.rejects(controller.getEvents(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('makeEvent', () => {
+
+        const validReq = () => ({
+            openUserId: 'uid',
+            body: { name: 'evt', event_time: { time_type: 'at', timestamp: 100 } }
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, body: { name: 'e', event_time: {} } };
+            const res = makeRes();
+            await assert.rejects(controller.makeEvent(req, res), Errors.BadRequest);
+        });
+
+        it('name 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', body: { event_time: {} } };
+            const res = makeRes();
+            await assert.rejects(controller.makeEvent(req, res), Errors.BadRequest);
+        });
+
+        it('event_time 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', body: { name: 'e' } };
+            const res = makeRes();
+            await assert.rejects(controller.makeEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const res = makeRes();
+            await controller.makeEvent(validReq(), res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const res = makeRes();
+            await assert.rejects(controller.makeEvent(validReq(), res), Errors.Application);
+        });
+    });
+
+
+    describe('putEvent', () => {
+
+        const validReq = () => ({
+            openUserId: 'uid',
+            params: { id: 'evt1' },
+            body: { name: 'evt', event_time: {} }
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'evt1' }, body: { name: 'e', event_time: {} } };
+            const res = makeRes();
+            await assert.rejects(controller.putEvent(req, res), Errors.BadRequest);
+        });
+
+        it('eventId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: { name: 'e', event_time: {} } };
+            const res = makeRes();
+            await assert.rejects(controller.putEvent(req, res), Errors.BadRequest);
+        });
+
+        it('name 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: { id: 'evt1' }, body: { event_time: {} } };
+            const res = makeRes();
+            await assert.rejects(controller.putEvent(req, res), Errors.BadRequest);
+        });
+
+        it('event_time 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: { id: 'evt1' }, body: { name: 'e' } };
+            const res = makeRes();
+            await assert.rejects(controller.putEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const res = makeRes();
+            await controller.putEvent(validReq(), res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const res = makeRes();
+            await assert.rejects(controller.putEvent(validReq(), res), Errors.Application);
+        });
+    });
+
+
+    describe('patchEvent', () => {
+
+        it('eventId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.patchEvent(req, res), Errors.BadRequest);
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'evt1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.patchEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const req = { openUserId: 'uid', params: { id: 'evt1' }, body: { name: 'patched' } };
+            const res = makeRes();
+            await controller.patchEvent(req, res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'evt1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.patchEvent(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('removeEvent', () => {
+
+        it('eventId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.removeEvent(req, res), Errors.BadRequest);
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'evt1' } };
+            const res = makeRes();
+            await assert.rejects(controller.removeEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const req = { openUserId: 'uid', params: { id: 'evt1' } };
+            const res = makeRes();
+            await controller.removeEvent(req, res);
+            assert.equal(res.statusCode, 201);
+            assert.deepEqual(res.body, { status: 'ok' });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'evt1' } };
+            const res = makeRes();
+            await assert.rejects(controller.removeEvent(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('makeNewEventWithExcludeFromRepeating', () => {
+
+        const validReq = () => ({
+            openUserId: 'uid',
+            params: { id: 'evt1' },
+            body: { new: { name: 'new', event_time: {} }, exclude_repeatings: 100 }
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const r = validReq(); r.openUserId = null;
+            const res = makeRes();
+            await assert.rejects(controller.makeNewEventWithExcludeFromRepeating(r, res), Errors.BadRequest);
+        });
+
+        it('eventId 없으면 BadRequest', async () => {
+            const r = validReq(); r.params = {};
+            const res = makeRes();
+            await assert.rejects(controller.makeNewEventWithExcludeFromRepeating(r, res), Errors.BadRequest);
+        });
+
+        it('new payload name 없으면 BadRequest', async () => {
+            const r = validReq(); r.body.new = { event_time: {} };
+            const res = makeRes();
+            await assert.rejects(controller.makeNewEventWithExcludeFromRepeating(r, res), Errors.BadRequest);
+        });
+
+        it('exclude_repeatings 없으면 BadRequest', async () => {
+            const r = validReq(); r.body.exclude_repeatings = null;
+            const res = makeRes();
+            await assert.rejects(controller.makeNewEventWithExcludeFromRepeating(r, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const res = makeRes();
+            await controller.makeNewEventWithExcludeFromRepeating(validReq(), res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const res = makeRes();
+            await assert.rejects(controller.makeNewEventWithExcludeFromRepeating(validReq(), res), Errors.Application);
+        });
+    });
+
+
+    describe('branchRepeatingEvent', () => {
+
+        const validReq = () => ({
+            openUserId: 'uid',
+            params: { id: 'evt1' },
+            body: { new: { name: 'new', event_time: {} }, end_time: 200 }
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const r = validReq(); r.openUserId = null;
+            const res = makeRes();
+            await assert.rejects(controller.branchRepeatingEvent(r, res), Errors.BadRequest);
+        });
+
+        it('eventId 없으면 BadRequest', async () => {
+            const r = validReq(); r.params = {};
+            const res = makeRes();
+            await assert.rejects(controller.branchRepeatingEvent(r, res), Errors.BadRequest);
+        });
+
+        it('end_time 없으면 BadRequest', async () => {
+            const r = validReq(); r.body.end_time = null;
+            const res = makeRes();
+            await assert.rejects(controller.branchRepeatingEvent(r, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const res = makeRes();
+            await controller.branchRepeatingEvent(validReq(), res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const res = makeRes();
+            await assert.rejects(controller.branchRepeatingEvent(validReq(), res), Errors.Application);
+        });
+    });
+
+
+    describe('excludeRepeatingTime', () => {
+
+        it('eventId 없으면 BadRequest', async () => {
+            const req = { params: {}, body: { exclude_repeatings: 100 } };
+            const res = makeRes();
+            await assert.rejects(controller.excludeRepeatingTime(req, res), Errors.BadRequest);
+        });
+
+        it('exclude_repeatings 없으면 BadRequest', async () => {
+            const req = { params: { id: 'evt1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.excludeRepeatingTime(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { params: { id: 'evt1' }, body: { exclude_repeatings: 100 } };
+            const res = makeRes();
+            await controller.excludeRepeatingTime(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { params: { id: 'evt1' }, body: { exclude_repeatings: 100 } };
+            const res = makeRes();
+            await assert.rejects(controller.excludeRepeatingTime(req, res), Errors.Application);
+        });
+    });
+});

--- a/functions/test/controllers/openapi/tagOpenController.test.js
+++ b/functions/test/controllers/openapi/tagOpenController.test.js
@@ -1,0 +1,139 @@
+
+const assert = require('assert');
+const TagOpenController = require('../../../controllers/openapi/tagOpenController');
+const Errors = require('../../../models/Errors');
+const StubServices = require('../../doubles/stubServices');
+const makeRes = StubServices.makeRes;
+
+
+describe('TagOpenController', () => {
+
+    let stubService;
+    let controller;
+
+    beforeEach(() => {
+        stubService = new StubServices.EventTag();
+        controller = new TagOpenController(stubService);
+    });
+
+
+    describe('getAllTags', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null };
+            const res = makeRes();
+            await assert.rejects(controller.getAllTags(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { openUserId: 'uid' };
+            const res = makeRes();
+            await controller.getAllTags(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid' };
+            const res = makeRes();
+            await assert.rejects(controller.getAllTags(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('postEventTag', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, body: { name: 'tag' } };
+            const res = makeRes();
+            await assert.rejects(controller.postEventTag(req, res), Errors.BadRequest);
+        });
+
+        it('name 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.postEventTag(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const req = { openUserId: 'uid', body: { name: 'tag', color_hex: '#FFF' } };
+            const res = makeRes();
+            await controller.postEventTag(req, res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', body: { name: 'tag' } };
+            const res = makeRes();
+            await assert.rejects(controller.postEventTag(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('putEventTag', () => {
+
+        it('tagId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: { name: 'updated' } };
+            const res = makeRes();
+            await assert.rejects(controller.putEventTag(req, res), Errors.BadRequest);
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'tag1' }, body: { name: 'u' } };
+            const res = makeRes();
+            await assert.rejects(controller.putEventTag(req, res), Errors.BadRequest);
+        });
+
+        it('name 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: { id: 'tag1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.putEventTag(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const req = { openUserId: 'uid', params: { id: 'tag1' }, body: { name: 'updated' } };
+            const res = makeRes();
+            await controller.putEventTag(req, res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'tag1' }, body: { name: 'u' } };
+            const res = makeRes();
+            await assert.rejects(controller.putEventTag(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('deleteTag', () => {
+
+        it('tagId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.deleteTag(req, res), Errors.BadRequest);
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'tag1' } };
+            const res = makeRes();
+            await assert.rejects(controller.deleteTag(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200 {status:ok}', async () => {
+            const req = { openUserId: 'uid', params: { id: 'tag1' } };
+            const res = makeRes();
+            await controller.deleteTag(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, { status: 'ok' });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'tag1' } };
+            const res = makeRes();
+            await assert.rejects(controller.deleteTag(req, res), Errors.Application);
+        });
+    });
+});

--- a/functions/test/controllers/openapi/todoOpenController.test.js
+++ b/functions/test/controllers/openapi/todoOpenController.test.js
@@ -1,0 +1,313 @@
+
+const assert = require('assert');
+const TodoOpenController = require('../../../controllers/openapi/todoOpenController');
+const Errors = require('../../../models/Errors');
+const StubServices = require('../../doubles/stubServices');
+const makeRes = StubServices.makeRes;
+
+
+describe('TodoOpenController', () => {
+
+    let stubService;
+    let controller;
+
+    beforeEach(() => {
+        stubService = new StubServices.TodoEvent();
+        controller = new TodoOpenController(stubService);
+    });
+
+
+    describe('getUncompletedTodos', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, query: { refTime: '100' } };
+            const res = makeRes();
+            await assert.rejects(controller.getUncompletedTodos(req, res), Errors.BadRequest);
+        });
+
+        it('refTime 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', query: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getUncompletedTodos(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { openUserId: 'uid', query: { refTime: '100' } };
+            const res = makeRes();
+            await controller.getUncompletedTodos(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, [{ uuid: 'todo1' }]);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', query: { refTime: '100' } };
+            const res = makeRes();
+            await assert.rejects(controller.getUncompletedTodos(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('getTodo', () => {
+
+        it('id 없으면 BadRequest', async () => {
+            const req = { params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { params: { id: 'todo1' } };
+            const res = makeRes();
+            await controller.getTodo(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, { uuid: 'todo1', name: 'some todo' });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { params: { id: 'todo1' } };
+            const res = makeRes();
+            await assert.rejects(controller.getTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('getTodos', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, query: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getTodos(req, res), Errors.BadRequest);
+        });
+
+        it('lower/upper 있으면 기간 조회 → 200', async () => {
+            const req = { openUserId: 'uid', query: { lower: '100', upper: '200' } };
+            const res = makeRes();
+            await controller.getTodos(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, [{ uuid: 'todo1' }, { uuid: 'todo2' }]);
+        });
+
+        it('lower/upper 없으면 current → 200', async () => {
+            const req = { openUserId: 'uid', query: {} };
+            const res = makeRes();
+            await controller.getTodos(req, res);
+            assert.equal(res.statusCode, 200);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', query: {} };
+            const res = makeRes();
+            await assert.rejects(controller.getTodos(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('makeTodo', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, body: { name: 'todo' } };
+            const res = makeRes();
+            await assert.rejects(controller.makeTodo(req, res), Errors.BadRequest);
+        });
+
+        it('name 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.makeTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const req = { openUserId: 'uid', body: { name: 'new todo' } };
+            const res = makeRes();
+            await controller.makeTodo(req, res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', body: { name: 'todo' } };
+            const res = makeRes();
+            await assert.rejects(controller.makeTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('putTodo', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'todo1' }, body: { name: 'updated' } };
+            const res = makeRes();
+            await assert.rejects(controller.putTodo(req, res), Errors.BadRequest);
+        });
+
+        it('todoId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: { name: 'updated' } };
+            const res = makeRes();
+            await assert.rejects(controller.putTodo(req, res), Errors.BadRequest);
+        });
+
+        it('name 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: { id: 'todo1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.putTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const req = { openUserId: 'uid', params: { id: 'todo1' }, body: { name: 'updated' } };
+            const res = makeRes();
+            await controller.putTodo(req, res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'todo1' }, body: { name: 'updated' } };
+            const res = makeRes();
+            await assert.rejects(controller.putTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('patchTodo', () => {
+
+        it('todoId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.patchTodo(req, res), Errors.BadRequest);
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'todo1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.patchTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const req = { openUserId: 'uid', params: { id: 'todo1' }, body: { name: 'patched' } };
+            const res = makeRes();
+            await controller.patchTodo(req, res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'todo1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.patchTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('removeTodo', () => {
+
+        it('todoId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {} };
+            const res = makeRes();
+            await assert.rejects(controller.removeTodo(req, res), Errors.BadRequest);
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'todo1' } };
+            const res = makeRes();
+            await assert.rejects(controller.removeTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200 {status:ok}', async () => {
+            const req = { openUserId: 'uid', params: { id: 'todo1' } };
+            const res = makeRes();
+            await controller.removeTodo(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, { status: 'ok' });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', params: { id: 'todo1' } };
+            const res = makeRes();
+            await assert.rejects(controller.removeTodo(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('completeTodo', () => {
+
+        const validReq = () => ({
+            openUserId: 'uid',
+            params: { id: 'todo1' },
+            body: { origin: { uuid: 'todo1', name: 'some todo' }, next_event_time: null }
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'todo1' }, body: { origin: { uuid: 'todo1' } } };
+            const res = makeRes();
+            await assert.rejects(controller.completeTodo(req, res), Errors.BadRequest);
+        });
+
+        it('originId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: { origin: { uuid: 'todo1' } } };
+            const res = makeRes();
+            await assert.rejects(controller.completeTodo(req, res), Errors.BadRequest);
+        });
+
+        it('origin 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: { id: 'todo1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.completeTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const res = makeRes();
+            await controller.completeTodo(validReq(), res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const res = makeRes();
+            await assert.rejects(controller.completeTodo(validReq(), res), Errors.Application);
+        });
+    });
+
+
+    describe('replaceRepeatingTodo', () => {
+
+        const validReq = () => ({
+            openUserId: 'uid',
+            params: { id: 'todo1' },
+            body: { new: { name: 'new todo' }, origin_next_event_time: 100 }
+        });
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, params: { id: 'todo1' }, body: { new: { name: 'n' } } };
+            const res = makeRes();
+            await assert.rejects(controller.replaceRepeatingTodo(req, res), Errors.BadRequest);
+        });
+
+        it('originId 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: {}, body: { new: { name: 'n' } } };
+            const res = makeRes();
+            await assert.rejects(controller.replaceRepeatingTodo(req, res), Errors.BadRequest);
+        });
+
+        it('new 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', params: { id: 'todo1' }, body: {} };
+            const res = makeRes();
+            await assert.rejects(controller.replaceRepeatingTodo(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201', async () => {
+            const res = makeRes();
+            await controller.replaceRepeatingTodo(validReq(), res);
+            assert.equal(res.statusCode, 201);
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const res = makeRes();
+            await assert.rejects(controller.replaceRepeatingTodo(validReq(), res), Errors.Application);
+        });
+    });
+});


### PR DESCRIPTION
## 개요

이슈 #152 (openAPI MVP) 의 **2번째 PR**. PR 1(미들웨어/시크릿 분리, #168) 위에 올라가는 컨트롤러 + 라우터 + index.js mount + 알려진 한계 명문화.

```
[PR 1 머지됨] 미들웨어 + 시크릿 분리
   └─ patAuth / signedUserAuth / requireScope, .env.test 분리
[PR 2 ← 이 PR] 컨트롤러/라우터 + mount + 한계 명문화
   └─ /v2/open/{todos, todos/dones, schedules, tags, event_details}
[PR 3] E2E 테스트 + 운영자 가이드
```

## 무엇을 추가했나

5개 리소스에 외부 호출용 엔드포인트 33개를 노출했습니다.

| 리소스 | 엔드포인트 수 | 노출 정책 |
|---|---|---|
| todos | 9 | 기존 v2 todos 와 동일 표면 |
| schedules | 9 | 기존 v2 schedules 와 동일 |
| tags | 4 | 단건 delete 만 노출 (일괄 삭제 미노출) |
| todos/dones | 5 | cancel·일괄 삭제 미노출 |
| event_details | 6 | active 3 + done 3 (라우트 분기) |

## 외부 호출 인증 흐름

```
HTTP 요청
   │
   ▼
patAuth                  ← Authorization: Bearer <service>_<secret>
   │ (서비스 식별)         req.callerId 세팅
   ▼
signedUserAuth           ← X-Open-User-Token: <HS256 JWT>
   │ (사용자 식별)         req.openUserId, req.openScope 세팅
   ▼
setVersion('v2')         ← req.apiVersion = 'v2' (기존 v2 분기 호환)
   │
   ▼
requireScope([...])      ← 라우트별 부착, scope 화이트리스트 검증
   │
   ▼
controller.method        ← req.openUserId 를 userId 로 사용
```

기존 `/v1/*`, `/v2/*` 경로는 Firebase ID 토큰 + `authValidator` 체인 그대로 — 완전히 분리된 라인.

## 의도적으로 좁힌 표면

외부 호출자가 한 번의 호출로 다수 데이터를 잃을 수 있는 동작은 공개하지 않았습니다.

- **tags**: `/tag_and_events/:id`, `/tag_with_events/:id` 같은 일괄 삭제 ❌
- **dones**: `DELETE /` (past_than 기반 일괄 삭제) ❌, `POST /cancel` (UX 전용 동작) ❌
- **revert**: v1 분기 없이 항상 `revertDoneTodoV2` 만 호출 (openAPI 는 v2 라인이라 분기 불필요)

## 응답 코드 정책 — 기존 v1/v2 controller 와 일치

리뷰 반영(코멘트 [r3212669906](https://github.com/sudopark/TodoCalendar-Functions/pull/172#discussion_r3212669906))으로 plan 매핑 표 초안과 다른 두 곳을 기존 v1/v2 동작 기준으로 정렬했습니다. 같은 클라이언트가 v1/v2 와 openAPI 둘 다 호출할 때 응답 코드 계약이 한 가지 모양이도록.

| 메서드 | 초안 | 최종 | 기존 v1/v2 |
|---|---|---|---|
| `removeEvent` (schedules) | 200 | **201** | 201 ✓ |
| `excludeRepeatingTime` (schedules) | 201 | **200** | 200 ✓ |
| `putDoneTodo` (dones) | 201 | **200** | 200 ✓ |

나머지(`removeTodo` 200, `deleteTag` 200, `deleteDoneTodo` 200, `revertDoneTodo` 201, event_detail `putData` 201 / 그 외 200)는 기존과 일치 — 변경 없음.

## 알려진 한계 — 후속 과제 #173

**ownership 검증 누락**: 일부 단건 조회/수정/삭제 엔드포인트가 자원 owner 검증을 하지 않습니다. 기존 v1/v2 controller 를 그대로 옮긴 결과로, 호출자가 다른 사용자의 식별자(todoId/eventId/doneId/event_detail eventId)만 알면 그 자원에 접근할 수 있습니다.

- 영향 메서드: `findTodo`, `getEvent`, `loadDoneTodo`, `removeDoneTodo`, `excludeRepeating`, `eventDetail.{findData/putData/removeData}`
- 가장 위험: `removeDoneTodo` 와 event_detail 계열 — service 시그니처 자체가 userId 를 안 받음.
- MVP 단계는 호출자(MCP, aiFrontAPI)가 신뢰 가능한 내부 컴포넌트라 외부 노출 전까지 허용. 사용자 PAT 같은 외부 발급 자격증명이 도입되기 전에 반드시 닫음.

후속 과제 → **#173** (이 PR 에서 코드 변경 X). `docs/ai-design/03-service-api.md §3.1.4` 에도 명문화.

## plan vs 실제 시그니처 — 차분점

`docs/superpowers/plans/2026-05-09-152-openapi-mvp.md` 초안과 실제 service 시그니처가 일부 어긋나서 실제 코드 기준으로 맞췄습니다.

| plan | 실제 service |
|---|---|
| `completeTodo(userId, id, donePayload, nextEventTime, nextRepeatingTurn)` 5인자 | `completeTodo(userId, originId, donePayload, nextEventTime)` 4인자 |
| `replaceRepeatingTodo(...nextRepeatingTurn)` 5인자 | 4인자 |
| `getEvents(userId, lower, upper)` | `findEvents(userId, lower, upper)` |
| `patchEvent` | `updateEvent` |
| `getDoneTodos`, `getDoneTodo` | `loadDoneTodos`, `loadDoneTodo` |
| `getData(userId, id, isDone)` | `findData(eventId, isDoneDetail)` — userId 안 씀 |

## 라우트 매칭 충돌 방지

Express 는 같은 method 안에서 먼저 등록된 패턴이 우선 매칭됩니다. literal 이 자동으로 우선되지 않습니다.

- todos: `GET /uncompleted` 를 `GET /:id` 보다 먼저
- schedules: `PATCH /:id/exclude` 를 `PATCH /:id` 보다 먼저
- event_details: `*/done/:id` 모두를 `*/:id` 보다 먼저
- mount: `/v2/open/todos/dones` 를 `/v2/open/todos` 보다 먼저 (prefix 흡수 회피)

## 테스트

각 컨트롤러마다 (필수 누락 → 400 / 정상 → 200·201 / service 실패 → 500 Application 래핑) 3종을 메서드별로 모두 커버.

| 컨트롤러 | 단위 테스트 |
|---|---|
| todoOpenController | 38건 |
| scheduleOpenController | 42건 |
| tagOpenController | 16건 |
| doneTodoOpenController | 19건 |
| eventDetailOpenController | 12건 |
| **합계** | **127건** |

`test/doubles/stubServices.js` 를 그대로 재사용 — service 인터페이스가 바뀌면 자연히 깨지도록.

기존 단위 테스트 회귀 없음 (전체 663 passing).

## 리뷰 반영 (force-push 사유)

[#172 리뷰](https://github.com/sudopark/TodoCalendar-Functions/pull/172#pullrequestreview-4257088275) 두 가지 반영을 위해 기존 6커밋을 history-rewrite + ai-design 한계 명시 1커밋 추가:

1. 응답 코드 3곳 기존 v1/v2 와 일치 (위 표) — 해당 commit 안에서 같이.
2. 알려진 한계 명문화 — 새 commit `[#152] AI 기능 설계 — openAPI MVP 의 알려진 한계 명문화 (#173 후속)`.

## E2E 는 PR 3 에서

실제 emulator 띄워서 PAT/JWT 흐름을 끝까지 검증하는 E2E 테스트 + 운영자 시크릿 가이드는 다음 PR (Task 11~14) 에서.

## Test plan

- [x] `npm test` — 663 passing
- [x] 메서드별 (필수 누락 / 정상 / service 실패) 단위 테스트 작성
- [x] `FUNCTIONS_EMULATOR=true node -e "require('./index.js')"` syntax-level 통과
- [ ] 에뮬레이터 smoke (PR 3 에서 cp .env.test.example 후 실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)