### PR TITLE
[#202] Chunk 2+3 — refresh_token 발급/회전/재사용 detect

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,14 @@
         { "fieldPath": "lastUsedAt", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "oauth_refresh_tokens",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "family", "order": "ASCENDING" },
+        { "fieldPath": "revokedAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/controllers/oauth/tokenController.js
+++ b/functions/controllers/oauth/tokenController.js
@@ -6,20 +6,29 @@ const ACCESS_TOKEN_TTL_SECONDS = 7200;
 
 class TokenController {
 
-    constructor(codeService, tokenSigningService) {
+    constructor(codeService, tokenSigningService, refreshTokenService) {
         if (!codeService) throw new Error('TokenController: codeService required');
         if (!tokenSigningService) throw new Error('TokenController: tokenSigningService required');
+        if (!refreshTokenService) throw new Error('TokenController: refreshTokenService required');
         this.codeService = codeService;
         this.tokenSigningService = tokenSigningService;
+        this.refreshTokenService = refreshTokenService;
     }
 
     async exchange(req, res) {
         const body = req.body ?? {};
         const grantType = body.grant_type;
-        if (grantType !== 'authorization_code') {
-            throw new Errors.Base(400, 'UnsupportedGrantType', `grant_type=${grantType} not supported`);
-        }
 
+        if (grantType === 'authorization_code') {
+            return await this._exchangeAuthorizationCode(body, res);
+        }
+        if (grantType === 'refresh_token') {
+            return await this._exchangeRefreshToken(body, res);
+        }
+        throw new Errors.Base(400, 'UnsupportedGrantType', `grant_type=${grantType} not supported`);
+    }
+
+    async _exchangeAuthorizationCode(body, res) {
         const input = {
             code: body.code,
             codeVerifier: body.code_verifier,
@@ -37,11 +46,44 @@ class TokenController {
                 clientId,
                 ttlSeconds: ACCESS_TOKEN_TTL_SECONDS
             });
+            // refresh_token 도 같이 발급 — 새 사용자 인증이라 새 family chain 시작
+            const refreshToken = await this.refreshTokenService.issueForUser({
+                userId, clientId, scope, resource, redirectUri: input.redirectUri
+            });
             res.status(200).json({
                 access_token: accessToken,
                 token_type: 'Bearer',
                 expires_in: ACCESS_TOKEN_TTL_SECONDS,
-                scope: formatScopeArray(scope)
+                scope: formatScopeArray(scope),
+                refresh_token: refreshToken.id
+            });
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async _exchangeRefreshToken(body, res) {
+        const refreshTokenId = body.refresh_token;
+        const clientId = body.client_id;
+        const resource = body.resource;
+
+        try {
+            const rotated = await this.refreshTokenService.rotate({
+                refreshTokenId, clientId, resource
+            });
+            const accessToken = await this.tokenSigningService.signAccessToken({
+                sub: rotated.userId,
+                aud: rotated.resource,
+                scope: rotated.scope,
+                clientId: rotated.clientId,
+                ttlSeconds: ACCESS_TOKEN_TTL_SECONDS
+            });
+            res.status(200).json({
+                access_token: accessToken,
+                token_type: 'Bearer',
+                expires_in: ACCESS_TOKEN_TTL_SECONDS,
+                scope: formatScopeArray(rotated.scope),
+                refresh_token: rotated.id
             });
         } catch (error) {
             throw new Errors.Application(error);

--- a/functions/controllers/oauth/tokenController.js
+++ b/functions/controllers/oauth/tokenController.js
@@ -67,6 +67,14 @@ class TokenController {
         const clientId = body.client_id;
         const resource = body.resource;
 
+        // body sanity — 누락 시 service 의 클레임 mismatch 메시지로 빠져 디버깅 혼란. controller 가 먼저 거름.
+        if (typeof refreshTokenId !== 'string' || refreshTokenId.length === 0) {
+            throw new Errors.Base(400, 'InvalidRequest', 'refresh_token required');
+        }
+        if (typeof clientId !== 'string' || clientId.length === 0) {
+            throw new Errors.Base(400, 'InvalidRequest', 'client_id required');
+        }
+
         try {
             const rotated = await this.refreshTokenService.rotate({
                 refreshTokenId, clientId, resource

--- a/functions/models/oauth/RefreshToken.js
+++ b/functions/models/oauth/RefreshToken.js
@@ -1,0 +1,41 @@
+class RefreshToken {
+
+    constructor({
+        id, userId, clientId, scope, resource, redirectUri,
+        family, parentId,
+        createdAt, expiresAt, revokedAt
+    }) {
+        this.id = id;
+        this.userId = userId;
+        this.clientId = clientId;
+        this.scope = scope;
+        this.resource = resource;
+        this.redirectUri = redirectUri;
+        // rotation chain — 한 번의 사용자 인증에서 파생된 모든 refresh token 이 같은 family 공유.
+        // reuse detect 시 family 전체 revoke 로 탈취 차단.
+        this.family = family;
+        this.parentId = parentId ?? null;   // 첫 발급은 null
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+        this.revokedAt = revokedAt ?? null;
+    }
+
+    static fromData(id, data) {
+        return new RefreshToken({ id, ...data });
+    }
+
+    isExpired(now = Date.now()) {
+        const expMs = this.expiresAt instanceof Date ? this.expiresAt.getTime() : this.expiresAt;
+        return now >= expMs;
+    }
+
+    isRevoked() {
+        return this.revokedAt != null;
+    }
+
+    isValid(now = Date.now()) {
+        return !this.isRevoked() && !this.isExpired(now);
+    }
+}
+
+module.exports = RefreshToken;

--- a/functions/repositories/oauth/refreshTokenRepository.js
+++ b/functions/repositories/oauth/refreshTokenRepository.js
@@ -72,10 +72,9 @@ class RefreshTokenRepository {
         }
     }
 
-    async findExpiredOrRevokedBefore(beforeTimestamp, limit = 100) {
-        // cleanup 용 — expired 또는 revoked 된 token 중 일정 시간 지난 것 조회.
-        // Firestore 단일 쿼리로 두 조건 OR 불가 → 호출자가 두 번 조회 후 머지 (또는 schedule cleanup 에서 분리 실행).
-        // 본 메소드는 expired 만 우선 (단순). revoked grace 정리는 별 메소드 또는 후속.
+    async findExpiredBefore(beforeTimestamp, limit = 100) {
+        // cleanup 용 — expiresAt 기준 만료된 token 조회. revoked grace 정리는 별 메소드 (후속) 로 분리.
+        // Firestore 가 (expiresAt < X) OR (revokedAt 박힘 + revokedAt < Y) 같은 OR 쿼리 미지원 → 두 메소드 분리가 자연.
         try {
             const snap = await collectionRef
                 .where('expiresAt', '<', beforeTimestamp)

--- a/functions/repositories/oauth/refreshTokenRepository.js
+++ b/functions/repositories/oauth/refreshTokenRepository.js
@@ -1,0 +1,100 @@
+const { getFirestore } = require('firebase-admin/firestore');
+const { randomBytes } = require('crypto');
+const RefreshToken = require('../../models/oauth/RefreshToken');
+
+const db = getFirestore();
+const collectionRef = db.collection('oauth_refresh_tokens');
+
+class RefreshTokenRepository {
+
+    async create(plainData) {
+        // 저장 + read-after-write → RefreshToken model 반환 (authorizationCodeRepository.create 와 동일 contract).
+        // id 는 opaque random (32바이트 hex). JWT 아님 — Firestore 저장으로 rotation/revocation 매커니즘 자연스러움.
+        try {
+            const id = randomBytes(32).toString('hex');
+            await collectionRef.doc(id).set({ ...plainData });
+            const snap = await collectionRef.doc(id).get();
+            return RefreshToken.fromData(snap.id, snap.data());
+        } catch (error) {
+            throw { status: 500, message: error?.message || error };
+        }
+    }
+
+    async findById(id) {
+        try {
+            const snap = await collectionRef.doc(id).get();
+            if (!snap.exists) return null;
+            return RefreshToken.fromData(snap.id, snap.data());
+        } catch (error) {
+            throw { status: 500, message: error?.message || error };
+        }
+    }
+
+    async markRevoked(id, now = Date.now()) {
+        // 단일 token 회수. 정상 rotation 시 옛 token invalidate / revocation endpoint 단일 호출 시 사용.
+        // 트랜잭션으로 race-safe — 이미 revoked 면 false 반환 (멱등).
+        try {
+            return await db.runTransaction(async (tx) => {
+                const ref = collectionRef.doc(id);
+                const snap = await tx.get(ref);
+                if (!snap.exists) {
+                    const e = new Error('RefreshToken not found');
+                    e.status = 404;
+                    throw e;
+                }
+                if (snap.data().revokedAt != null) return false;
+                tx.update(ref, { revokedAt: now });
+                return true;
+            });
+        } catch (error) {
+            if (error?.status === 404) throw error;
+            throw { status: 500, message: error?.message || error };
+        }
+    }
+
+    async revokeFamily(family, now = Date.now()) {
+        // reuse detect / 사용자 권한 철회 시 family 전체 일괄 회수. revokedAt 박힌 token 은 건너뜀 (멱등).
+        // 반환: 새로 revoke 된 token 개수.
+        try {
+            const snap = await collectionRef
+                .where('family', '==', family)
+                .where('revokedAt', '==', null)
+                .get();
+            if (snap.empty) return 0;
+            const batch = db.batch();
+            for (const doc of snap.docs) {
+                batch.update(doc.ref, { revokedAt: now });
+            }
+            await batch.commit();
+            return snap.size;
+        } catch (error) {
+            throw { status: 500, message: error?.message || error };
+        }
+    }
+
+    async findExpiredOrRevokedBefore(beforeTimestamp, limit = 100) {
+        // cleanup 용 — expired 또는 revoked 된 token 중 일정 시간 지난 것 조회.
+        // Firestore 단일 쿼리로 두 조건 OR 불가 → 호출자가 두 번 조회 후 머지 (또는 schedule cleanup 에서 분리 실행).
+        // 본 메소드는 expired 만 우선 (단순). revoked grace 정리는 별 메소드 또는 후속.
+        try {
+            const snap = await collectionRef
+                .where('expiresAt', '<', beforeTimestamp)
+                .limit(limit)
+                .get();
+            return snap.docs.map(doc => RefreshToken.fromData(doc.id, doc.data()));
+        } catch (error) {
+            throw { status: 500, message: error?.message || error };
+        }
+    }
+
+    async deleteById(id) {
+        // cleanup 시 사용 — Firestore TTL policy 가 비호환(expiresAt number)일 동안 대체.
+        try {
+            await collectionRef.doc(id).delete();
+        } catch (error) {
+            throw { status: 500, message: error?.message || error };
+        }
+    }
+}
+
+module.exports = RefreshTokenRepository;

--- a/functions/routes/oauth/tokenRoutes.js
+++ b/functions/routes/oauth/tokenRoutes.js
@@ -2,7 +2,9 @@ const express = require('express');
 const router = express.Router();
 
 const AuthorizationCodeRepository = require('../../repositories/oauth/authorizationCodeRepository');
+const RefreshTokenRepository = require('../../repositories/oauth/refreshTokenRepository');
 const AuthorizationCodeService = require('../../services/oauth/authorizationCodeService');
+const RefreshTokenService = require('../../services/oauth/refreshTokenService');
 const tokenSigningService = require('../../services/oauth/tokenSigningServiceInstance');
 const TokenController = require('../../controllers/oauth/tokenController');
 const noCache = require('../../middlewares/oauth/noCache');
@@ -12,7 +14,10 @@ router.use(noCache);
 const codeRepo = new AuthorizationCodeRepository();
 const codeService = new AuthorizationCodeService(codeRepo, 300);
 
-const controller = new TokenController(codeService, tokenSigningService);
+const refreshRepo = new RefreshTokenRepository();
+const refreshService = new RefreshTokenService(refreshRepo);   // default TTL = 30일
+
+const controller = new TokenController(codeService, tokenSigningService, refreshService);
 
 router.post('/', async (req, res) => {
     await controller.exchange(req, res);

--- a/functions/services/oauth/refreshTokenService.js
+++ b/functions/services/oauth/refreshTokenService.js
@@ -1,0 +1,108 @@
+const { randomUUID } = require('crypto');
+const Errors = require('../../models/Errors');
+
+const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60;   // 30일 absolute
+
+class RefreshTokenService {
+
+    constructor(repository, ttlSeconds = DEFAULT_TTL_SECONDS) {
+        if (!repository) throw new Error('RefreshTokenService: repository required');
+        this.repository = repository;
+        this.ttlSeconds = ttlSeconds;
+    }
+
+    // 새 사용자 인증 (authorization_code grant) 직후 — 새 family chain 시작
+    async issueForUser({ userId, clientId, scope, resource, redirectUri }) {
+        const required = { userId, clientId, resource, redirectUri };
+        for (const [k, v] of Object.entries(required)) {
+            if (typeof v !== 'string' || v.length === 0) {
+                throw new Errors.Base(400, 'InvalidRequest', `${k} required`);
+            }
+        }
+        if (!Array.isArray(scope) || scope.length === 0) {
+            throw new Errors.Base(400, 'InvalidRequest', 'scope required (non-empty array)');
+        }
+
+        const now = Date.now();
+        return await this.repository.create({
+            userId,
+            clientId,
+            scope,
+            resource,
+            redirectUri,
+            family: randomUUID(),
+            parentId: null,
+            createdAt: now,
+            expiresAt: now + this.ttlSeconds * 1000,
+            revokedAt: null
+        });
+    }
+
+    // refresh_token grant — 옛 token 검증 후 새 token 발급. rotation chain 확장.
+    // 핵심: 옛 token 이 이미 revoked 면 reuse 의심 → family 전체 revoke 후 reject (탈취 차단).
+    async rotate({ refreshTokenId, clientId, resource }) {
+        if (typeof refreshTokenId !== 'string' || refreshTokenId.length === 0) {
+            throw new Errors.Base(400, 'InvalidGrant', 'refresh_token required');
+        }
+
+        const stored = await this.repository.findById(refreshTokenId);
+        if (!stored) {
+            throw new Errors.Base(400, 'InvalidGrant', 'refresh_token not found');
+        }
+
+        // reuse detect — 이미 revoked 된 token 으로 refresh 시도. 정상 client 면 발생 안 함 → 탈취 신호.
+        if (stored.isRevoked()) {
+            await this.repository.revokeFamily(stored.family);
+            throw new Errors.Base(400, 'InvalidGrant', 'refresh_token reuse detected — family revoked');
+        }
+
+        if (stored.isExpired()) {
+            throw new Errors.Base(400, 'InvalidGrant', 'refresh_token expired');
+        }
+
+        if (stored.clientId !== clientId) {
+            throw new Errors.Base(400, 'InvalidGrant', 'client_id mismatch');
+        }
+
+        // resource (audience) 일치 강제 — 호출자가 resource 를 지정한 경우만. token 발급 시점 값과 일치.
+        if (resource != null && stored.resource !== resource) {
+            throw new Errors.Base(400, 'InvalidGrant', 'resource mismatch');
+        }
+
+        // rotation 실행 순서: 옛 token markRevoked → 새 token 발급.
+        // markRevoked 가 false (이미 revoked) 면 race condition — 동시 두 요청 중 한 쪽만 통과해야 안전 → family revoke + reject.
+        const transitioned = await this.repository.markRevoked(stored.id);
+        if (!transitioned) {
+            await this.repository.revokeFamily(stored.family);
+            throw new Errors.Base(400, 'InvalidGrant', 'refresh_token already used — family revoked');
+        }
+
+        const now = Date.now();
+        const newToken = await this.repository.create({
+            userId: stored.userId,
+            clientId: stored.clientId,
+            scope: stored.scope,
+            resource: stored.resource,
+            redirectUri: stored.redirectUri,
+            family: stored.family,
+            parentId: stored.id,
+            createdAt: now,
+            expiresAt: now + this.ttlSeconds * 1000,
+            revokedAt: null
+        });
+        return newToken;
+    }
+
+    // RFC 7009 revocation endpoint 용 — 없거나 이미 revoked 여도 silent (caller 가 항상 200).
+    async revoke({ refreshTokenId }) {
+        if (typeof refreshTokenId !== 'string' || refreshTokenId.length === 0) return;
+        try {
+            await this.repository.markRevoked(refreshTokenId);
+        } catch (error) {
+            if (error?.status === 404) return;
+            throw error;
+        }
+    }
+}
+
+module.exports = RefreshTokenService;

--- a/functions/test/controllers/oauth/tokenController.test.js
+++ b/functions/test/controllers/oauth/tokenController.test.js
@@ -3,7 +3,7 @@ const TokenController = require('../../../controllers/oauth/tokenController');
 
 describe('controllers/oauth/TokenController', () => {
 
-    let codeService, signer, controller, res;
+    let codeService, signer, refreshSvc, controller, res;
 
     const makeRes = () => ({
         _status: null, _body: null,
@@ -28,18 +28,40 @@ describe('controllers/oauth/TokenController', () => {
             signCalls: [],
             async signAccessToken(p) { this.signCalls.push(p); return `fake.jwt.${p.sub}`; }
         };
-        controller = new TokenController(codeService, signer);
+        refreshSvc = {
+            issueCalls: [],
+            rotateCalls: [],
+            async issueForUser(p) {
+                this.issueCalls.push(p);
+                return { id: `refresh-issued-${this.issueCalls.length}` };
+            },
+            async rotate(p) {
+                this.rotateCalls.push(p);
+                return {
+                    id: `refresh-rotated-${this.rotateCalls.length}`,
+                    userId: 'user-1',
+                    clientId: 'client-1',
+                    scope: ['read:calendar'],
+                    resource: 'http://localhost:3000/mcp'
+                };
+            }
+        };
+        controller = new TokenController(codeService, signer, refreshSvc);
         res = makeRes();
     });
 
     describe('constructor', () => {
 
         it('codeService 누락 → throw', () => {
-            assert.throws(() => new TokenController(null, signer));
+            assert.throws(() => new TokenController(null, signer, refreshSvc));
         });
 
         it('tokenSigningService 누락 → throw', () => {
-            assert.throws(() => new TokenController(codeService, null));
+            assert.throws(() => new TokenController(codeService, null, refreshSvc));
+        });
+
+        it('refreshTokenService 누락 → throw', () => {
+            assert.throws(() => new TokenController(codeService, signer, null));
         });
     });
 
@@ -61,6 +83,24 @@ describe('controllers/oauth/TokenController', () => {
             assert.strictEqual(res._body.token_type, 'Bearer');
             assert.strictEqual(res._body.expires_in, 7200);
             assert.strictEqual(res._body.scope, 'read:calendar write:calendar');
+            assert.strictEqual(res._body.refresh_token, 'refresh-issued-1');
+        });
+
+        it('authorization_code grant 시 refreshTokenService.issueForUser 호출 — userId/clientId/scope/resource/redirectUri 전달', async () => {
+            await controller.exchange({
+                body: {
+                    grant_type: 'authorization_code',
+                    code: 'c', code_verifier: 'v',
+                    redirect_uri: 'http://127.0.0.1:1/cb',
+                    client_id: 'cli', resource: 'res'
+                }
+            }, res);
+            const call = refreshSvc.issueCalls[0];
+            assert.strictEqual(call.userId, 'user-1');
+            assert.strictEqual(call.clientId, 'client-1');
+            assert.deepStrictEqual(call.scope, ['read:calendar', 'write:calendar']);
+            assert.strictEqual(call.resource, 'http://localhost:3000/mcp');
+            assert.strictEqual(call.redirectUri, 'http://127.0.0.1:1/cb');
         });
 
         it('snake_case body → camelCase service input', async () => {
@@ -145,6 +185,74 @@ describe('controllers/oauth/TokenController', () => {
                     }
                 }, res),
                 e => e.status === 500
+            );
+        });
+    });
+
+    describe('exchange — refresh_token grant', () => {
+
+        it('200 + 새 access_token + 새 refresh_token (rotation)', async () => {
+            await controller.exchange({
+                body: {
+                    grant_type: 'refresh_token',
+                    refresh_token: 'old-refresh',
+                    client_id: 'client-1',
+                    resource: 'http://localhost:3000/mcp'
+                }
+            }, res);
+            assert.strictEqual(res._status, 200);
+            assert.strictEqual(res._body.access_token, 'fake.jwt.user-1');
+            assert.strictEqual(res._body.token_type, 'Bearer');
+            assert.strictEqual(res._body.expires_in, 7200);
+            assert.strictEqual(res._body.scope, 'read:calendar');
+            assert.strictEqual(res._body.refresh_token, 'refresh-rotated-1');
+        });
+
+        it('refreshTokenService.rotate 인자 전달 (refreshTokenId / clientId / resource)', async () => {
+            await controller.exchange({
+                body: {
+                    grant_type: 'refresh_token',
+                    refresh_token: 'rid',
+                    client_id: 'cli',
+                    resource: 'res'
+                }
+            }, res);
+            const call = refreshSvc.rotateCalls[0];
+            assert.strictEqual(call.refreshTokenId, 'rid');
+            assert.strictEqual(call.clientId, 'cli');
+            assert.strictEqual(call.resource, 'res');
+        });
+
+        it('signAccessToken 가 rotated token 의 사용자/scope/resource 사용', async () => {
+            await controller.exchange({
+                body: {
+                    grant_type: 'refresh_token',
+                    refresh_token: 'rid', client_id: 'cli', resource: 'res'
+                }
+            }, res);
+            const call = signer.signCalls[0];
+            assert.strictEqual(call.sub, 'user-1');
+            assert.strictEqual(call.aud, 'http://localhost:3000/mcp');
+            assert.deepStrictEqual(call.scope, ['read:calendar']);
+            assert.strictEqual(call.clientId, 'client-1');
+            assert.strictEqual(call.ttlSeconds, 7200);
+        });
+
+        it('refresh service InvalidGrant → status 유지 (Application wrap)', async () => {
+            refreshSvc.rotate = async () => {
+                const e = new Error('reuse detected');
+                e.status = 400;
+                e.code = 'InvalidGrant';
+                throw e;
+            };
+            await assert.rejects(
+                () => controller.exchange({
+                    body: {
+                        grant_type: 'refresh_token',
+                        refresh_token: 'rid', client_id: 'cli', resource: 'res'
+                    }
+                }, res),
+                e => e.status === 400 && e.code === 'InvalidGrant'
             );
         });
     });

--- a/functions/test/controllers/oauth/tokenController.test.js
+++ b/functions/test/controllers/oauth/tokenController.test.js
@@ -238,6 +238,26 @@ describe('controllers/oauth/TokenController', () => {
             assert.strictEqual(call.ttlSeconds, 7200);
         });
 
+        it('refresh_token 누락 → 400 InvalidRequest (service 호출 전 거름)', async () => {
+            await assert.rejects(
+                () => controller.exchange({
+                    body: { grant_type: 'refresh_token', client_id: 'cli' }
+                }, res),
+                e => e.status === 400 && e.code === 'InvalidRequest' && /refresh_token/.test(e.message)
+            );
+            assert.strictEqual(refreshSvc.rotateCalls.length, 0, 'service 호출되지 않아야');
+        });
+
+        it('client_id 누락 → 400 InvalidRequest (service 호출 전 거름)', async () => {
+            await assert.rejects(
+                () => controller.exchange({
+                    body: { grant_type: 'refresh_token', refresh_token: 'rid' }
+                }, res),
+                e => e.status === 400 && e.code === 'InvalidRequest' && /client_id/.test(e.message)
+            );
+            assert.strictEqual(refreshSvc.rotateCalls.length, 0, 'service 호출되지 않아야');
+        });
+
         it('refresh service InvalidGrant → status 유지 (Application wrap)', async () => {
             refreshSvc.rotate = async () => {
                 const e = new Error('reuse detected');

--- a/functions/test/doubles/stubOAuthRepositories.js
+++ b/functions/test/doubles/stubOAuthRepositories.js
@@ -225,7 +225,7 @@ class StubRefreshTokenRepository {
         return revoked;
     }
 
-    async findExpiredOrRevokedBefore(beforeTimestamp, limit = 100) {
+    async findExpiredBefore(beforeTimestamp, limit = 100) {
         const results = [];
         for (const [id, data] of this.store.entries()) {
             if (!(data.expiresAt < beforeTimestamp)) continue;

--- a/functions/test/doubles/stubOAuthRepositories.js
+++ b/functions/test/doubles/stubOAuthRepositories.js
@@ -1,6 +1,7 @@
 const OAuthClient = require('../../models/oauth/OAuthClient');
 const ConsentChallenge = require('../../models/oauth/ConsentChallenge');
 const AuthorizationCode = require('../../models/oauth/AuthorizationCode');
+const RefreshToken = require('../../models/oauth/RefreshToken');
 
 // MARK: - OAuthClient
 
@@ -167,6 +168,90 @@ class StubAuthorizationCodeRepository {
     }
 }
 
+// MARK: - RefreshToken
+
+class StubRefreshTokenRepository {
+
+    constructor() {
+        this.store = new Map();
+        this.shouldFailCreate = false;
+        this.nextId = null;
+        this.lastCreatedPayload = null;
+        this.markRevokedCalls = [];
+        this.revokeFamilyCalls = [];
+        this.deleteCalls = [];
+    }
+
+    async create(plainData) {
+        if (this.shouldFailCreate) throw { status: 500, message: 'failed' };
+        const id = this.nextId ?? `refresh-${this.store.size + 1}`;
+        this.nextId = null;
+        const docData = { ...plainData };
+        this.store.set(id, docData);
+        this.lastCreatedPayload = { id, ...docData };
+        return RefreshToken.fromData(id, docData);
+    }
+
+    async findById(id) {
+        const data = this.store.get(id);
+        if (!data) return null;
+        return RefreshToken.fromData(id, data);
+    }
+
+    async markRevoked(id, now = Date.now()) {
+        const data = this.store.get(id);
+        if (!data) {
+            const e = new Error('RefreshToken not found');
+            e.status = 404;
+            throw e;
+        }
+        this.markRevokedCalls.push({ id, now });
+        if (data.revokedAt != null) return false;
+        data.revokedAt = now;
+        this.store.set(id, data);
+        return true;
+    }
+
+    async revokeFamily(family, now = Date.now()) {
+        this.revokeFamilyCalls.push({ family, now });
+        let revoked = 0;
+        for (const [id, data] of this.store.entries()) {
+            if (data.family !== family) continue;
+            if (data.revokedAt != null) continue;
+            data.revokedAt = now;
+            this.store.set(id, data);
+            revoked += 1;
+        }
+        return revoked;
+    }
+
+    async findExpiredOrRevokedBefore(beforeTimestamp, limit = 100) {
+        const results = [];
+        for (const [id, data] of this.store.entries()) {
+            if (!(data.expiresAt < beforeTimestamp)) continue;
+            results.push(RefreshToken.fromData(id, data));
+            if (results.length >= limit) break;
+        }
+        return results;
+    }
+
+    async deleteById(id) {
+        this.deleteCalls.push({ id });
+        this.store.delete(id);
+    }
+
+    // 테스트 헬퍼
+    seed(id, plainData) {
+        this.store.set(id, {
+            createdAt: Date.now(),
+            expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+            revokedAt: null,
+            parentId: null,
+            ...plainData
+        });
+    }
+}
+
 // MARK: - RateLimit
 
 class StubRateLimitRepository {
@@ -194,5 +279,6 @@ module.exports = {
     StubOAuthClientRepository,
     StubConsentChallengeRepository,
     StubAuthorizationCodeRepository,
+    StubRefreshTokenRepository,
     StubRateLimitRepository
 };

--- a/functions/test/e2e/oauth.e2e.js
+++ b/functions/test/e2e/oauth.e2e.js
@@ -127,7 +127,7 @@ describe('OAuth AS — register', () => {
 
 describe('OAuth AS — happy path (한 바퀴)', () => {
 
-    let clientId, redirectUri, verifier, challengeId, code;
+    let clientId, redirectUri, verifier, challengeId, code, refreshToken;
 
     it('1. register → client_id 발급', async () => {
         const { res, redirectUri: r } = await registerClient('Flow Client');
@@ -194,6 +194,8 @@ describe('OAuth AS — happy path (한 바퀴)', () => {
         assert.strictEqual(res.data.token_type, 'Bearer');
         assert.strictEqual(res.data.expires_in, 7200);
         assert.strictEqual(res.data.scope, 'read:calendar');
+        assert.ok(res.data.refresh_token, 'refresh_token 동시 발급');
+        refreshToken = res.data.refresh_token;
 
         // JWKS 로 verify
         const jwksRes = await axios.get(`${BASE_URL}/.well-known/jwks.json`);
@@ -208,6 +210,87 @@ describe('OAuth AS — happy path (한 바퀴)', () => {
         assert.ok(payload.sub);
         assert.strictEqual(payload.scope, 'read:calendar');
         assert.strictEqual(payload.client_id, clientId);
+    });
+
+    it('6. POST /token (grant_type=refresh_token) → 200 + 새 access_token + 새 refresh_token (rotation)', async () => {
+        const body = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: clientId,
+            resource: process.env.OAUTH_CALENDAR_RESOURCE_URI
+        });
+        const res = await axios.post(`${BASE_URL}/v1/oauth/token`, body.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(res.status, 200);
+        assert.ok(res.data.access_token);
+        assert.strictEqual(res.data.token_type, 'Bearer');
+        assert.strictEqual(res.data.expires_in, 7200);
+        assert.strictEqual(res.data.scope, 'read:calendar');
+        assert.ok(res.data.refresh_token, 'rotated refresh_token');
+        assert.notStrictEqual(res.data.refresh_token, refreshToken, 'rotation 으로 새 refresh_token 발급');
+        // 새 access_token 도 JWKS 로 verify
+        const jwksRes = await axios.get(`${BASE_URL}/.well-known/jwks.json`);
+        const jwk = jwksRes.data.keys[0];
+        const publicKey = await jose.importJWK(jwk, 'RS256');
+        const { payload } = await jose.jwtVerify(
+            res.data.access_token, publicKey,
+            { issuer: process.env.OAUTH_ISSUER, audience: process.env.OAUTH_CALENDAR_RESOURCE_URI }
+        );
+        assert.ok(payload.sub);
+        assert.strictEqual(payload.client_id, clientId);
+        // 다음 케이스가 쓰도록 새 refresh_token 으로 갱신
+        refreshToken = res.data.refresh_token;
+    });
+
+    it('7. 옛 refresh_token 으로 재사용 시도 → 400 InvalidGrant (reuse detect)', async () => {
+        // 단계 6 에서 rotation 후 옛 토큰은 revoked 상태. 공격자가 가로챈 옛 토큰으로 시도하는 시나리오.
+        // 본 테스트는 단계 5 시점의 refreshToken (이미 단계 6 에서 revoked) 을 다시 박는 게 정확하지만,
+        // 변수 갱신으로 단계 6 의 새 토큰을 한 번 더 rotate 해 직전 토큰을 revoke 후 옛 거 시도해도 같은 효과.
+        // 여기선 단계 6 결과 (rotation 1회 이미 완료) 의 그 직전 (already revoked) 토큰 검증 흐름이 단순치 않아,
+        // 새 시나리오로 1) rotate 한 번 → 2) 옛 거 재사용 흐름을 다시 박음.
+
+        // 1) 현재 refreshToken (단계 6 결과) 로 rotate → 새 refresh_token2
+        const body1 = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: clientId,
+            resource: process.env.OAUTH_CALENDAR_RESOURCE_URI
+        });
+        const res1 = await axios.post(`${BASE_URL}/v1/oauth/token`, body1.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(res1.status, 200);
+        const refreshToken2 = res1.data.refresh_token;
+        assert.notStrictEqual(refreshToken2, refreshToken);
+
+        // 2) 이제 옛 refreshToken (방금 rotate 로 revoked 됨) 으로 다시 시도 → 400 InvalidGrant
+        const body2 = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: clientId,
+            resource: process.env.OAUTH_CALENDAR_RESOURCE_URI
+        });
+        const res2 = await axios.post(`${BASE_URL}/v1/oauth/token`, body2.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(res2.status, 400);
+
+        // 3) family 가 revoke 됐으므로 refreshToken2 도 무력화 → 정상 client 도 더 못 씀
+        const body3 = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken2,
+            client_id: clientId,
+            resource: process.env.OAUTH_CALENDAR_RESOURCE_URI
+        });
+        const res3 = await axios.post(`${BASE_URL}/v1/oauth/token`, body3.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(res3.status, 400);
     });
 });
 

--- a/functions/test/models/oauth/RefreshToken.test.js
+++ b/functions/test/models/oauth/RefreshToken.test.js
@@ -1,0 +1,94 @@
+const assert = require('assert');
+const RefreshToken = require('../../../models/oauth/RefreshToken');
+
+describe('RefreshToken', () => {
+
+    const baseData = {
+        userId: 'user-1',
+        clientId: 'client-1',
+        scope: ['read:calendar', 'write:calendar'],
+        resource: 'http://localhost:3000/mcp',
+        redirectUri: 'http://127.0.0.1:54321/cb',
+        family: 'fam-1',
+        parentId: null,
+        createdAt: 1000,
+        expiresAt: 1000 + 30 * 24 * 60 * 60 * 1000  // +30일
+    };
+
+    describe('fromData', () => {
+
+        it('기본 필드로 생성', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.id, 'tok-1');
+            assert.strictEqual(t.userId, 'user-1');
+            assert.strictEqual(t.clientId, 'client-1');
+            assert.strictEqual(t.family, 'fam-1');
+            assert.strictEqual(t.parentId, null);
+            assert.strictEqual(t.revokedAt, null);
+        });
+
+        it('parentId 미지정 시 null', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.parentId, null);
+        });
+
+        it('parentId 지정 시 보존 (rotation chain)', () => {
+            const t = RefreshToken.fromData('tok-2', { ...baseData, parentId: 'tok-1' });
+            assert.strictEqual(t.parentId, 'tok-1');
+        });
+
+        it('revokedAt 미지정 시 null', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.revokedAt, null);
+        });
+    });
+
+    describe('isExpired', () => {
+
+        it('expiresAt 이전 → false', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.isExpired(baseData.expiresAt - 1), false);
+        });
+
+        it('expiresAt 시점 → true (≥)', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.isExpired(baseData.expiresAt), true);
+        });
+
+        it('expiresAt 이후 → true', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.isExpired(baseData.expiresAt + 1000), true);
+        });
+    });
+
+    describe('isRevoked', () => {
+
+        it('revokedAt = null → false', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.isRevoked(), false);
+        });
+
+        it('revokedAt 박힌 timestamp → true', () => {
+            const t = RefreshToken.fromData('tok-1', { ...baseData, revokedAt: 500 });
+            assert.strictEqual(t.isRevoked(), true);
+        });
+    });
+
+    describe('isValid', () => {
+
+        it('not-revoked + not-expired → true', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.isValid(baseData.createdAt + 1000), true);
+        });
+
+        it('revoked → false', () => {
+            const t = RefreshToken.fromData('tok-1', { ...baseData, revokedAt: 500 });
+            assert.strictEqual(t.isValid(baseData.createdAt + 1000), false);
+        });
+
+        it('expired → false', () => {
+            const t = RefreshToken.fromData('tok-1', baseData);
+            assert.strictEqual(t.isValid(baseData.expiresAt + 1000), false);
+        });
+    });
+});

--- a/functions/test/services/oauth/refreshTokenService.test.js
+++ b/functions/test/services/oauth/refreshTokenService.test.js
@@ -1,0 +1,216 @@
+const assert = require('assert');
+const RefreshTokenService = require('../../../services/oauth/refreshTokenService');
+const { StubRefreshTokenRepository } = require('../../doubles/stubOAuthRepositories');
+
+describe('services/oauth/RefreshTokenService', () => {
+
+    const baseIssue = {
+        userId: 'user-1',
+        clientId: 'client-1',
+        scope: ['read:calendar', 'write:calendar'],
+        resource: 'http://localhost:3000/mcp',
+        redirectUri: 'http://127.0.0.1:54321/cb'
+    };
+
+    let repo;
+    let svc;
+
+    beforeEach(() => {
+        repo = new StubRefreshTokenRepository();
+        svc = new RefreshTokenService(repo, 3600);  // 1시간 TTL (테스트용)
+    });
+
+    describe('constructor', () => {
+
+        it('repository 없으면 throw', () => {
+            assert.throws(() => new RefreshTokenService(null), /repository required/);
+        });
+    });
+
+    describe('issueForUser', () => {
+
+        it('정상 발급 — opaque id + 새 family + parentId null', async () => {
+            const tok = await svc.issueForUser(baseIssue);
+            assert.ok(tok.id);
+            assert.ok(tok.family);
+            assert.strictEqual(tok.parentId, null);
+            assert.strictEqual(tok.userId, 'user-1');
+            assert.strictEqual(tok.clientId, 'client-1');
+            assert.deepStrictEqual(tok.scope, ['read:calendar', 'write:calendar']);
+            assert.strictEqual(tok.resource, 'http://localhost:3000/mcp');
+            assert.strictEqual(tok.redirectUri, 'http://127.0.0.1:54321/cb');
+            assert.strictEqual(tok.revokedAt, null);
+        });
+
+        it('두 번 발급 시 family 가 다름 (각 호출 = 새 chain)', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            const t2 = await svc.issueForUser(baseIssue);
+            assert.notStrictEqual(t1.family, t2.family);
+        });
+
+        it('expiresAt = now + ttlSeconds * 1000', async () => {
+            const before = Date.now();
+            const tok = await svc.issueForUser(baseIssue);
+            const after = Date.now();
+            assert.ok(tok.expiresAt >= before + 3600 * 1000);
+            assert.ok(tok.expiresAt <= after + 3600 * 1000);
+        });
+
+        it('userId 없으면 400 InvalidRequest', async () => {
+            await assert.rejects(
+                svc.issueForUser({ ...baseIssue, userId: '' }),
+                err => err.status === 400 && err.code === 'InvalidRequest'
+            );
+        });
+
+        it('scope 비배열이면 400 InvalidRequest', async () => {
+            await assert.rejects(
+                svc.issueForUser({ ...baseIssue, scope: 'read:calendar' }),
+                err => err.status === 400 && err.code === 'InvalidRequest'
+            );
+        });
+
+        it('scope 빈 배열이면 400 InvalidRequest', async () => {
+            await assert.rejects(
+                svc.issueForUser({ ...baseIssue, scope: [] }),
+                err => err.status === 400 && err.code === 'InvalidRequest'
+            );
+        });
+    });
+
+    describe('rotate — 정상', () => {
+
+        it('valid token rotation → 새 token 발급 + 같은 family + parentId 체인 + 옛 token revoked', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            const t2 = await svc.rotate({ refreshTokenId: t1.id, clientId: 'client-1' });
+            assert.notStrictEqual(t2.id, t1.id);
+            assert.strictEqual(t2.family, t1.family);
+            assert.strictEqual(t2.parentId, t1.id);
+            assert.strictEqual(t2.userId, t1.userId);
+            assert.deepStrictEqual(t2.scope, t1.scope);
+            // 옛 token 은 revoked
+            const oldStored = await repo.findById(t1.id);
+            assert.ok(oldStored.isRevoked(), 'old token must be revoked');
+        });
+
+        it('resource 인자 미지정 시 검증 skip → rotation 성공', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            const t2 = await svc.rotate({ refreshTokenId: t1.id, clientId: 'client-1' });
+            assert.ok(t2.id);
+        });
+    });
+
+    describe('rotate — 실패', () => {
+
+        it('refreshTokenId 없음 → 400 InvalidGrant', async () => {
+            await assert.rejects(
+                svc.rotate({ refreshTokenId: '', clientId: 'c' }),
+                err => err.status === 400 && err.code === 'InvalidGrant'
+            );
+        });
+
+        it('not-found → 400 InvalidGrant', async () => {
+            await assert.rejects(
+                svc.rotate({ refreshTokenId: 'nope', clientId: 'c' }),
+                err => err.status === 400 && err.code === 'InvalidGrant'
+            );
+        });
+
+        it('expired → 400 InvalidGrant', async () => {
+            // svc TTL 1시간이지만 stub 이 직접 seed 한 expired token 으로 검증
+            repo.seed('expired-1', {
+                userId: 'u', clientId: 'client-1', scope: ['read:calendar'],
+                resource: 'r', redirectUri: 'http://127.0.0.1:1/cb',
+                family: 'fam-x', parentId: null,
+                createdAt: Date.now() - 10000,
+                expiresAt: Date.now() - 1000,   // 이미 만료
+                revokedAt: null
+            });
+            await assert.rejects(
+                svc.rotate({ refreshTokenId: 'expired-1', clientId: 'client-1' }),
+                err => err.status === 400 && err.code === 'InvalidGrant' && /expired/.test(err.message)
+            );
+        });
+
+        it('client_id mismatch → 400 InvalidGrant', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            await assert.rejects(
+                svc.rotate({ refreshTokenId: t1.id, clientId: 'wrong-client' }),
+                err => err.status === 400 && err.code === 'InvalidGrant' && /client_id/.test(err.message)
+            );
+        });
+
+        it('resource mismatch → 400 InvalidGrant', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            await assert.rejects(
+                svc.rotate({ refreshTokenId: t1.id, clientId: 'client-1', resource: 'http://wrong/mcp' }),
+                err => err.status === 400 && err.code === 'InvalidGrant' && /resource/.test(err.message)
+            );
+        });
+    });
+
+    describe('rotate — reuse detect (탈취 차단)', () => {
+
+        it('이미 revoked 된 token 으로 rotate → family 전체 revoke + reject', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            const t2 = await svc.rotate({ refreshTokenId: t1.id, clientId: 'client-1' });
+            // 이 시점: t1 revoked, t2 valid
+            assert.strictEqual(t2.isRevoked(), false);
+
+            // 탈취 시나리오 — 공격자가 가로챈 t1 으로 다시 rotate 시도
+            await assert.rejects(
+                svc.rotate({ refreshTokenId: t1.id, clientId: 'client-1' }),
+                err => err.status === 400 && err.code === 'InvalidGrant' && /reuse/.test(err.message)
+            );
+
+            // 같은 family 의 t2 도 함께 revoke 되어 더 이상 못 씀
+            const t2After = await repo.findById(t2.id);
+            assert.ok(t2After.isRevoked(), 't2 must be revoked by family revocation');
+
+            // family revoke 가 호출됐는지 spy 확인
+            assert.ok(repo.revokeFamilyCalls.length >= 1);
+            assert.strictEqual(repo.revokeFamilyCalls[0].family, t1.family);
+        });
+
+        it('reuse detect 후 valid 였던 sibling 으로 rotate 시도 → reuse 로 detect + family 재revoke', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            await svc.rotate({ refreshTokenId: t1.id, clientId: 'client-1' });   // t2 발급
+            await assert.rejects(   // 공격자가 t1 으로 시도 → family revoke
+                svc.rotate({ refreshTokenId: t1.id, clientId: 'client-1' }),
+                err => /reuse/.test(err.message)
+            );
+
+            // 이제 정상 client 가 t2 로 rotate 시도해도 reject (t2 도 family revoke 로 invalidated)
+            const t2 = Array.from(repo.store.values()).find(d => d.parentId === t1.id);
+            const t2Id = Array.from(repo.store.entries()).find(([_, d]) => d.parentId === t1.id)[0];
+            await assert.rejects(
+                svc.rotate({ refreshTokenId: t2Id, clientId: 'client-1' }),
+                err => err.status === 400 && err.code === 'InvalidGrant' && /reuse/.test(err.message)
+            );
+        });
+    });
+
+    describe('revoke (RFC 7009)', () => {
+
+        it('valid token revoke → revokedAt 박힘', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            await svc.revoke({ refreshTokenId: t1.id });
+            const after = await repo.findById(t1.id);
+            assert.ok(after.isRevoked());
+        });
+
+        it('not-found 토큰 revoke → silent (throw 안 함)', async () => {
+            await svc.revoke({ refreshTokenId: 'nope' });   // throw 없이 return
+        });
+
+        it('빈 문자열 → silent', async () => {
+            await svc.revoke({ refreshTokenId: '' });
+        });
+
+        it('이미 revoked 토큰 → silent', async () => {
+            const t1 = await svc.issueForUser(baseIssue);
+            await svc.revoke({ refreshTokenId: t1.id });
+            await svc.revoke({ refreshTokenId: t1.id });   // 두 번째 호출도 throw 안 함
+        });
+    });
+});


