### PR TITLE
[#212] OAuth consent endpoint 응답 scope 를 space-separated string 으로 직렬화

### DIFF
--- a/functions/controllers/oauth/authorizeController.js
+++ b/functions/controllers/oauth/authorizeController.js
@@ -1,4 +1,5 @@
 const Errors = require('../../models/Errors');
+const { formatScopeArray } = require('../../models/oauth/scopes');
 
 class AuthorizeController {
 
@@ -54,7 +55,9 @@ class AuthorizeController {
             res.status(200).json({
                 client_name: client.clientName,
                 redirect_uri_origin: origin,
-                scope: challenge.scope,
+                // RFC 6749 §3.3 wire-format — scope 는 space-separated string. metadata 의
+                // `scopes_supported` (capability 광고) 만 array, wire-level value 는 string.
+                scope: formatScopeArray(challenge.scope),
                 resource: challenge.resource,
                 expires_at: expMs
             });

--- a/functions/test/controllers/oauth/authorizeController.test.js
+++ b/functions/test/controllers/oauth/authorizeController.test.js
@@ -151,9 +151,21 @@ describe('controllers/oauth/AuthorizeController', () => {
             assert.strictEqual(res._status, 200);
             assert.strictEqual(res._body.client_name, 'Claude Desktop');
             assert.strictEqual(res._body.redirect_uri_origin, 'http://127.0.0.1:54321');
-            assert.deepStrictEqual(res._body.scope, ['read:calendar']);
+            // RFC 6749 §3.3 — wire-level scope 는 space-separated string (array 아님).
+            assert.strictEqual(res._body.scope, 'read:calendar');
             assert.strictEqual(res._body.resource, 'http://localhost:3000/mcp');
             assert.ok(typeof res._body.expires_at === 'number');
+        });
+
+        it('multi-scope challenge → 응답 scope 는 space-separated string', async () => {
+            const multiScope = ConsentChallenge.fromData('ch-multi', {
+                ...SAMPLE_CHALLENGE,
+                scope: ['read:calendar', 'write:calendar']
+            });
+            svc.getConsentInfo = async () => ({ challenge: multiScope, client: SAMPLE_CLIENT });
+            await controller.getConsentPayload(makeReq({ params: { id: 'ch-multi' } }), res);
+            assert.strictEqual(res._status, 200);
+            assert.strictEqual(res._body.scope, 'read:calendar write:calendar');
         });
 
         it('challenge invalid → 404 InvalidChallenge', async () => {

--- a/functions/test/e2e/oauth.e2e.js
+++ b/functions/test/e2e/oauth.e2e.js
@@ -168,7 +168,8 @@ describe('OAuth AS — happy path (한 바퀴)', () => {
         assert.strictEqual(res.status, 200);
         assert.strictEqual(res.data.client_name, 'Flow Client');
         assert.strictEqual(res.data.redirect_uri_origin, new URL(redirectUri).origin);
-        assert.deepStrictEqual(res.data.scope, ['read:calendar']);
+        // RFC 6749 §3.3 — wire-level scope 는 space-separated string (array 아님).
+        assert.strictEqual(res.data.scope, 'read:calendar');
         assert.strictEqual(res.data.resource, process.env.OAUTH_CALENDAR_RESOURCE_URI);
         assert.ok(typeof res.data.expires_at === 'number');
     });


### PR DESCRIPTION
Closes #212

## 현상

표준 OAuth client → `/v1/oauth/authorize` → Web consent UI 흐름에서 Web 페이지가 "일시적 오류" 토스트 뜨고 진행 못함. AS 로그상 `GET /v1/oauth/consent/<challenge>` 200 OK 로 정상 응답하지만, 응답 body 의 `scope` 가 **JSON array** 로 직렬화됨:

```json
{ "scope": ["read:calendar", "write:calendar"], ... }
```

Web consent ViewModel 은 OAuth wire-format 관례대로 `scope` 를 space-separated string 으로 가정 → `String.prototype.split(/\s+/)` 호출 → `TypeError: raw.scope.split is not a function` → catch → `transient_error` state.

## 원인

`AuthorizeController.getConsentPayload` 가 `scope: challenge.scope` 를 그대로 응답해 array 로 새던 게 유일한 누락 지점.

## RFC 표준

| RFC | 컨텍스트 | scope 형식 |
|---|---|---|
| RFC 6749 §3.3 | wire-level scope value | space-separated string |
| RFC 7591 §2 | DCR client metadata `scope` | space-separated string |
| RFC 7662 §2.2 | introspection 응답 | space-separated string |
| RFC 8414 §2 | AS metadata `scopes_supported` | JSON array |

→ server capability 광고 (metadata) 만 array, 그 외 모든 wire-level scope value 는 string. consent endpoint 는 "이 client 가 요청한 scope" 라는 특정 flow instance value 라 string 이 관례 부합.

## 일괄 점검 결과

| 응답 endpoint | scope 직렬화 | 상태 |
|---|---|---|
| `GET /v1/oauth/consent/:id` | array (← bug) | **이번 PR 에서 string 으로 fix** |
| `POST /v1/oauth/register` (DCR) | string (via `OAuthClient.toJSON`) | OK |
| `POST /v1/oauth/token` (auth_code) | string (via `formatScopeArray`) | OK |
| `POST /v1/oauth/token` (refresh) | string (via `formatScopeArray`) | OK |
| JWT access_token claim | string (via `tokenSigningService.signAccessToken`) | OK |
| `GET /.well-known/oauth-authorization-server` `scopes_supported` | array | OK (RFC 8414 §2) |

## 변경

- `controllers/oauth/authorizeController.js` — `formatScopeArray` import + `getConsentPayload` 응답의 scope 를 `formatScopeArray(challenge.scope)` 로 변환.
- `test/controllers/oauth/authorizeController.test.js` — 기존 정상 케이스의 array 단언을 string 단언으로 갱신 + multi-scope challenge 가 space-separated string 으로 나오는지 검증하는 케이스 신규.
- `test/e2e/oauth.e2e.js` — consent payload scope string 단언으로 갱신.

## 테스트

- unit **906 passing**
- e2e **140 passing**