### PR TITLE
[#175] v1-only 라우터 8종 v2 경로 미러 마운트 (1단계)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -57,7 +57,9 @@ const setVersion = (version) => {
 };
 
 app.use("/v1/accounts", setVersion('v1'), accountRouter);
+app.use("/v2/accounts", setVersion('v2'), accountRouter);
 app.use('/v1/user', authValidator, setVersion('v1'), userRouter);
+app.use('/v2/user', authValidator, setVersion('v2'), userRouter);
 app.use("/v1/todos", authValidator, setVersion('v1'), todoRouter);
 app.use("/v2/todos", authValidator, setVersion('v2'), todoRouter);
 app.use('/v1/todos/dones', authValidator, setVersion('v1'), doneTodoRouter);
@@ -65,13 +67,19 @@ app.use('/v2/todos/dones', authValidator, setVersion('v2'), doneTodoRouter);
 app.use("/v1/schedules", authValidator, setVersion('v1'), scheduleRouter);
 app.use("/v2/schedules", authValidator, setVersion('v2'), scheduleRouter);
 app.use("/v1/foremost", authValidator, setVersion('v1'), foremostEventRouter);
+app.use("/v2/foremost", authValidator, setVersion('v2'), foremostEventRouter);
 app.use('/v1/tags', authValidator, setVersion('v1'), eventTagRouter);
 app.use('/v2/tags', authValidator, setVersion('v2'), eventTagRouter);
 app.use('/v1/event_details', authValidator, setVersion('v1'), eventDetailRouter);
+app.use('/v2/event_details', authValidator, setVersion('v2'), eventDetailRouter);
 app.use('/v1/migration', authValidator, setVersion('v1'), migrationRouter);
+app.use('/v2/migration', authValidator, setVersion('v2'), migrationRouter);
 app.use('/v1/setting', authValidator, setVersion('v1'), settingRouter);
+app.use('/v2/setting', authValidator, setVersion('v2'), settingRouter);
 app.use('/v1/holiday', setVersion('v1'), holidayRouter);
+app.use('/v2/holiday', setVersion('v2'), holidayRouter);
 app.use('/v1/sync', authValidator, setVersion('v1'), syncRouter);
+app.use('/v2/sync', authValidator, setVersion('v2'), syncRouter);
 // app.use('/v1/tests', v1TestRouter);
 
 // request logging

--- a/functions/test/e2e/v2-mirror-smoke.e2e.js
+++ b/functions/test/e2e/v2-mirror-smoke.e2e.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const { authedClient, publicClient } = require('./helpers/request');
+
+describe('v2 mirror smoke (v1-only routers mounted at /v2)', function () {
+    describe('PUT /v2/accounts/info', function () {
+        it('reaches accountRouter at v2 path', async function () {
+            const res = await authedClient().put('/v2/accounts/info');
+            assert.strictEqual(res.status, 201);
+            assert.ok(res.data.uid);
+        });
+    });
+
+    describe('PUT /v2/user/notification', function () {
+        it('reaches userRouter at v2 path', async function () {
+            const res = await authedClient().put('/v2/user/notification',
+                { fcm_token: 'v2-smoke-token', device_model: 'iPhone' },
+                { headers: { 'device_id': 'v2-smoke-device' } }
+            );
+            assert.strictEqual(res.status, 201);
+            assert.strictEqual(res.data.status, 'ok');
+        });
+    });
+
+    describe('GET /v2/foremost/event', function () {
+        it('reaches foremostEventRouter at v2 path', async function () {
+            const res = await authedClient().get('/v2/foremost/event');
+            assert.strictEqual(res.status, 200);
+        });
+    });
+
+    describe('PUT /v2/event_details/:id', function () {
+        it('reaches eventDetailRouter at v2 path', async function () {
+            const res = await authedClient().put('/v2/event_details/v2-smoke-detail', {
+                place: 'Smoke',
+                memo: 'v2 smoke memo'
+            });
+            assert.strictEqual(res.status, 201);
+        });
+    });
+
+    describe('POST /v2/migration/event_tags', function () {
+        it('reaches migrationRouter at v2 path', async function () {
+            const res = await authedClient().post('/v2/migration/event_tags', {
+                'v2-smoke-tag': { name: 'V2 Smoke Tag', color_hex: '#000000' }
+            });
+            assert.strictEqual(res.status, 201);
+            assert.strictEqual(res.data.status, 'ok');
+        });
+    });
+
+    describe('GET /v2/setting/event/tag/default/color', function () {
+        it('reaches settingRouter at v2 path', async function () {
+            const res = await authedClient().get('/v2/setting/event/tag/default/color');
+            assert.strictEqual(res.status, 200);
+        });
+    });
+
+    describe('GET /v2/holiday/', function () {
+        it('reaches holidayRouter at v2 path (no auth)', async function () {
+            const res = await publicClient().get('/v2/holiday/', {
+                params: { year: 2026, locale: 'ko_KR', code: 'KR' }
+            });
+            assert.ok([200, 500].includes(res.status));
+        });
+    });
+
+    describe('GET /v2/sync/check', function () {
+        it('reaches syncRouter at v2 path', async function () {
+            const res = await authedClient().get('/v2/sync/check', {
+                params: { dataType: 'EventTag' }
+            });
+            assert.strictEqual(res.status, 200);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

#175 1단계 — v1-only 8개 라우터를 `/v2/*` 경로에도 미러 마운트해 클라가 v2 단일 prefix로 옮길 수 있는 발판 마련.

## 변경 내용

- `functions/index.js` — `accounts`/`user`/`foremost`/`event_details`/`migration`/`setting`/`holiday`/`sync` 8종에 v2 미러 마운트 추가. 라우터 인스턴스/미들웨어 체인 재사용. 응답 모양은 v1 그대로 (이 8개는 컨트롤러/서비스에서 `req.apiVersion` 분기를 안 씀).
- `functions/test/e2e/v2-mirror-smoke.e2e.js` (신규) — 8개 라우터당 대표 엔드포인트 1건씩 smoke. v1 e2e 146건 전수 복제는 의도적으로 회피하고 "v2 마운트 됐다" 라우팅 증명에만 집중.

## 선행 점검 결과

- production 코드의 `apiVersion` 분기는 `controllers/doneTodoController.js#revertDoneTodo` 단 1곳. 본 8개 라우터엔 분기 없음 → 단순 미러로 v2 응답 = v1 응답.
- CLAUDE.md 의 "tag delete v1/v2 동작 차이" 노트는 현 코드 기준 stale (`eventTagController`/`Service` 에 분기 없음). 5단계에서 함께 정리 대상.

## 1단계 종료 조건

본 PR 머지 → `develop` → `master` 머지 → prod 배포까지 완료돼야 #175 2단계(클라가 v2 base URL 로 호출 전환)가 v2 가용성을 전제로 진행 가능.

## 범위 외

- 4개 dual-registered 라우터(`todos`/`todos/dones`/`schedules`/`tags`) — 이미 v2 마운트 존재. 이번 범위 X.
- v1 라우터 / `setVersion` / `req.apiVersion` 제거 — 5단계.
- 기존 v1 e2e 146건의 `/v1/` → `/v2/` 일괄 치환 — 5단계.

## Test plan

- [ ] `npm test` — 514 unit passing
- [ ] `npm run test:e2e:run` — 76 passing (기존 68 + v2 smoke 8)
- [ ] 머지 후 develop → master → prod 배포 진행
- [ ] prod 에서 대표 v2 엔드포인트(`GET /v2/sync/check?dataType=EventTag` 등) 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)