### PR TITLE
[#202] Chunk 1 — access token TTL 30분 → 2시간 연장

### DIFF
--- a/functions/controllers/oauth/tokenController.js
+++ b/functions/controllers/oauth/tokenController.js
@@ -1,7 +1,8 @@
 const Errors = require('../../models/Errors');
 const { formatScopeArray } = require('../../models/oauth/scopes');
 
-const ACCESS_TOKEN_TTL_SECONDS = 1800;
+// 30분 (1800) → 2시간 (7200) 연장. LLM tool 호출 한 세션 끊김 완화. 자세한 결정 배경: issue #202
+const ACCESS_TOKEN_TTL_SECONDS = 7200;
 
 class TokenController {
 

--- a/functions/services/oauth/tokenSigningService.js
+++ b/functions/services/oauth/tokenSigningService.js
@@ -75,7 +75,7 @@ class TokenSigningService {
         };
     }
 
-    async signAccessToken({ sub, aud, scope, clientId, ttlSeconds = 1800 }) {
+    async signAccessToken({ sub, aud, scope, clientId, ttlSeconds = 7200 }) {
         const priv = await this._loadPriv();
         const kid = await this.getKid();
         return await new jose.SignJWT({ scope: formatScopeArray(scope), client_id: clientId })

--- a/functions/test/controllers/oauth/tokenController.test.js
+++ b/functions/test/controllers/oauth/tokenController.test.js
@@ -59,7 +59,7 @@ describe('controllers/oauth/TokenController', () => {
             assert.strictEqual(res._status, 200);
             assert.strictEqual(res._body.access_token, 'fake.jwt.user-1');
             assert.strictEqual(res._body.token_type, 'Bearer');
-            assert.strictEqual(res._body.expires_in, 1800);
+            assert.strictEqual(res._body.expires_in, 7200);
             assert.strictEqual(res._body.scope, 'read:calendar write:calendar');
         });
 
@@ -81,7 +81,7 @@ describe('controllers/oauth/TokenController', () => {
             assert.strictEqual(call.resource, 'r');
         });
 
-        it('signAccessToken 인자 (sub, aud, scope, clientId, ttlSeconds=1800)', async () => {
+        it('signAccessToken 인자 (sub, aud, scope, clientId, ttlSeconds=7200)', async () => {
             await controller.exchange({
                 body: {
                     grant_type: 'authorization_code',
@@ -95,7 +95,7 @@ describe('controllers/oauth/TokenController', () => {
             assert.strictEqual(call.aud, 'http://localhost:3000/mcp');
             assert.deepStrictEqual(call.scope, ['read:calendar', 'write:calendar']);
             assert.strictEqual(call.clientId, 'client-1');
-            assert.strictEqual(call.ttlSeconds, 1800);
+            assert.strictEqual(call.ttlSeconds, 7200);
         });
     });
 

--- a/functions/test/e2e/oauth.e2e.js
+++ b/functions/test/e2e/oauth.e2e.js
@@ -192,7 +192,7 @@ describe('OAuth AS — happy path (한 바퀴)', () => {
         assert.strictEqual(res.headers['pragma'], 'no-cache');
         assert.ok(res.data.access_token);
         assert.strictEqual(res.data.token_type, 'Bearer');
-        assert.strictEqual(res.data.expires_in, 1800);
+        assert.strictEqual(res.data.expires_in, 7200);
         assert.strictEqual(res.data.scope, 'read:calendar');
 
         // JWKS 로 verify

--- a/functions/test/services/oauth/tokenSigningService.test.js
+++ b/functions/test/services/oauth/tokenSigningService.test.js
@@ -150,14 +150,14 @@ describe('services/oauth/TokenSigningService', () => {
             assert.strictEqual(payload.iss, 'https://x.example');
         });
 
-        it('ttlSeconds 기본값 30분 (1800s)', async () => {
+        it('ttlSeconds 기본값 2시간 (7200s)', async () => {
             const before = Math.floor(Date.now() / 1000);
             const token = await svc.signAccessToken({
                 sub: 'u', aud: 'a', scope: ['read:calendar'], clientId: 'c'
             });
             const pubKey = await jose.importSPKI(pubPem, 'RS256');
             const { payload } = await jose.jwtVerify(token, pubKey, { issuer: ISSUER, audience: 'a' });
-            assert.ok(payload.exp - payload.iat === 1800, `exp - iat == 1800 (got ${payload.exp - payload.iat})`);
+            assert.ok(payload.exp - payload.iat === 7200, `exp - iat == 7200 (got ${payload.exp - payload.iat})`);
             assert.ok(payload.iat >= before);
         });
     });


### PR DESCRIPTION
## Summary

`#202` (OAuth access TTL 연장 + refresh + revocation 도입) 의 첫 단계. access_token TTL 만 30분(1800s) → 2시간(7200s) 으로 연장. refresh / revocation 본 구현은 같은 issue 의 후속 Chunk.

## 배경

본 AS 머지 시점 (#189) 결정값 = 30분. 운영 컨텍스트가 LLM tool 호출 (MCP RS) 이라 30분 만료 시 사용자가 consent 화면 빈번하게 보는 UX 결손. 자세한 결정 배경 / 옵션 검토는 issue #202 참고.

24시간 같은 long TTL 은 *access blocklist 도입* 과 stateless 정당화가 충돌해 제외. 단기에 2시간으로 부분 완화 → 후속 Chunk 에서 refresh + revocation (refresh 만 회수) 으로 표준 OAuth 패턴 마무리.

## 변경

- `controllers/oauth/tokenController.js` — `ACCESS_TOKEN_TTL_SECONDS` 1800 → 7200. token endpoint 응답의 `expires_in` 도 같이 7200.
- `services/oauth/tokenSigningService.js` — `signAccessToken` default `ttlSeconds` 1800 → 7200. controller 가 명시값 주입하지만 단위 테스트가 default 검증 + 향후 직접 호출 일관성 위해 동시 변경.
- `test/controllers/oauth/tokenController.test.js` — `expires_in` / `signAccessToken` 인자 케이스 갱신.
- `test/services/oauth/tokenSigningService.test.js` — '기본값 30분 (1800s)' 케이스 → '2시간 (7200s)' 갱신.
- `test/e2e/oauth.e2e.js` — `POST /v1/oauth/token` 응답 단언 갱신.

## MCP / 외부 영향

- access_token `exp - iat == 7200`. MCP RS 측은 단순히 JWT verify 만 하므로 코드 변경 X. 자체 캐시 정책에 만료 반영만 하면 OK.
- 호환성 깨짐 X (응답 형식 동일, TTL 값만 길어짐).

## Test plan

- [x] 단위 테스트 850 통과
- [x] e2e 136 통과

Refs #202 (Chunk 1)