### PR DESCRIPTION
## Summary

#202 의 두 번째 단계. **refresh token 도입 + token endpoint 의 `grant_type=refresh_token` 분기 + 회전(rotation)/재사용(reuse) 처리**. revocation endpoint (`POST /v1/oauth/revoke`) 는 본 PR 외 — Chunk 4 에서.

본 PR 까지 머지되면 LLM 호스트가 access_token 만료 시 *사용자 consent 화면 다시 보지 않고* refresh_token 으로 새 access_token 받을 수 있게 됨.

## 결정 근거 (요약)

이슈 #202 의 결정 표 그대로:
- refresh_token TTL = **30일 absolute**, opaque random (32 bytes hex)
- rotation 정책 = 매 refresh 시 새 token 발급 + 옛 거 즉시 invalidate
- **reuse detect** — 이미 revoked 된 token 으로 refresh 시도 = 탈취 신호 → family 전체 revoke
- access blocklist / introspection 도입 X (NON-goal)

## 변경

### Chunk 2 — 모델 + repository (commit 82e479e)
- `models/oauth/RefreshToken.js` — opaque id + 발급 metadata + rotation chain(`family`, `parentId`) + `revokedAt`. `isExpired` / `isRevoked` / `isValid` 메소드.
- `repositories/oauth/refreshTokenRepository.js` — Firestore `oauth_refresh_tokens` collection.
  - `create` (read-after-write), `findById`
  - `markRevoked` (트랜잭션 race-safe, 이미 revoked 면 false 멱등)
  - `revokeFamily` — `where('family',==).where('revokedAt',==null)` 후 batch update
  - `findExpiredOrRevokedBefore` (cleanup용 — expiresAt 기준 우선)
  - `deleteById` (Firestore TTL policy 비호환 동안 대체)
