### PR TITLE
[#207] RFC 8414 §3 host-root well-known metadata variant 응답 추가

### DIFF
--- a/dev-status.js
+++ b/dev-status.js
@@ -11,6 +11,7 @@ const services = [
   { name: 'Emulator UI',                port: 4000, url: 'http://localhost:4000' },
   { name: 'Emulator Hub',               port: 4400, url: 'http://localhost:4400' },
   { name: 'Web Dev Server (Vite)',       port: 5173, url: 'http://localhost:5173' },
+  { name: 'TodoCalendar MCP',            port: 3000, url: 'http://localhost:3000' },
 ];
 
 // Group: emulator ports share a single parent process

--- a/functions/routes/oauth/wellKnownRoutes.js
+++ b/functions/routes/oauth/wellKnownRoutes.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { URL } = require('url');
 const router = express.Router();
 
 const tokenSigningService = require('../../services/oauth/tokenSigningServiceInstance');
@@ -13,9 +14,24 @@ router.use((req, res, next) => {
     next();
 });
 
-router.get('/oauth-authorization-server', async (req, res) => {
+const getMetadata = async (req, res) => {
     await controller.getMetadata(req, res);
-});
+};
+
+// path-aware variant — OIDC discovery 호환: <issuer>/.well-known/oauth-authorization-server
+router.get('/oauth-authorization-server', getMetadata);
+
+// RFC 8414 §3 host-root variant — issuer 가 path 컴포넌트를 가질 때 표준 경로:
+//   <host>/.well-known/oauth-authorization-server<issuer-path>
+// 라우트는 issuer-path 와 정확히 일치할 때만 등록 (와일드카드 X — 임의 path 에 metadata leak 방지).
+// path 없는 host-root issuer 일 때는 위 path-aware variant 와 같은 URL 로 흡수되어 별도 등록 불필요.
+const issuerPath = (() => {
+    if (!process.env.OAUTH_ISSUER) return '';
+    return new URL(process.env.OAUTH_ISSUER).pathname.replace(/\/$/, '');
+})();
+if (issuerPath) {
+    router.get(`/oauth-authorization-server${issuerPath}`, getMetadata);
+}
 
 router.get('/jwks.json', async (req, res) => {
     await controller.getJwks(req, res);

--- a/functions/test/e2e/oauth.e2e.js
+++ b/functions/test/e2e/oauth.e2e.js
@@ -62,6 +62,29 @@ describe('OAuth AS — well-known', () => {
         assert.deepStrictEqual(res.data.scopes_supported.sort(), ['read:calendar', 'write:calendar']);
     });
 
+    it('GET /.well-known/oauth-authorization-server<issuer-path> → RFC 8414 §3 host-root variant', async () => {
+        // RFC 8414 §3 표준 path: <host>/.well-known/oauth-authorization-server<issuer-path>.
+        // path-aware issuer (예: emulator) 일 때 SDK 가 시도하는 정통 경로.
+        const issuerPath = new URL(process.env.OAUTH_ISSUER).pathname.replace(/\/$/, '');
+        assert.ok(issuerPath, 'emulator OAUTH_ISSUER 는 path 컴포넌트를 가져야 한다 — 본 케이스 전제');
+        const res = await axios.get(`${BASE_URL}/.well-known/oauth-authorization-server${issuerPath}`);
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(res.data.issuer, process.env.OAUTH_ISSUER);
+        // path-aware variant 와 동일한 metadata body
+        assert.ok(res.data.authorization_endpoint.endsWith('/v1/oauth/authorize'));
+        assert.ok(res.data.registration_endpoint.endsWith('/v1/oauth/register'));
+        assert.ok(res.data.jwks_uri.endsWith('/.well-known/jwks.json'));
+    });
+
+    it('GET /.well-known/oauth-authorization-server/<wrong-path> → 404 (metadata leak 방지)', async () => {
+        // issuer-path 와 정확히 일치하지 않는 path 는 라우트 미등록.
+        const res = await axios.get(
+            `${BASE_URL}/.well-known/oauth-authorization-server/some/other/path`,
+            { validateStatus: () => true }
+        );
+        assert.strictEqual(res.status, 404);
+    });
+
     it('GET /.well-known/jwks.json → RFC 7517 JWKS', async () => {
         const res = await axios.get(`${BASE_URL}/.well-known/jwks.json`);
         assert.strictEqual(res.status, 200);


### PR DESCRIPTION
Closes #207

## 문제

`OAUTH_ISSUER` 가 path-aware URL (예: emulator 의 `http://127.0.0.1:5001/<project>/<region>/api`) 일 때, RFC 8414 §3 표준 metadata URL 을 응답하지 못했음. 표준 path 는 host component 와 path component 사이에 well-known URI 가 끼워들어가는 형태:

```
<host>/.well-known/oauth-authorization-server<issuer-path>
```

현재 AS 는 `/.well-known/oauth-authorization-server` (OIDC 호환 path-aware variant) 만 응답해서, 표준 path 로 discovery 시도하는 외부 client (Claude Code MCP SDK 등) 가 metadata 를 받지 못함. metadata 누락은 후속 dynamic client registration 도 비표준 path fallback 으로 연쇄 실패시킴.

## 접근

- AS 라우터에 issuer-path 인지하는 host-root variant 라우트 추가. 같은 controller 가 같은 metadata 응답.
- 임의 path 에 metadata 가 leak 되지 않도록 와일드카드 대신 `OAUTH_ISSUER` 의 path 컴포넌트와 정확히 일치할 때만 라우트 등록. path 없는 host-root issuer 일 땐 기존 라우트 URL 과 겹쳐 별도 등록 생략.
- e2e 케이스로 표준 path 200 + 잘못된 path 404 양쪽 모두 검증.

곁다리로 dev-status 대시보드(:3333) 의 services 배열에 TodoCalendar MCP (:3000) 카드 한 줄 추가 — 로컬 OAuth 연동 검증 시 RS 상태를 같은 화면에서 보기 위해.

## 검증

- `npm run test:e2e:run` — RFC 표준 path 200 + 잘못된 path 404 케이스 추가, 141 passing
- `npm test` — 902 passing, 회귀 없음

## 남은 과제

- emulator 한정으로는 firebase functions emulator 가 `<project>/<region>/<function-name>` prefix 를 강제하기 때문에 RFC 표준 host-root path 가 함수에 도달하려면 hosting emulator 가 함께 떠 있어야 함. `npm run emulator` 는 이미 hosting 까지 띄움 (확인됨). production 은 `firebase.json` 의 hosting rewrite (`**` → `apiV2`) 가 받쳐줌.
- 본 PR 은 라우트 등록까지. 외부 OAuth client (Claude Code MCP SDK 등) 의 end-to-end discovery → registration → authorize → token 흐름의 emulator 통합 검증은 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)