### PR TITLE
[#209] DCR grant_types validation 을 metadata 광고와 align (refresh_token 허용)

### DIFF
--- a/functions/models/oauth/grantTypes.js
+++ b/functions/models/oauth/grantTypes.js
@@ -1,0 +1,8 @@
+// metadata `grant_types_supported` (services/oauth/tokenSigningService.getMetadata) 와
+// DCR validation (services/oauth/oauthClientService._validateGrantTypes) 의 single source.
+// 한 군데서 추가/제거하면 양쪽이 자동 align — RFC 8414 광고 vs DCR enforcement 모순 재발 방지 (issue #209).
+const KNOWN_GRANT_TYPES = ['authorization_code', 'refresh_token'];
+
+module.exports = {
+    KNOWN_GRANT_TYPES
+};

--- a/functions/services/oauth/oauthClientService.js
+++ b/functions/services/oauth/oauthClientService.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const Errors = require('../../models/Errors');
 const { parseScopeString } = require('../../models/oauth/scopes');
+const { KNOWN_GRANT_TYPES } = require('../../models/oauth/grantTypes');
 
 const CLIENT_NAME_MAX = 64;
 const CONTROL_CHAR_REGEX = /[\x00-\x1F\x7F]/;
@@ -104,8 +105,11 @@ class OAuthClientService {
         if (!Array.isArray(arr) || arr.length === 0) {
             throw new Errors.Base(400, 'InvalidRequest', 'grant_types required');
         }
+        if (!arr.includes('authorization_code')) {
+            throw new Errors.Base(400, 'InvalidRequest', "grant_types must include 'authorization_code'");
+        }
         for (const g of arr) {
-            if (g !== 'authorization_code') {
+            if (!KNOWN_GRANT_TYPES.includes(g)) {
                 throw new Errors.Base(400, 'InvalidRequest', `grant_types contains unsupported: ${g}`);
             }
         }

--- a/functions/services/oauth/tokenSigningService.js
+++ b/functions/services/oauth/tokenSigningService.js
@@ -1,5 +1,6 @@
 const jose = require('jose');
 const { KNOWN_SCOPES, formatScopeArray } = require('../../models/oauth/scopes');
+const { KNOWN_GRANT_TYPES } = require('../../models/oauth/grantTypes');
 
 class TokenSigningService {
 
@@ -69,7 +70,7 @@ class TokenSigningService {
             revocation_endpoint: `${this.issuer}/v1/oauth/revoke`,
             jwks_uri: `${this.issuer}/.well-known/jwks.json`,
             response_types_supported: ['code'],
-            grant_types_supported: ['authorization_code', 'refresh_token'],
+            grant_types_supported: [...KNOWN_GRANT_TYPES],
             code_challenge_methods_supported: ['S256'],
             token_endpoint_auth_methods_supported: ['none'],
             revocation_endpoint_auth_methods_supported: ['none'],

--- a/functions/test/e2e/oauth.e2e.js
+++ b/functions/test/e2e/oauth.e2e.js
@@ -113,6 +113,20 @@ describe('OAuth AS — register', () => {
         assert.strictEqual(res.status, 400);
     });
 
+    it('grant_types=[authorization_code, refresh_token] → 201 (metadata `grant_types_supported` 와 align)', async () => {
+        const redirectUri = `http://127.0.0.1:${10000 + Math.floor(Math.random() * 50000)}/cb`;
+        const res = await axios.post(`${BASE_URL}/v1/oauth/register`, {
+            client_name: 'Standard Client',
+            redirect_uris: [redirectUri],
+            scope: 'read:calendar',
+            token_endpoint_auth_method: 'none',
+            grant_types: ['authorization_code', 'refresh_token'],
+            response_types: ['code']
+        }, NO_REDIRECT);
+        assert.strictEqual(res.status, 201);
+        assert.ok(res.data.client_id);
+    });
+
     it('redirect_uri 에 userinfo 포함 (`https://victim@evil.com/cb`) → 400', async () => {
         const res = await axios.post(`${BASE_URL}/v1/oauth/register`, {
             client_name: 'X',

--- a/functions/test/services/oauth/oauthClientService.test.js
+++ b/functions/test/services/oauth/oauthClientService.test.js
@@ -187,6 +187,31 @@ describe('services/oauth/OAuthClientService', () => {
             );
         });
 
+        it('grant_types=[authorization_code, refresh_token] → 정상 (metadata grant_types_supported 와 align)', async () => {
+            const c = await svc.register(
+                { ...VALID, grantTypes: ['authorization_code', 'refresh_token'] },
+                { ip: '1.1.1.1' }
+            );
+            assert.ok(c.id);
+        });
+
+        it('grant_types=[refresh_token] (authorization_code 누락) → 400', async () => {
+            await assert.rejects(
+                () => svc.register({ ...VALID, grantTypes: ['refresh_token'] }, { ip: '1.1.1.1' }),
+                e => e.status === 400 && /authorization_code/.test(e.message)
+            );
+        });
+
+        it('grant_types=[authorization_code, password] → 400 (unsupported 거부 유지)', async () => {
+            await assert.rejects(
+                () => svc.register(
+                    { ...VALID, grantTypes: ['authorization_code', 'password'] },
+                    { ip: '1.1.1.1' }
+                ),
+                e => e.status === 400 && /password/.test(e.message)
+            );
+        });
+
         it('response_types=token → 400', async () => {
             await assert.rejects(
                 () => svc.register({ ...VALID, responseTypes: ['token'] }, { ip: '1.1.1.1' }),


### PR DESCRIPTION
Closes #209

## 문제

표준 OAuth client (Claude Code MCP SDK 등) 가 AS 의 metadata 광고대로
`grant_types: ['authorization_code', 'refresh_token']` 으로 dynamic client
registration 시도 시 400 InvalidRequest 로 차단. 핸드셰이크가 첫 단계에서
멈춰 토큰 발급 불가.

원인은 AS 내부 정합성 모순 — metadata 가 `grant_types_supported` 에 두
grant 를 광고하는데, DCR `_validateGrantTypes` 는 `authorization_code` 만
허용하고 다른 모든 grant 를 reject 했음.

## 접근

`_validateGrantTypes` 에 metadata 광고와 같은 whitelist (`KNOWN_GRANT_TYPES`)
를 도입해 align. 와일드카드 허용이 아니라 metadata 가 명시한 두 grant 만
허용. `authorization_code` 는 필수로 포함되어야 함 — RFC 6749 §1.3.4 상
refresh_token 은 단독 grant 가 아니라 access token 갱신용이라 단독 등록은
의미 없음.

## 검증

- emulator 에서 표준 client payload (`grant_types: ['authorization_code', 'refresh_token']`) 로 직접 register 호출 → 400 → 201 전환 확인
- 단위 테스트 세 케이스 추가 (정상 / refresh_token 단독 / unsupported 거부 유지)
- e2e 케이스 한 건 추가 (표준 client register payload 201)
- 회귀: unit 905 / e2e 140 모두 통과 — 기존 register / authorize / token / refresh rotation / reuse detect / revoke 흐름 영향 없음

## 남은 과제

본 PR 은 DCR validation 만 align. 사용자가 emulator 환경에서 본 "HTTP 404 / Not Found"
증상의 첫 layer (SDK 가 친 host-root path 가 functions emulator 함수 prefix 강제로
도달 못 함) 는 별도. SDK 가 metadata 의 `registration_endpoint` 를 정확히 따라 정상
경로로 가는 경우엔 본 fix 만으로 DCR 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)