### PR TITLE
[#194] OAuth cleanup 함수 IAM 격리 — named admin app + repository 의존성 주입

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -16,10 +16,14 @@ const isEmulator = process.env.FUNCTIONS_EMULATOR === 'true';
 if (isEmulator) {
     require('dotenv').config({ path: './secrets/.env.test' });
     initializeApp();
+    initializeApp(undefined, 'cleanup-app');
 } else {
     const serviceAccount = require('./secrets/todocalendar-serviceAccountKey.json');
     require('dotenv').config({ path: './secrets/.env' });
     initializeApp({ credential: cert(serviceAccount) });
+    // cleanup 함수 전용 named app — credentials 미지정 = ADC (runtime SA credentials).
+    // production 에선 oauth-cleanup SA 의 권한으로 Firestore 접근 (issue #194 IAM 격리).
+    initializeApp({ projectId: process.env.GCLOUD_PROJECT }, 'cleanup-app');
 }
 getFirestore().settings({ignoreUndefinedProperties: true});
 

--- a/functions/repositories/oauth/oauthClientRepository.js
+++ b/functions/repositories/oauth/oauthClientRepository.js
@@ -1,19 +1,22 @@
-const { getFirestore } = require('firebase-admin/firestore');
 const { randomUUID } = require('crypto');
 const OAuthClient = require('../../models/oauth/OAuthClient');
 
-const db = getFirestore();
-const collectionRef = db.collection('oauth_clients');
-
 class OAuthClientRepository {
+
+    // db 는 firebase-admin/firestore 의 Firestore instance — 의존성 주입.
+    // 의도: cleanup 함수가 별도 admin app (cleanup-app) 의 firestore 로 접근 가능 → SA 권한 격리 (issue #194).
+    constructor(db) {
+        this.db = db;
+        this.collectionRef = db.collection('oauth_clients');
+    }
 
     async create(plainData) {
         // create 는 저장 + 다시 read → model 인스턴스 반환 (read-after-write).
         // service 측이 별도 findById 호출 안 해도 stored 최종값 (Firestore admin SDK 의 타입 변환 / 향후 자동 필드 추가 포함) 반영된 model 을 받음.
         try {
             const id = randomUUID();
-            await collectionRef.doc(id).set({ ...plainData });
-            const snap = await collectionRef.doc(id).get();
+            await this.collectionRef.doc(id).set({ ...plainData });
+            const snap = await this.collectionRef.doc(id).get();
             return OAuthClient.fromData(snap.id, snap.data());
         } catch (error) {
             throw { status: 500, message: error?.message || error };
@@ -22,7 +25,7 @@ class OAuthClientRepository {
 
     async findById(id) {
         try {
-            const snap = await collectionRef.doc(id).get();
+            const snap = await this.collectionRef.doc(id).get();
             if (!snap.exists) return null;
             return OAuthClient.fromData(snap.id, snap.data());
         } catch (error) {
@@ -34,7 +37,7 @@ class OAuthClientRepository {
         try {
             // orderBy createdAt desc — 같은 hash 가 누적되면 가장 최근 record 반환 (결정적 동작).
             // Firestore composite index 필요 (firestore.indexes.json 참조).
-            const query = collectionRef
+            const query = this.collectionRef
                 .where('dedupHash', '==', hash)
                 .orderBy('createdAt', 'desc')
                 .limit(1);
@@ -49,7 +52,7 @@ class OAuthClientRepository {
 
     async markUsed(id, timestamp = Date.now()) {
         try {
-            await collectionRef.doc(id).update({ lastUsedAt: timestamp });
+            await this.collectionRef.doc(id).update({ lastUsedAt: timestamp });
         } catch (error) {
             throw { status: 500, message: error?.message || error };
         }
@@ -57,8 +60,8 @@ class OAuthClientRepository {
 
     async deleteIfUnused(id, beforeTimestamp) {
         try {
-            return await db.runTransaction(async (tx) => {
-                const ref = collectionRef.doc(id);
+            return await this.db.runTransaction(async (tx) => {
+                const ref = this.collectionRef.doc(id);
                 const snap = await tx.get(ref);
                 if (!snap.exists) return false;
                 const data = snap.data();
@@ -74,7 +77,7 @@ class OAuthClientRepository {
 
     async findUnusedBefore(beforeTimestamp, limit = 100) {
         try {
-            const query = collectionRef
+            const query = this.collectionRef
                 .where('lastUsedAt', '==', null)
                 .where('createdAt', '<', beforeTimestamp)
                 .limit(limit);

--- a/functions/routes/oauth/authorizeRoutes.js
+++ b/functions/routes/oauth/authorizeRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { getAuth } = require('firebase-admin/auth');
+const { getFirestore } = require('firebase-admin/firestore');
 const router = express.Router();
 
 const OAuthClientRepository = require('../../repositories/oauth/oauthClientRepository');
@@ -12,7 +13,7 @@ const noCache = require('../../middlewares/oauth/noCache');
 
 router.use(noCache);
 
-const clientRepo = new OAuthClientRepository();
+const clientRepo = new OAuthClientRepository(getFirestore());
 const challengeRepo = new ConsentChallengeRepository();
 const codeRepo = new AuthorizationCodeRepository();
 

--- a/functions/routes/oauth/registerRoutes.js
+++ b/functions/routes/oauth/registerRoutes.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { getFirestore } = require('firebase-admin/firestore');
 const router = express.Router();
 
 const OAuthClientRepository = require('../../repositories/oauth/oauthClientRepository');
@@ -10,7 +11,7 @@ const noCache = require('../../middlewares/oauth/noCache');
 
 router.use(noCache);
 
-const clientRepo = new OAuthClientRepository();
+const clientRepo = new OAuthClientRepository(getFirestore());
 const rateLimitRepo = new RateLimitRepository();
 const clientService = new OAuthClientService(clientRepo);
 const controller = new RegisterController(clientService);

--- a/functions/scheduled/oauthClientCleanup.js
+++ b/functions/scheduled/oauthClientCleanup.js
@@ -1,17 +1,26 @@
 const { onSchedule } = require('firebase-functions/v2/scheduler');
+const { getApp } = require('firebase-admin/app');
+const { getFirestore } = require('firebase-admin/firestore');
 const logger = require('firebase-functions/logger');
 
 const SCHEDULE_DAYS = parseInt(process.env.OAUTH_CLIENT_CLEANUP_AGE_DAYS ?? '30', 10);
 
+// production 에선 OAUTH_CLEANUP_SERVICE_ACCOUNT env 로 격리 SA (oauth-cleanup@...) 명시.
+// 미설정 (emulator / 로컬 dev) 이면 default runtime SA 사용 (격리 효과 X, dev 전용).
+const CLEANUP_SERVICE_ACCOUNT = process.env.OAUTH_CLEANUP_SERVICE_ACCOUNT;
+
 module.exports = onSchedule({
     schedule: 'every 24 hours',
-    timeZone: 'Asia/Seoul'
+    timeZone: 'Asia/Seoul',
+    ...(CLEANUP_SERVICE_ACCOUNT ? { serviceAccount: CLEANUP_SERVICE_ACCOUNT } : {})
 }, async () => {
     // lazy require: 함수 인스턴스 콜드 스타트 시 Firebase Admin SDK 가 이미 init 된 상태에서 평가
     const OAuthClientRepository = require('../repositories/oauth/oauthClientRepository');
     const OAuthClientCleanupService = require('../services/oauth/oauthClientCleanupService');
 
-    const repo = new OAuthClientRepository();
+    // cleanup-app named instance 의 firestore — credentials 가 runtime SA 로 격리됨 (issue #194).
+    const cleanupDb = getFirestore(getApp('cleanup-app'));
+    const repo = new OAuthClientRepository(cleanupDb);
     const svc = new OAuthClientCleanupService(repo, SCHEDULE_DAYS);
     const deleted = await svc.cleanupUnusedClients();
     logger.info(`oauth_client_cleanup: deleted ${deleted.length} unused clients (age > ${SCHEDULE_DAYS}d)`);

--- a/functions/test/doubles/stubOAuthRepositories.js
+++ b/functions/test/doubles/stubOAuthRepositories.js
@@ -6,7 +6,8 @@ const AuthorizationCode = require('../../models/oauth/AuthorizationCode');
 
 class StubOAuthClientRepository {
 
-    constructor() {
+    // production repo 와 시그니처 호환 — db 인자 받지만 in-memory 라 무시.
+    constructor(_db) {
         this.store = new Map();
         this.shouldFailCreate = false;
         this.shouldFailFindById = false;


### PR DESCRIPTION
## Summary

Issue #194 — `oauthClientCleanup` scheduled function 의 권한 범위 격리. 현재 `cert(serviceAccount)` 의 광범위 Firestore admin 권한이 cleanup 함수 process 에 박혀, 코드 compromise 시 모든 collection (todos / schedules / users / event_tags 등) 영향 가능. 본 PR 은 named admin app + IAM 분리로 blast radius 를 `oauth_clients` collection 안으로 축소.

## 격리 메커니즘

같은 Firestore DB 인데 cleanup 함수만 **다른 자격 증명 (credentials)** 사용 → 자격 증명에 박힌 IAM 권한 범위로 접근 제어:

- **default app** (다른 함수들) — `cert(serviceAccount)` → service account JSON key 의 광범위 권한
- **cleanup-app** (이 함수만) — `initializeApp({...}, 'cleanup-app')` → credentials 미지정 = ADC (Cloud Run runtime SA credentials)

production 에선 runtime SA = `oauth-cleanup@todocalendar-1707723626269.iam.gserviceaccount.com` 으로 격리. `roles/datastore.user` 만 grant.

## 변경

| 파일 | 변경 |
|---|---|
| `functions/index.js` | named admin app `cleanup-app` 추가 (production + emulator 양쪽) |
| `functions/repositories/oauth/oauthClientRepository.js` | module-level db → constructor 의존성 주입 |
| `functions/routes/oauth/registerRoutes.js`, `authorizeRoutes.js` | `new OAuthClientRepository(getFirestore())` 명시 주입 |
| `functions/scheduled/oauthClientCleanup.js` | `getFirestore(getApp('cleanup-app'))` 주입 + `OAUTH_CLEANUP_SERVICE_ACCOUNT` env 반영 |
| `functions/test/doubles/stubOAuthRepositories.js` | constructor 시그니처 호환 (`_db` 받지만 무시) |

다른 oauth repo (consentChallenge / authorizationCode / rateLimit) 는 cleanup 함수가 안 쓰니까 본 PR 에선 그대로. 일관성 위해 같은 패턴 전파는 별도 ticket.

## 운영 작업 (PR 머지 후 사용자 직접)

\`\`\`bash
gcloud iam service-accounts create oauth-cleanup \
    --display-name="OAuth Cleanup Function" \
    --project=todocalendar-1707723626269

gcloud projects add-iam-policy-binding todocalendar-1707723626269 \
    --member="serviceAccount:oauth-cleanup@todocalendar-1707723626269.iam.gserviceaccount.com" \
    --role="roles/datastore.user"

gcloud projects add-iam-policy-binding todocalendar-1707723626269 \
    --member="serviceAccount:oauth-cleanup@todocalendar-1707723626269.iam.gserviceaccount.com" \
    --role="roles/logging.logWriter"
\`\`\`

그 후 \`secrets/.env\` 에 추가:
\`\`\`
OAUTH_CLEANUP_SERVICE_ACCOUNT=oauth-cleanup@todocalendar-1707723626269.iam.gserviceaccount.com
\`\`\`

deploy: \`npm run deploy\` (현재 \`functions,hosting:api\` 묶음)

## Test plan

- [x] 847 단위 테스트 통과 (`npm test`)
- [x] 136 e2e 통과 (`npm run test:e2e:run`) — emulator 에서 cleanup 함수 require 흐름 + named app 분기 검증
- [ ] PR 머지 후 신규 SA 생성 + IAM grant
- [ ] `OAUTH_CLEANUP_SERVICE_ACCOUNT` env 등록 + deploy
- [ ] cleanup 함수 수동 trigger (또는 24시간 대기) → 로그 확인 (정상 동작 / PERMISSION_DENIED 없음)
- [ ] 다른 함수 영향 회귀 검증 — register / authorize 호출 정상

Closes #194