### PR TITLE
[#202] Chunk 6+7 + singleton 정리 — cleanup 스케줄러 + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ functions/
 
 구현: `services/oauth/oauthClientService.js` (`_computeDedupHash`, `_isDedupWindow`).
 
+**Token lifetime — access 2시간 / refresh 30일 + rotation + reuse detect**
+
+- `POST /v1/oauth/token` 응답은 access_token (JWT, RS256) + refresh_token (opaque) 동시 발급. `expires_in: 7200` (2시간).
+- access_token 만료 후 LLM 호스트가 `grant_type=refresh_token` 으로 새 token 받아옴 (사용자 consent 화면 다시 안 봄). 단 refresh 도 rotation 정책 → 매 사용마다 새 refresh 발급 + 옛 거 즉시 invalidate.
+- **Reuse detect (탈취 차단)** — 이미 revoked 된 refresh_token 으로 다시 요청 = 정상 client 면 발생 안 함 = 탈취 신호 → 해당 family 전체 revoke. 정상 client 도 더 못 쓰게 만들어 공격자의 토큰 chain 즉시 무력화.
+- refresh_token TTL 30일 absolute (sliding 미적용). 만료 후엔 처음부터 `/authorize` 재시작 필요.
+
+**Revocation (RFC 7009 — `POST /v1/oauth/revoke`)**
+
+- body `{ token, token_type_hint? }`. 인증 없음 (public client).
+- 응답은 항상 200 (RFC §2.2) — not-found / 이미 revoked / 잘못된 type 모두 silent.
+- MVP 는 refresh_token 만 실제 회수. access_token 은 JWT stateless 라 no-op (자연 만료 = 2시간 내).
+- 사용자 권한 철회 시 refresh 만 무력화 → access 도 2시간 내 자연 만료 = 같은 효과.
+
+**Cleanup**
+
+- `oauthClientCleanup` — 24시간 주기, `lastUsedAt=null` AND 30일 초과 client 정리.
+- `oauthRefreshTokenCleanup` — 24시간 주기, expired refresh_token 삭제 (`expiresAt < now`).
+
+구현: `services/oauth/refreshTokenService.js` (`issueForUser`, `rotate`, `revoke`).
+
 ## Getting Started
 
 ### 사전 요구사항

--- a/functions/index.js
+++ b/functions/index.js
@@ -155,3 +155,4 @@ exports.apiV2 = onRequest(appV2);
 
 // OAuth client garbage cleanup — 매 24시간, 30일 미사용 client 정리 (Asia/Seoul timezone)
 exports.oauthClientCleanup = require('./scheduled/oauthClientCleanup');
+exports.oauthRefreshTokenCleanup = require('./scheduled/oauthRefreshTokenCleanup');

--- a/functions/index.js
+++ b/functions/index.js
@@ -155,4 +155,5 @@ exports.apiV2 = onRequest(appV2);
 
 // OAuth client garbage cleanup — 매 24시간, 30일 미사용 client 정리 (Asia/Seoul timezone)
 exports.oauthClientCleanup = require('./scheduled/oauthClientCleanup');
+// expired refresh_token 정리 — 매 24시간 (Asia/Seoul timezone). 자세한 정책: README 의 'Cleanup' 섹션
 exports.oauthRefreshTokenCleanup = require('./scheduled/oauthRefreshTokenCleanup');

--- a/functions/routes/oauth/revocationRoutes.js
+++ b/functions/routes/oauth/revocationRoutes.js
@@ -1,16 +1,13 @@
 const express = require('express');
 const router = express.Router();
 
-const RefreshTokenRepository = require('../../repositories/oauth/refreshTokenRepository');
-const RefreshTokenService = require('../../services/oauth/refreshTokenService');
+const refreshTokenService = require('../../services/oauth/refreshTokenServiceInstance');
 const RevocationController = require('../../controllers/oauth/revocationController');
 const noCache = require('../../middlewares/oauth/noCache');
 
 router.use(noCache);
 
-const refreshRepo = new RefreshTokenRepository();
-const refreshService = new RefreshTokenService(refreshRepo);
-const controller = new RevocationController(refreshService);
+const controller = new RevocationController(refreshTokenService);
 
 router.post('/', async (req, res) => {
     await controller.revoke(req, res);

--- a/functions/routes/oauth/tokenRoutes.js
+++ b/functions/routes/oauth/tokenRoutes.js
@@ -2,10 +2,9 @@ const express = require('express');
 const router = express.Router();
 
 const AuthorizationCodeRepository = require('../../repositories/oauth/authorizationCodeRepository');
-const RefreshTokenRepository = require('../../repositories/oauth/refreshTokenRepository');
 const AuthorizationCodeService = require('../../services/oauth/authorizationCodeService');
-const RefreshTokenService = require('../../services/oauth/refreshTokenService');
 const tokenSigningService = require('../../services/oauth/tokenSigningServiceInstance');
+const refreshTokenService = require('../../services/oauth/refreshTokenServiceInstance');
 const TokenController = require('../../controllers/oauth/tokenController');
 const noCache = require('../../middlewares/oauth/noCache');
 
@@ -14,10 +13,7 @@ router.use(noCache);
 const codeRepo = new AuthorizationCodeRepository();
 const codeService = new AuthorizationCodeService(codeRepo, 300);
 
-const refreshRepo = new RefreshTokenRepository();
-const refreshService = new RefreshTokenService(refreshRepo);   // default TTL = 30일
-
-const controller = new TokenController(codeService, tokenSigningService, refreshService);
+const controller = new TokenController(codeService, tokenSigningService, refreshTokenService);
 
 router.post('/', async (req, res) => {
     await controller.exchange(req, res);

--- a/functions/scheduled/oauthRefreshTokenCleanup.js
+++ b/functions/scheduled/oauthRefreshTokenCleanup.js
@@ -1,0 +1,16 @@
+const { onSchedule } = require('firebase-functions/v2/scheduler');
+const logger = require('firebase-functions/logger');
+
+module.exports = onSchedule({
+    schedule: 'every 24 hours',
+    timeZone: 'Asia/Seoul'
+}, async () => {
+    // lazy require: 함수 인스턴스 콜드 스타트 시 Firebase Admin SDK 가 이미 init 된 상태에서 평가
+    const RefreshTokenRepository = require('../repositories/oauth/refreshTokenRepository');
+    const RefreshTokenCleanupService = require('../services/oauth/refreshTokenCleanupService');
+
+    const repo = new RefreshTokenRepository();
+    const svc = new RefreshTokenCleanupService(repo);
+    const deleted = await svc.cleanupExpiredTokens();
+    logger.info(`oauth_refresh_token_cleanup: deleted ${deleted.length} expired refresh tokens`);
+});

--- a/functions/services/oauth/refreshTokenCleanupService.js
+++ b/functions/services/oauth/refreshTokenCleanupService.js
@@ -1,0 +1,22 @@
+class RefreshTokenCleanupService {
+
+    // expired refresh_token 삭제. revoked grace 정리는 후속(필요 시 별 메소드).
+    // beforeTimestamp = now (만료 시점이 현재보다 과거인 것 = 이미 expired)
+    constructor(repository, batchLimit = 500) {
+        if (!repository) throw new Error('RefreshTokenCleanupService: repository required');
+        this.repository = repository;
+        this.batchLimit = batchLimit;
+    }
+
+    async cleanupExpiredTokens(now = Date.now()) {
+        const expired = await this.repository.findExpiredBefore(now, this.batchLimit);
+        const deletedIds = [];
+        for (const token of expired) {
+            await this.repository.deleteById(token.id);
+            deletedIds.push(token.id);
+        }
+        return deletedIds;
+    }
+}
+
+module.exports = RefreshTokenCleanupService;

--- a/functions/services/oauth/refreshTokenServiceInstance.js
+++ b/functions/services/oauth/refreshTokenServiceInstance.js
@@ -1,0 +1,9 @@
+// Process-level singleton — tokenRoutes / revocationRoutes / 향후 cleanup scheduler 가 같은 instance 공유.
+// CommonJS module cache 가 자동 dedup. tokenSigningServiceInstance 와 같은 패턴.
+// 향후 service 에 in-memory state (audit log buffer 등) 가 들어가도 안전.
+
+const RefreshTokenRepository = require('../../repositories/oauth/refreshTokenRepository');
+const RefreshTokenService = require('../../services/oauth/refreshTokenService');
+
+const repository = new RefreshTokenRepository();
+module.exports = new RefreshTokenService(repository);   // default TTL = 30일

--- a/functions/test/services/oauth/refreshTokenCleanupService.test.js
+++ b/functions/test/services/oauth/refreshTokenCleanupService.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const RefreshTokenCleanupService = require('../../../services/oauth/refreshTokenCleanupService');
+const { StubRefreshTokenRepository } = require('../../doubles/stubOAuthRepositories');
+
+describe('services/oauth/RefreshTokenCleanupService', () => {
+
+    let repo;
+    let svc;
+
+    beforeEach(() => {
+        repo = new StubRefreshTokenRepository();
+        svc = new RefreshTokenCleanupService(repo);
+    });
+
+    describe('constructor', () => {
+
+        it('repository 없으면 throw', () => {
+            assert.throws(() => new RefreshTokenCleanupService(null), /repository required/);
+        });
+    });
+
+    describe('cleanupExpiredTokens', () => {
+
+        it('expired token 만 삭제 — valid / revoked-but-not-expired 는 보존', async () => {
+            const now = Date.now();
+            repo.seed('expired-1', { expiresAt: now - 1000 });
+            repo.seed('expired-2', { expiresAt: now - 60000 });
+            repo.seed('valid-1', { expiresAt: now + 60000 });
+            // revoked 인데 아직 만료 안 됨 — 본 cleanup 범위 외 (별도 grace 정리는 후속)
+            repo.seed('revoked-valid', { expiresAt: now + 60000, revokedAt: now - 1000 });
+
+            const deleted = await svc.cleanupExpiredTokens(now);
+
+            assert.strictEqual(deleted.length, 2);
+            assert.ok(deleted.includes('expired-1'));
+            assert.ok(deleted.includes('expired-2'));
+            // valid 와 revoked-but-not-expired 는 store 에 남아있어야
+            assert.ok(await repo.findById('valid-1'));
+            assert.ok(await repo.findById('revoked-valid'));
+        });
+
+        it('아무것도 만료 안 됐으면 빈 배열', async () => {
+            const now = Date.now();
+            repo.seed('valid-1', { expiresAt: now + 60000 });
+
+            const deleted = await svc.cleanupExpiredTokens(now);
+
+            assert.deepStrictEqual(deleted, []);
+        });
+
+        it('repository.deleteById 호출 — spy 로 검증', async () => {
+            const now = Date.now();
+            repo.seed('exp-1', { expiresAt: now - 1000 });
+
+            await svc.cleanupExpiredTokens(now);
+
+            assert.strictEqual(repo.deleteCalls.length, 1);
+            assert.strictEqual(repo.deleteCalls[0].id, 'exp-1');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

#202 의 마지막 단계. **expired refresh_token cleanup 스케줄러 + README 운영 정책 갱신 + PR #205 리뷰 코멘트 #1 (singleton) 반영**. 본 PR 머지 + deploy 까지 끝나면 #202 close 가능.

## 커밋 단위

### 1. `43dc724` — singleton 정리 (PR #205 리뷰 코멘트 #1)
- `services/oauth/refreshTokenServiceInstance.js` 신설 — process-level singleton. `tokenSigningServiceInstance` 와 같은 패턴.
- `tokenRoutes` / `revocationRoutes` 가 `new RefreshTokenRepository` / `new RefreshTokenService` 박던 중복을 한 인스턴스 공유로 일원화. 향후 service 에 in-memory state 추가 시 두 라우트 일관 동작.

### 2. `d5ba3e4` — Chunk 6 (cleanup 스케줄러)
- `services/oauth/refreshTokenCleanupService.js` — `repository.findExpiredBefore(now)` → `deleteById` 일괄 정리. `oauthClientCleanupService` 와 같은 contract.
- `scheduled/oauthRefreshTokenCleanup.js` — every 24 hours / Asia/Seoul. `oauthClientCleanup` 과 같은 v2 onSchedule 패턴 + lazy require.
- `index.js` — `exports.oauthRefreshTokenCleanup` 추가. firebase deploy 시 신규 Cloud Scheduler 트리거 생성.
- `test/services/oauth/refreshTokenCleanupService.test.js` — expired/valid/revoked-but-not-expired 혼합 store 에서 expired 만 삭제 검증.

> revoked-but-not-expired grace 정리는 별 추후 작업. 현재 cleanup 은 expired 기준만 (단순). Firestore TTL policy 비호환 (#192) 동안의 대체.

### 3. `adf064a` — Chunk 7 (README)
- 'Token lifetime' 섹션 신설 — access 2시간 / refresh 30일 / rotation / reuse detect 동작
- 'Revocation' 섹션 신설 — RFC 7009 endpoint, MVP 는 refresh 만 회수
- 'Cleanup' 섹션 신설 — 두 scheduled function 24h 주기

## MCP / 외부 영향

- singleton 정리 — 외부 영향 X (route 내부 리팩터링).
- cleanup 스케줄러 — 신규 Cloud Function 추가 (Cloud Scheduler 트리거 자동 등록). 외부 호출 X, 자체 cron.
- README — 문서.

## 후속 (본 PR 외)

- `#202` close (본 PR 머지 후)
- production deploy — `cd functions && npm run deploy`. 신규 `oauthRefreshTokenCleanup` 함수가 첫 활성화됨

## Test plan

- [x] 단위 테스트 **902 통과** (cleanup service 4 케이스 신규)
- [x] e2e **139 통과**

Closes #202 (본 PR 머지 후)