### PR TITLE
[#195] JWKS / metadata 응답에 Cache-Control: max-age=600 추가

### DIFF
--- a/functions/routes/oauth/wellKnownRoutes.js
+++ b/functions/routes/oauth/wellKnownRoutes.js
@@ -6,6 +6,13 @@ const WellKnownController = require('../../controllers/oauth/wellKnownController
 
 const controller = new WellKnownController(tokenSigningService);
 
+// JWKS / metadata 는 정적 public 데이터. RS / 프록시 캐시 활용해 부하 절감.
+// max-age=600 (10분) — 향후 key rotation 도입 시 조정. (issue #195)
+router.use((req, res, next) => {
+    res.set('Cache-Control', 'public, max-age=600');
+    next();
+});
+
 router.get('/oauth-authorization-server', async (req, res) => {
     await controller.getMetadata(req, res);
 });

--- a/functions/test/e2e/oauth.e2e.js
+++ b/functions/test/e2e/oauth.e2e.js
@@ -49,6 +49,7 @@ describe('OAuth AS — well-known', () => {
     it('GET /.well-known/oauth-authorization-server → RFC 8414 metadata', async () => {
         const res = await axios.get(`${BASE_URL}/.well-known/oauth-authorization-server`);
         assert.strictEqual(res.status, 200);
+        assert.strictEqual(res.headers['cache-control'], 'public, max-age=600');
         assert.strictEqual(res.data.issuer, process.env.OAUTH_ISSUER);
         assert.ok(res.data.authorization_endpoint.endsWith('/v1/oauth/authorize'));
         assert.ok(res.data.token_endpoint.endsWith('/v1/oauth/token'));
@@ -63,6 +64,7 @@ describe('OAuth AS — well-known', () => {
     it('GET /.well-known/jwks.json → RFC 7517 JWKS', async () => {
         const res = await axios.get(`${BASE_URL}/.well-known/jwks.json`);
         assert.strictEqual(res.status, 200);
+        assert.strictEqual(res.headers['cache-control'], 'public, max-age=600');
         assert.strictEqual(res.data.keys.length, 1);
         const k = res.data.keys[0];
         assert.strictEqual(k.kty, 'RSA');


### PR DESCRIPTION
## Summary

`/.well-known/jwks.json` 과 `/.well-known/oauth-authorization-server` 응답에 `Cache-Control: public, max-age=600` 헤더 추가. PR #190 2차 보안 리뷰 backlog (#195).

두 well-known endpoint 는 정적 public 데이터 (RSA public key 와 RFC 8414 metadata) — RS(MCP server) 와 reverse proxy 가 매 access_token 검증마다 fetch 하면 부하 누적. 명시적 캐시 헤더 없으면 클라/프록시 캐시 정책이 모호해 환경별 동작이 갈림.

## 변경

- `routes/oauth/wellKnownRoutes.js` — `router.use` 미들웨어로 두 endpoint 일괄 적용. 위치는 `noCache` 미들웨어와 같은 라우터 레벨이라 OAuth 동적 endpoint 의 `no-store` 정책과 분리가 명확.
- `test/e2e/oauth.e2e.js` — metadata / jwks 케이스 각각에 `res.headers['cache-control']` 단언 추가.

`max-age=600` (10분) 은 부하 절감과 향후 key rotation 시 stale window 의 절충값. 현재는 key rotation 정책 없음 (정적 키 운영).

## Test plan

- [x] 단위 테스트 847 통과
- [x] e2e 136 통과 (well-known 두 케이스 헤더 검증 포함)

Closes #195