### PR TITLE
[#178] branch_repeating Firestore 500 — Schedule 인스턴스 plain object 변환

### DIFF
--- a/functions/services/scheduleEventService.js
+++ b/functions/services/scheduleEventService.js
@@ -87,8 +87,9 @@ class ScheduleEventService {
         }
         origin.repeating.end = endTime
         delete origin.repeating.end_count
+        const originPayload = origin.toJSON()
         const updated = await this.scheduleEventRepository.putEvent(
-            originEventId, origin
+            originEventId, originPayload
         )
         await this.#updateEventtime(userId, updated);
         const newEvent = await this.scheduleEventRepository.makeEvent(newPayload);

--- a/functions/test/doubles/stubRepositories.js
+++ b/functions/test/doubles/stubRepositories.js
@@ -167,9 +167,7 @@ class StubScheduleEventRepository {
         this.shouldFailUpdate = false
         this.eventMap = new Map();
         this.spyEventMap = new Map();
-        this.lastMakePayload = null
         this.lastPutPayload = null
-        this.lastUpdatePayload = null
     }
 
     async findEvent(eventId) {
@@ -188,7 +186,6 @@ class StubScheduleEventRepository {
     }
 
     async makeEvent(payload) {
-        this.lastMakePayload = payload
         if(this.shouldFailMake) {
             throw { message: 'failed' }
         }
@@ -211,7 +208,6 @@ class StubScheduleEventRepository {
     }
 
     async updateEvent(eventId, payload) {
-        this.lastUpdatePayload = payload
         if(this.shouldFailUpdate) {
             throw { message: 'failed' }
         }

--- a/functions/test/doubles/stubRepositories.js
+++ b/functions/test/doubles/stubRepositories.js
@@ -167,6 +167,9 @@ class StubScheduleEventRepository {
         this.shouldFailUpdate = false
         this.eventMap = new Map();
         this.spyEventMap = new Map();
+        this.lastMakePayload = null
+        this.lastPutPayload = null
+        this.lastUpdatePayload = null
     }
 
     async findEvent(eventId) {
@@ -183,8 +186,9 @@ class StubScheduleEventRepository {
         })
         return events
     }
- 
+
     async makeEvent(payload) {
+        this.lastMakePayload = payload
         if(this.shouldFailMake) {
             throw { message: 'failed' }
         }
@@ -196,6 +200,7 @@ class StubScheduleEventRepository {
     }
 
     async putEvent(eventId, payload) {
+        this.lastPutPayload = payload
         if(this.shouldFailPut) {
             throw { message: 'failed' }
         }
@@ -206,6 +211,7 @@ class StubScheduleEventRepository {
     }
 
     async updateEvent(eventId, payload) {
+        this.lastUpdatePayload = payload
         if(this.shouldFailUpdate) {
             throw { message: 'failed' }
         }

--- a/functions/test/e2e/schedule.e2e.js
+++ b/functions/test/e2e/schedule.e2e.js
@@ -95,5 +95,42 @@ describe('Schedule API', function () {
             assert.strictEqual(res.status, 201);
             assert.ok(res.data.uuid);
         });
+
+        describe('POST /v2/schedules/schedule/:id/branch_repeating', function () {
+            let originId;
+
+            beforeEach(async function () {
+                const created = await authedClient().post('/v2/schedules/schedule', {
+                    name: 'Repeating origin',
+                    event_time: { time_type: 'at', timestamp: futureTimestamp },
+                    repeating: {
+                        start: futureTimestamp,
+                        option: { optionType: 'every_day', interval: 1 }
+                    }
+                });
+                assert.strictEqual(created.status, 201);
+                originId = created.data.uuid;
+            });
+
+            it('origin의 repeating.end를 갱신하고 새 분기 schedule 생성 (issue #178 회귀)', async function () {
+                const endTime = futureTimestamp + 3600;
+                const res = await authedClient().post(`/v2/schedules/schedule/${originId}/branch_repeating`, {
+                    end_time: endTime,
+                    new: {
+                        name: 'Branched',
+                        event_time: { time_type: 'at', timestamp: futureTimestamp + 86400 },
+                        repeating: {
+                            start: futureTimestamp + 86400,
+                            option: { optionType: 'every_day', interval: 1 }
+                        }
+                    }
+                });
+                assert.strictEqual(res.status, 201);
+                assert.strictEqual(res.data.origin.uuid, originId);
+                assert.strictEqual(res.data.origin.repeating.end, endTime);
+                assert.strictEqual(res.data.new.name, 'Branched');
+                assert.ok(res.data.new.uuid);
+            });
+        });
     });
 });

--- a/functions/test/e2e/schedule.e2e.js
+++ b/functions/test/e2e/schedule.e2e.js
@@ -112,7 +112,7 @@ describe('Schedule API', function () {
                 originId = created.data.uuid;
             });
 
-            it('origin의 repeating.end를 갱신하고 새 분기 schedule 생성 (issue #178 회귀)', async function () {
+            it('should update origin repeating.end and create branched schedule (issue #178 regression)', async function () {
                 const endTime = futureTimestamp + 3600;
                 const res = await authedClient().post(`/v2/schedules/schedule/${originId}/branch_repeating`, {
                     end_time: endTime,

--- a/functions/test/services/scheduleEventService.test.js
+++ b/functions/test/services/scheduleEventService.test.js
@@ -366,6 +366,17 @@ describe('ScheduleEventService', () => {
             assert.equal(newRange.upper, constants.eventTimeMaxUpperBound);
             assert.equal(newRange.isTodo, false);
         })
+
+        it('origin은 plain object로 변환되어 putEvent에 전달 (Firestore 직렬화 보장)', async () => {
+            await scheduleService.branchNewRepeatingEvent(
+                'owner', 'origin', 200, newPayload
+            )
+            const payload = stubScheduleReopository.lastPutPayload
+            assert.equal(Object.getPrototypeOf(payload), Object.prototype)
+            assert.equal(Object.getPrototypeOf(payload.event_time), Object.prototype)
+            assert.equal(Object.getPrototypeOf(payload.repeating), Object.prototype)
+            assert.equal(payload.repeating.end, 200)
+        })
     })
 
     describe('remove event', () => {


### PR DESCRIPTION
closes #178

## 배경

`POST /v2/schedules/schedule/:id/branch_repeating` 호출 시 500 응답. `scheduleEventService.branchNewRepeatingEvent`가 `findEvent`로 받은 `Schedule` 모델 인스턴스를 그대로 `putEvent`에 넘겨 `ref.set(payload, ...)` 호출 → Firestore admin SDK가 custom prototype(`Schedule`/`EventTime`/`Repeating`)을 거부하며 throw → 500 wrap.

`CLAUDE.md` Common Pitfalls의 PR #145 (`doneTodoService.js#revertTodoPayload`)와 동일 패턴.

## 변경

- `ScheduleEventService.branchNewRepeatingEvent` — `origin.toJSON()`으로 평탄화 후 `putEvent` 호출. `Schedule.toJSON()`이 nested `event_time`/`repeating`까지 재귀 직렬화.
- `StubScheduleEventRepository` — `lastMakePayload`/`lastPutPayload`/`lastUpdatePayload` spy 추가. 호출 시점의 raw payload 보관, 검증 책임은 테스트 쪽.
- `scheduleEventService.test.js` — payload prototype이 `Object.prototype` 직속인지 확인하는 회귀 케이스 추가.
- `schedule.e2e.js` — `/v2/schedules/schedule/:id/branch_repeating` 분기 정상 시나리오 e2e 추가.

## 영향 범위

`branchNewRepeatingEvent` 한 곳을 수정하므로 호출하는 모든 진입점(v1, v2 미러)에서 회귀 해소. v2 미러는 PR #175 에서 마운트된 라우트 → 동일 service 공유.

## 테스트 계획

- [x] `npm test` — 515 passing (기존 514 + 회귀 케이스 1)
- [x] TDD RED→GREEN 사이클 검증 (fix 임시 revert → 신규 케이스 RED 확인 → fix 복원 → GREEN)
- [x] emulator e2e — `schedule.e2e.js` 26 passing (신규 branch_repeating 케이스 포함)
- [ ] 리뷰어: 사후 e2e 회귀 — 다른 라우트 e2e 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)