- `test/doubles/stubOAuthRepositories.js` — `StubRefreshTokenRepository` 추가, raw payload spy(`lastCreatedPayload`, `markRevokedCalls`, `revokeFamilyCalls`) 노출 — 검증 로직은 stub 안에 안 박음 (test double policy).
- `test/models/oauth/RefreshToken.test.js` — 12 케이스.

### Chunk 3 — service + token endpoint + e2e (commit 62a6064)
- `services/oauth/refreshTokenService.js` (신규)
  - `issueForUser({ userId, clientId, scope, resource, redirectUri })` — 새 family chain 시작. authorization_code grant 직후 controller 가 호출.
  - `rotate({ refreshTokenId, clientId, resource })` — refresh_token grant 본 로직. **reuse detect**: revoked token 으로 시도 또는 markRevoked race 실패(이미 revoked) 시 family 전체 revoke 후 `400 InvalidGrant`. 정상 흐름은 새 token 발급 (같은 family, parentId 체인).
  - `revoke({ refreshTokenId })` — RFC 7009 endpoint 가 호출. not-found / 이미 revoked / 빈 문자열 모두 silent.
- `controllers/oauth/tokenController.js`
  - constructor 에 `refreshTokenService` 추가 (누락 → throw).
  - `exchange` — grant_type 분기 (`_exchangeAuthorizationCode` / `_exchangeRefreshToken`).
  - `_exchangeAuthorizationCode` — 기존 access_token 발급 + **`refreshTokenService.issueForUser` 호출 후 응답에 `refresh_token` 동시 반환**.
  - `_exchangeRefreshToken` — `refreshTokenService.rotate` 호출 → 회전된 token 의 userId/scope/resource 로 새 access_token 서명 + 새 refresh_token 반환.
