### PR TITLE
[#196] OAUTH_ISSUER trailing slash 정규화

### DIFF
--- a/functions/services/oauth/tokenSigningService.js
+++ b/functions/services/oauth/tokenSigningService.js
@@ -9,7 +9,8 @@ class TokenSigningService {
         if (!issuer) throw new Error('OAUTH_ISSUER missing');
         this.privKeyPem = privKeyPem;
         this.pubKeyPem = pubKeyPem;
-        this.issuer = issuer;
+        // trailing slash 정규화 — metadata URL concat 시 double slash / JWT iss strict 비교 mismatch 방지. (issue #196)
+        this.issuer = issuer.replace(/\/+$/, '');
         this._privKey = null;
         this._pubKey = null;
         this._jwk = null;

--- a/functions/test/services/oauth/tokenSigningService.test.js
+++ b/functions/test/services/oauth/tokenSigningService.test.js
@@ -36,6 +36,15 @@ describe('services/oauth/TokenSigningService', () => {
         it('issuer 없으면 throw', () => {
             assert.throws(() => new TokenSigningService(privPem, pubPem, null), /ISSUER missing/);
         });
+
+        it('issuer trailing slash 제거', () => {
+            const s1 = new TokenSigningService(privPem, pubPem, 'https://x.example/');
+            assert.strictEqual(s1.issuer, 'https://x.example');
+            const s2 = new TokenSigningService(privPem, pubPem, 'https://x.example///');
+            assert.strictEqual(s2.issuer, 'https://x.example');
+            const s3 = new TokenSigningService(privPem, pubPem, 'https://x.example');
+            assert.strictEqual(s3.issuer, 'https://x.example');
+        });
     });
 
     describe('getMetadata', () => {
@@ -56,6 +65,16 @@ describe('services/oauth/TokenSigningService', () => {
         it('scopes_supported 가 KNOWN_SCOPES 와 일치', () => {
             const meta = svc.getMetadata();
             assert.deepStrictEqual(meta.scopes_supported.sort(), ['read:calendar', 'write:calendar']);
+        });
+
+        it('issuer trailing slash 박혀도 metadata URL double slash 없음', () => {
+            const slashSvc = new TokenSigningService(privPem, pubPem, 'https://x.example/');
+            const meta = slashSvc.getMetadata();
+            assert.strictEqual(meta.issuer, 'https://x.example');
+            assert.strictEqual(meta.authorization_endpoint, 'https://x.example/v1/oauth/authorize');
+            assert.strictEqual(meta.token_endpoint, 'https://x.example/v1/oauth/token');
+            assert.strictEqual(meta.registration_endpoint, 'https://x.example/v1/oauth/register');
+            assert.strictEqual(meta.jwks_uri, 'https://x.example/.well-known/jwks.json');
         });
     });
 

--- a/functions/test/services/oauth/tokenSigningService.test.js
+++ b/functions/test/services/oauth/tokenSigningService.test.js
@@ -140,6 +140,16 @@ describe('services/oauth/TokenSigningService', () => {
             assert.strictEqual(payload.scope, 'read:calendar write:calendar');
         });
 
+        it('issuer trailing slash 박혀도 JWT iss 클레임 정규화', async () => {
+            const slashSvc = new TokenSigningService(privPem, pubPem, 'https://x.example/');
+            const token = await slashSvc.signAccessToken({
+                sub: 'u', aud: 'a', scope: ['read:calendar'], clientId: 'c'
+            });
+            const pubKey = await jose.importSPKI(pubPem, 'RS256');
+            const { payload } = await jose.jwtVerify(token, pubKey, { issuer: 'https://x.example', audience: 'a' });
+            assert.strictEqual(payload.iss, 'https://x.example');
+        });
+
         it('ttlSeconds 기본값 30분 (1800s)', async () => {
             const before = Math.floor(Date.now() / 1000);
             const token = await svc.signAccessToken({


### PR DESCRIPTION
## Summary

`OAUTH_ISSUER` env 끝의 trailing slash 를 service constructor 에서 정규화. PR #190 2차 보안 backlog (#196).

## 배경

`OAUTH_ISSUER` 에 trailing slash 가 박히면 두 경로에서 문제:
- `getMetadata()` 가 \`\${issuer}/v1/oauth/authorize\` 처럼 raw concat → \`https://issuer//v1/oauth/authorize\` (double slash).
- `signAccessToken().setIssuer(issuer)` → JWT `iss` 클레임에 slash 가 그대로 들어가 RS(MCP server) strict 비교 시 mismatch 가능.

현재 prod env (`https://api.todo-calendar.com`, slash 없음) 는 즉시 영향 X — 운영 robust 차원.

## 변경

- `services/oauth/tokenSigningService.js` — constructor 에서 `issuer.replace(/\/+$/, '')`. 끝의 slash 1+ 제거. service 자체가 input 을 정규화하므로 어떤 entry 가 호출하든(현재는 `tokenSigningServiceInstance` 한 곳, 향후 e2e/스크립트가 직접 생성하더라도) 일관 동작.
- `test/services/oauth/tokenSigningService.test.js`
  - constructor 케이스: `/`, `///`, slash 없음 세 입력 → 모두 정규화된 issuer 저장.
  - getMetadata 케이스: trailing slash 박힌 issuer 가 `authorization_endpoint` / `token_endpoint` / `registration_endpoint` / `jwks_uri` 네 URL 에 double slash 만들지 않음.

## Test plan

- [x] 단위 테스트 849 통과 (신규 2 케이스 포함)
- 기존 e2e 는 정상 입력으로 backward compat 자연 확인 (정규화는 단위 커버)

Closes #196