### PR TITLE
[#202] Chunk 4+5 — RFC 7009 revocation endpoint + discovery metadata

### DIFF
--- a/functions/controllers/oauth/revocationController.js
+++ b/functions/controllers/oauth/revocationController.js
@@ -1,0 +1,27 @@
+const Errors = require('../../models/Errors');
+
+class RevocationController {
+
+    constructor(refreshTokenService) {
+        if (!refreshTokenService) throw new Error('RevocationController: refreshTokenService required');
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    // RFC 7009 §2.1 — POST body `{ token, token_type_hint? }`. public client 라 인증 없음.
+    // MVP 는 refresh_token 만 회수 (access_token 은 JWT stateless 라 silent no-op).
+    // RFC §2.1 마지막 문단 — token_type_hint 가 잘못 지정/미지정이어도 모든 type 검색 필요 → 본 구현은 항상 refresh_token 으로 시도.
+    async revoke(req, res) {
+        const body = req.body ?? {};
+        const token = body.token;
+
+        if (typeof token !== 'string' || token.length === 0) {
+            throw new Errors.Base(400, 'InvalidRequest', 'token required');
+        }
+
+        // RFC 7009 §2.2 — token not-found / 이미 revoked / 잘못된 type 모두 200. service.revoke 가 silent 처리.
+        await this.refreshTokenService.revoke({ refreshTokenId: token });
+        res.status(200).json({});
+    }
+}
+
+module.exports = RevocationController;

--- a/functions/index.js
+++ b/functions/index.js
@@ -50,6 +50,7 @@ const oauthWellKnownRouter = require('./routes/oauth/wellKnownRoutes');
 const oauthRegisterRouter = require('./routes/oauth/registerRoutes');
 const oauthAuthorizeRouter = require('./routes/oauth/authorizeRoutes');
 const oauthTokenRouter = require('./routes/oauth/tokenRoutes');
+const oauthRevocationRouter = require('./routes/oauth/revocationRoutes');
 
 const logger = require("firebase-functions/logger");
 
@@ -114,6 +115,7 @@ app.use('/v2/open/event_details', openApiAuth, eventDetailOpenRouter);
 app.use('/.well-known', oauthWellKnownRouter);
 app.use('/v1/oauth/register', oauthRegisterRouter);
 app.use('/v1/oauth/token', oauthTokenRouter);
+app.use('/v1/oauth/revoke', oauthRevocationRouter);
 app.use('/v1/oauth', oauthAuthorizeRouter);
 
 // request logging

--- a/functions/routes/oauth/revocationRoutes.js
+++ b/functions/routes/oauth/revocationRoutes.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+
+const RefreshTokenRepository = require('../../repositories/oauth/refreshTokenRepository');
+const RefreshTokenService = require('../../services/oauth/refreshTokenService');
+const RevocationController = require('../../controllers/oauth/revocationController');
+const noCache = require('../../middlewares/oauth/noCache');
+
+router.use(noCache);
+
+const refreshRepo = new RefreshTokenRepository();
+const refreshService = new RefreshTokenService(refreshRepo);
+const controller = new RevocationController(refreshService);
+
+router.post('/', async (req, res) => {
+    await controller.revoke(req, res);
+});
+
+module.exports = router;

--- a/functions/services/oauth/tokenSigningService.js
+++ b/functions/services/oauth/tokenSigningService.js
@@ -66,11 +66,13 @@ class TokenSigningService {
             authorization_endpoint: `${this.issuer}/v1/oauth/authorize`,
             token_endpoint: `${this.issuer}/v1/oauth/token`,
             registration_endpoint: `${this.issuer}/v1/oauth/register`,
+            revocation_endpoint: `${this.issuer}/v1/oauth/revoke`,
             jwks_uri: `${this.issuer}/.well-known/jwks.json`,
             response_types_supported: ['code'],
-            grant_types_supported: ['authorization_code'],
+            grant_types_supported: ['authorization_code', 'refresh_token'],
             code_challenge_methods_supported: ['S256'],
             token_endpoint_auth_methods_supported: ['none'],
+            revocation_endpoint_auth_methods_supported: ['none'],
             scopes_supported: Object.keys(KNOWN_SCOPES)
         };
     }

--- a/functions/test/controllers/oauth/revocationController.test.js
+++ b/functions/test/controllers/oauth/revocationController.test.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+const RevocationController = require('../../../controllers/oauth/revocationController');
+
+describe('controllers/oauth/RevocationController', () => {
+
+    let refreshSvc, controller, res;
+
+    const makeRes = () => ({
+        _status: null, _body: null,
+        status(s) { this._status = s; return this; },
+        json(b) { this._body = b; return this; }
+    });
+
+    beforeEach(() => {
+        refreshSvc = {
+            revokeCalls: [],
+            async revoke(p) { this.revokeCalls.push(p); }
+        };
+        controller = new RevocationController(refreshSvc);
+        res = makeRes();
+    });
+
+    describe('constructor', () => {
+
+        it('refreshTokenService 누락 → throw', () => {
+            assert.throws(() => new RevocationController(null));
+        });
+    });
+
+    describe('revoke — 정상', () => {
+
+        it('200 + 빈 body (RFC 7009 §2.2)', async () => {
+            await controller.revoke({ body: { token: 'tok-1' } }, res);
+            assert.strictEqual(res._status, 200);
+            assert.deepStrictEqual(res._body, {});
+        });
+
+        it('refreshTokenService.revoke 호출 — token 을 refreshTokenId 로 매핑', async () => {
+            await controller.revoke({ body: { token: 'tok-xyz' } }, res);
+            assert.strictEqual(refreshSvc.revokeCalls.length, 1);
+            assert.strictEqual(refreshSvc.revokeCalls[0].refreshTokenId, 'tok-xyz');
+        });
+
+        it('token_type_hint 가 access_token 이어도 그대로 refresh service 호출 (MVP — type 무시, silent)', async () => {
+            await controller.revoke({ body: { token: 'tok-1', token_type_hint: 'access_token' } }, res);
+            assert.strictEqual(res._status, 200);
+            assert.strictEqual(refreshSvc.revokeCalls.length, 1);
+        });
+
+        it('not-found / 이미 revoked 도 200 (service 가 silent 처리)', async () => {
+            // service stub 은 throw 안 하니 자연스럽게 200. 실제 service 의 silent 동작은 refreshTokenService.test 에서 검증.
+            await controller.revoke({ body: { token: 'unknown' } }, res);
+            assert.strictEqual(res._status, 200);
+        });
+    });
+
+    describe('revoke — 실패', () => {
+
+        it('token 누락 → 400 InvalidRequest', async () => {
+            await assert.rejects(
+                () => controller.revoke({ body: {} }, res),
+                e => e.status === 400 && e.code === 'InvalidRequest' && /token/.test(e.message)
+            );
+            assert.strictEqual(refreshSvc.revokeCalls.length, 0, 'service 호출되지 않아야');
+        });
+
+        it('token 빈 문자열 → 400 InvalidRequest', async () => {
+            await assert.rejects(
+                () => controller.revoke({ body: { token: '' } }, res),
+                e => e.status === 400 && e.code === 'InvalidRequest'
+            );
+        });
+
+        it('body 없음 → 400 InvalidRequest', async () => {
+            await assert.rejects(
+                () => controller.revoke({}, res),
+                e => e.status === 400 && e.code === 'InvalidRequest'
+            );
+        });
+    });
+});

--- a/functions/test/e2e/oauth.e2e.js
+++ b/functions/test/e2e/oauth.e2e.js
@@ -54,8 +54,9 @@ describe('OAuth AS — well-known', () => {
         assert.ok(res.data.authorization_endpoint.endsWith('/v1/oauth/authorize'));
         assert.ok(res.data.token_endpoint.endsWith('/v1/oauth/token'));
         assert.ok(res.data.registration_endpoint.endsWith('/v1/oauth/register'));
+        assert.ok(res.data.revocation_endpoint.endsWith('/v1/oauth/revoke'));
         assert.deepStrictEqual(res.data.response_types_supported, ['code']);
-        assert.deepStrictEqual(res.data.grant_types_supported, ['authorization_code']);
+        assert.deepStrictEqual(res.data.grant_types_supported, ['authorization_code', 'refresh_token']);
         assert.deepStrictEqual(res.data.code_challenge_methods_supported, ['S256']);
         assert.deepStrictEqual(res.data.token_endpoint_auth_methods_supported, ['none']);
         assert.deepStrictEqual(res.data.scopes_supported.sort(), ['read:calendar', 'write:calendar']);
@@ -291,6 +292,72 @@ describe('OAuth AS — happy path (한 바퀴)', () => {
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
         });
         assert.strictEqual(res3.status, 400);
+    });
+
+    it('8. POST /revoke — refresh_token 회수 후 동일 token 으로 refresh 시도 → 400', async () => {
+        // 단계 1~5 재실행해 새로운 valid refresh_token 확보 (직전 family 는 7단계에서 모두 revoked).
+        const { res: rr } = await registerClient('Revoke Client');
+        const newClientId = rr.data.client_id;
+        const newRedirectUri = rr.data.redirect_uris[0];
+        const { verifier: v, challenge: ch } = pkce();
+        const qs = authorizeQuery({ clientId: newClientId, redirectUri: newRedirectUri, codeChallenge: ch });
+        const authzRes = await axios.get(`${BASE_URL}/v1/oauth/authorize?${qs}`, NO_REDIRECT);
+        const newChallengeId = challengeIdFromLocation(authzRes.headers.location);
+        const idToken = getAuthToken();
+        const cbBody = new URLSearchParams({ challenge: newChallengeId, allow: 'true', id_token: idToken });
+        const cbRes = await axios.post(`${BASE_URL}/v1/oauth/consent/callback`, cbBody.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        const newCode = new URL(cbRes.headers.location).searchParams.get('code');
+        const tokenBody = new URLSearchParams({
+            grant_type: 'authorization_code',
+            code: newCode, code_verifier: v,
+            redirect_uri: newRedirectUri, client_id: newClientId,
+            resource: process.env.OAUTH_CALENDAR_RESOURCE_URI
+        });
+        const tokenRes = await axios.post(`${BASE_URL}/v1/oauth/token`, tokenBody.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        const newRefreshToken = tokenRes.data.refresh_token;
+
+        // POST /revoke → 200 (RFC 7009 §2.2)
+        const revokeBody = new URLSearchParams({ token: newRefreshToken });
+        const revokeRes = await axios.post(`${BASE_URL}/v1/oauth/revoke`, revokeBody.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(revokeRes.status, 200);
+
+        // 회수된 token 으로 refresh 시도 → 400 InvalidGrant (reuse detect 분기)
+        const useBody = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: newRefreshToken,
+            client_id: newClientId,
+            resource: process.env.OAUTH_CALENDAR_RESOURCE_URI
+        });
+        const useRes = await axios.post(`${BASE_URL}/v1/oauth/token`, useBody.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(useRes.status, 400);
+
+        // 9. 알 수 없는 token 으로 revoke → silent 200 (RFC 7009 §2.2)
+        const unknownBody = new URLSearchParams({ token: 'totally-unknown-token-id' });
+        const unknownRes = await axios.post(`${BASE_URL}/v1/oauth/revoke`, unknownBody.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(unknownRes.status, 200);
+
+        // 10. token 누락 → 400 InvalidRequest
+        const emptyBody = new URLSearchParams({});
+        const emptyRes = await axios.post(`${BASE_URL}/v1/oauth/revoke`, emptyBody.toString(), {
+            ...NO_REDIRECT,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+        assert.strictEqual(emptyRes.status, 400);
     });
 });
 

--- a/functions/test/services/oauth/tokenSigningService.test.js
+++ b/functions/test/services/oauth/tokenSigningService.test.js
@@ -55,11 +55,13 @@ describe('services/oauth/TokenSigningService', () => {
             assert.strictEqual(meta.authorization_endpoint, `${ISSUER}/v1/oauth/authorize`);
             assert.strictEqual(meta.token_endpoint, `${ISSUER}/v1/oauth/token`);
             assert.strictEqual(meta.registration_endpoint, `${ISSUER}/v1/oauth/register`);
+            assert.strictEqual(meta.revocation_endpoint, `${ISSUER}/v1/oauth/revoke`);
             assert.strictEqual(meta.jwks_uri, `${ISSUER}/.well-known/jwks.json`);
             assert.deepStrictEqual(meta.response_types_supported, ['code']);
-            assert.deepStrictEqual(meta.grant_types_supported, ['authorization_code']);
+            assert.deepStrictEqual(meta.grant_types_supported, ['authorization_code', 'refresh_token']);
             assert.deepStrictEqual(meta.code_challenge_methods_supported, ['S256']);
             assert.deepStrictEqual(meta.token_endpoint_auth_methods_supported, ['none']);
+            assert.deepStrictEqual(meta.revocation_endpoint_auth_methods_supported, ['none']);
         });
 
         it('scopes_supported 가 KNOWN_SCOPES 와 일치', () => {
@@ -74,6 +76,7 @@ describe('services/oauth/TokenSigningService', () => {
             assert.strictEqual(meta.authorization_endpoint, 'https://x.example/v1/oauth/authorize');
             assert.strictEqual(meta.token_endpoint, 'https://x.example/v1/oauth/token');
             assert.strictEqual(meta.registration_endpoint, 'https://x.example/v1/oauth/register');
+            assert.strictEqual(meta.revocation_endpoint, 'https://x.example/v1/oauth/revoke');
             assert.strictEqual(meta.jwks_uri, 'https://x.example/.well-known/jwks.json');
         });
     });


### PR DESCRIPTION
## Summary

#202 의 세 번째 단계. **RFC 7009 revocation endpoint + RFC 8414 metadata 갱신**. 본 PR 까지 머지되면 사용자가 LLM 호스트 권한 철회 시 refresh_token 회수 요청 가능 → access_token 도 2시간 내 자연 만료로 같은 효과 (MVP 의도된 회수 매커니즘).

남은: Chunk 6 (cleanup), Chunk 7 (문서) — 작은 후속.

## 변경

### Chunk 4 — revocation endpoint

**`controllers/oauth/revocationController.js`** (신규)
- RFC 7009 §2.1 — body 의 `token` / `token_type_hint` 받음
- token 누락 → 400 `InvalidRequest`
- 정상 / not-found / 이미 revoked / type_hint=access_token / 잘못된 hint 모두 → 200 `{}` (RFC §2.2 silent). MVP 는 refresh_token 만 실제 회수, access_token 은 JWT stateless 라 no-op.
- RFC §2.1 마지막 문단 "MUST extend search across all supported token types" — 본 MVP 는 항상 refresh 로 시도 (다른 type 없음).

**`routes/oauth/revocationRoutes.js`** (신규)
- `POST /` + `noCache` 미들웨어
- `RefreshTokenRepository` + `RefreshTokenService` 인스턴스화 후 controller 주입 (default TTL 30일)

**`index.js`**
- `/v1/oauth/revoke` mount (token 라우터 다음, authorize 분리)

**테스트**
- `test/controllers/oauth/revocationController.test.js` — 8 케이스 (constructor 누락 / 정상 200 / token 매핑 / type_hint=access_token 도 silent / not-found silent / token 누락·빈문자·body 없음 → InvalidRequest)
- `test/e2e/oauth.e2e.js` 8단계: revoke → reuse 시도 400 + 알 수 없는 token silent 200 + token 누락 400

### Chunk 5 — discovery metadata

**`services/oauth/tokenSigningService.js#getMetadata`**
- `revocation_endpoint: ${issuer}/v1/oauth/revoke` 추가 (RFC 8414 §2)
- `revocation_endpoint_auth_methods_supported: ['none']` (public client)
- `grant_types_supported` 에 `'refresh_token'` 추가 (Chunk 3 머지로 이미 동작 중인데 metadata 가 못 따라가던 상태)

**테스트**
- `test/services/oauth/tokenSigningService.test.js` — metadata 필드 단언 갱신 + trailing slash 정규화 케이스에 revocation 단언 보강
- `test/e2e/oauth.e2e.js` well-known metadata 케이스에 `revocation_endpoint` / `grant_types_supported` 단언

## MCP / 외부 영향

- `/v1/oauth/revoke` 신규 endpoint. 본 MCP RS 는 access_token verify 만 하므로 영향 X. 외부 OAuth client (LLM 호스트, 또는 사용자가 권한 철회 UI 트리거하는 곳) 가 활용.
- well-known metadata 변경 — RFC 8414 표준 필드 추가라 호환성 깨짐 없음. cache `max-age=600` 이라 prod 반영 후 최대 10분 stale.

## Test plan

- [x] 단위 테스트 **898 통과** (revocation controller 8 + 기존 갱신)
- [x] e2e **139 통과** (revocation flow + metadata 단언)

Refs #202 (Chunk 4+5)