### PR TITLE
[#185] userRepository.loadUserDevice ReferenceError + new 오용 결함 정정

### DIFF
--- a/functions/repositories/userRepository.js
+++ b/functions/repositories/userRepository.js
@@ -8,9 +8,9 @@ const UserDevice = require('../models/UserDevice');
 class UserRepository {
 
     async loadUserDevice(deviceId) {
-        const snapShot = await collectionRef.doc(device).get();
-        const device = new UserDevice.fromData({ deviceId: deviceId, ...snapShot.data() })
-        return device
+        const snapShot = await collectionRef.doc(deviceId).get();
+        if (!snapShot.exists) return null;
+        return UserDevice.fromData({ deviceId, ...snapShot.data() });
     }
 
     async updateUserDevice(device) {


### PR DESCRIPTION
closes #185

## 배경

`userRepository.loadUserDevice`에 두 가지 결함이 함께 있어 호출되는 즉시 깨지는 dead code였음.

1. `collectionRef.doc(device)` — `device` 변수가 같은 함수 line 12에서 선언됨에도 line 11에서 먼저 참조 → 호출 시 `ReferenceError`
2. `new UserDevice.fromData(...)` — 정적 팩토리 메서드에 `new` 연산자 오용 → `TypeError`

호출처 0건이라 런타임에 깨질 일은 없었지만, 향후 알림 토큰 조회 등 요구사항으로 호출이 추가되는 즉시 터지는 잠재 버그.

## 변경

- **`UserRepository.loadUserDevice`**
  - `doc(device)` → `doc(deviceId)`: 인자 그대로 참조
  - `new UserDevice.fromData(...)` → `UserDevice.fromData(...)`: 정적 팩토리 호출 정정
  - `snapShot.exists` 체크 추가로 미존재 deviceId에 대해 `null` 반환

## 처리 방향 결정

dead code 삭제 vs 정정 두 옵션 중 정정 보존 선택. 이유: stub(`StubUserRepository.loadUserDevice`)에 인터페이스가 이미 존재하고, 알림 토큰 조회 같은 자연스러운 후속 사용처가 있어 재사용 가치가 있음.

## 테스트 계획

- [x] `npm test` — 515 passing (회귀 없음)
- [x] `node -c functions/repositories/userRepository.js` — syntax OK
- [ ] 호출처가 추가되는 후속 작업에서 e2e 검증 (현 PR 범위 외)

## 관련

- 발견 경위: #178 후속으로 동일 패턴(모델 인스턴스를 firestore write에 그대로 전달) 전수조사 중 부수 발견. 본 결함은 #178과 무관한 별개 결함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)