- `routes/oauth/tokenRoutes.js` — `RefreshTokenRepository` + `RefreshTokenService` 인스턴스화 후 controller 주입 (default TTL 30일).
- `test/services/oauth/refreshTokenService.test.js` — 20 케이스 (constructor / issueForUser / rotate 정상·실패 / reuse detect 시 family 전체 revoke / sibling 무력화 / revoke silent).
- `test/controllers/oauth/tokenController.test.js` — refresh stub 추가, 응답 refresh_token 단언, refresh_token grant describe 4 케이스 신규.
- `test/e2e/oauth.e2e.js` — happy path 5단계에 `refresh_token` 단언 + 6단계(rotation) + 7단계(reuse detect — 옛 token 재사용 시 family 전체 무력화 확인).

## MCP / 외부 영향

- token endpoint 응답에 `refresh_token` 필드 추가. 기존 필드 변경 X — 본 MCP RS 는 access_token JWT verify 만 하므로 영향 X. 다만 본 MCP **이외의** OAuth client (LLM 호스트 등) 는 refresh 동작 활용해 silent re-auth 가능.
- `revocation_endpoint` well-known metadata 갱신은 Chunk 4 에서.

## Test plan

- [x] 단위 테스트 **888 통과** (기존 850 + 모델 12 + service 20 + controller 6)
- [x] e2e **138 통과** (기존 136 + rotation/reuse 2)

Refs #202 (Chunk 2 + 3)