### PR TITLE
[#153] aiFrontAPI MVP — 자연어 명령 진입점 + 비동기 Job 흐름 (Agent Loop stub)

### DIFF
--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -1,0 +1,42 @@
+
+const Errors = require('../../models/Errors');
+
+
+class AiController {
+
+    constructor(jobService) {
+        this.jobService = jobService;
+    }
+
+    async postCommand(req, res) {
+        const deviceId = req.header('device_id');
+        if (!deviceId) {
+            throw new Errors.BadRequest('device_id header is required');
+        }
+
+        const rawCommandText = req.body.command_text;
+        if (!rawCommandText || !rawCommandText.trim()) {
+            throw new Errors.BadRequest('command_text is required');
+        }
+        const commandText = rawCommandText.trim();
+
+        const userId = req.auth.uid;
+        const jobId = await this.jobService.createJob({ userId, deviceId, commandText });
+        res.status(202).send({ job_id: jobId });
+    }
+
+    async getJob(req, res) {
+        const job = await this.jobService.loadJob(req.params.id);
+        if (!job) {
+            throw new Errors.NotFound('job not found');
+        }
+
+        if (job.userId !== req.auth.uid) {
+            throw new Errors.Base(403, 'Forbidden', 'forbidden');
+        }
+
+        res.status(200).send(job.toJSON());
+    }
+}
+
+module.exports = AiController;

--- a/functions/index.js
+++ b/functions/index.js
@@ -37,6 +37,7 @@ const settingRouter = require('./routes/settingRoutes');
 const holidayRouter = require('./routes/holidayRoutes');
 const syncRouter = require('./routes/dataSyncRoutes.js');
 const testRouter = require('./routes/testRoutes');
+const aiRouter = require('./routes/ai/aiRoutes');
 
 const todoOpenRouter = require('./routes/openapi/todoOpenRoutes');
 const doneTodoOpenRouter = require('./routes/openapi/doneTodoOpenRoutes');
@@ -109,6 +110,11 @@ app.use('/v1/sync', authValidator, setVersion('v1'), syncRouter);
 app.use('/v2/sync', authValidator, setVersion('v2'), syncRouter);
 // app.use('/v1/tests', v1TestRouter);
 
+// aiFrontAPI (/v1/ai/*) — 앱이 호출하는 자연어 명령 진입점 (#153). Firebase Auth.
+// 처리는 비동기 — POST /command 가 ai_jobs/{jobId} doc 만 만들고 jobId 즉시 반환.
+// 실제 Agent Loop 은 aiAgentLoop trigger (별도 export, Firestore onCreate) 가 실행.
+app.use('/v1/ai', authValidator, setVersion('v1'), aiRouter);
+
 // openAPI (/v2/open/*) — PAT (서비스 식별) + signed user JWT (사용자 식별) + scope 인가
 // dones 가 todos 보다 먼저 mount: '/v2/open/todos/dones/...' 가 '/v2/open/todos' 의 prefix 매칭으로 흡수되지 않게.
 const openApiAuth = [patAuth, signedUserAuth, setVersion('v2')];
@@ -165,3 +171,6 @@ exports.apiV2 = onRequest(appV2);
 exports.oauthClientCleanup = require('./scheduled/oauthClientCleanup');
 // expired refresh_token 정리 — 매 24시간 (Asia/Seoul timezone). 자세한 정책: README 의 'Cleanup' 섹션
 exports.oauthRefreshTokenCleanup = require('./scheduled/oauthRefreshTokenCleanup');
+
+// AI agent loop trigger — ai_jobs/{jobId} 문서 생성 시 발화, stub/실 AI 처리 후 결과 기록
+exports.aiAgentLoop = require('./triggers/ai/agentLoopTrigger');

--- a/functions/models/ai/AiJob.js
+++ b/functions/models/ai/AiJob.js
@@ -1,0 +1,89 @@
+
+
+/**
+ * Firestore Timestamp 객체, Date 인스턴스, ISO string 을 모두 ISO string 으로 정규화.
+ * Firestore snapshot 의 Timestamp 타입에는 toDate() 메서드가 있다.
+ *
+ * 호출 경계: 본 모델의 시간 필드(createdAt/updatedAt/expireAt) 는 항상
+ * Firestore Timestamp 로 저장됨 (jobRepository 가 FieldValue.serverTimestamp /
+ * Timestamp.fromDate 만 사용). Date / ISO string 분기는 테스트 편의용 입력 케이스.
+ * 그 외 타입(숫자 timestamp, 잘못된 형식 string 등) 은 caller 보장 — 정규화 안 함.
+ */
+function toISOString(value) {
+    if (!value) return null;
+    if (typeof value.toDate === 'function') {
+        // Firestore Timestamp
+        return value.toDate().toISOString();
+    }
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    // ISO string 가정 — 그 외 primitive 는 caller 보장
+    return value;
+}
+
+class AiJob {
+    constructor({ jobId, userId, deviceId, commandText, status, result, createdAt, updatedAt, expireAt }) {
+        this.jobId = jobId;
+        this.userId = userId;
+        this.deviceId = deviceId;
+        this.commandText = commandText;
+        this.status = status;
+        this.result = result ?? null;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.expireAt = expireAt;
+    }
+
+    static fromData(jobId, data) {
+        return new AiJob({
+            jobId,
+            userId: data.userId,
+            deviceId: data.deviceId,
+            commandText: data.commandText,
+            status: data.status,
+            result: data.result ?? null,
+            createdAt: toISOString(data.createdAt),
+            updatedAt: toISOString(data.updatedAt),
+            expireAt: toISOString(data.expireAt)
+        });
+    }
+
+    toJSON() {
+        return {
+            job_id: this.jobId,
+            user_id: this.userId,
+            device_id: this.deviceId,
+            command_text: this.commandText,
+            status: this.status,
+            result: this.result,
+            created_at: this.createdAt,
+            updated_at: this.updatedAt
+            // expireAt 은 내부 운영 필드 — 외부 응답에 노출 X
+        };
+    }
+
+    /**
+     * 상태 머신 종료 여부 판별.
+     * DONE / CONFIRM / FAILED 는 terminal — 이후 상태 전이 없음.
+     * jobService 와 trigger 가 polling 종료 조건으로 사용.
+     *
+     * @param {string} status
+     * @returns {boolean}
+     */
+    static isTerminal(status) {
+        return status === AiJob.STATUS.DONE ||
+               status === AiJob.STATUS.CONFIRM ||
+               status === AiJob.STATUS.FAILED;
+    }
+}
+
+AiJob.STATUS = Object.freeze({
+    PENDING: 'PENDING',
+    RUNNING: 'RUNNING',
+    DONE: 'DONE',
+    CONFIRM: 'CONFIRM',
+    FAILED: 'FAILED'
+});
+
+module.exports = AiJob;

--- a/functions/models/ai/AiJobResult.js
+++ b/functions/models/ai/AiJobResult.js
@@ -1,0 +1,81 @@
+
+/**
+ * AiJobResult — AI job 결과 union 타입의 factory 함수 모음.
+ *
+ * 모든 factory 는 plain object 를 반환한다.
+ * Firestore admin SDK 가 custom prototype 객체를 거부하므로
+ * 이 결과는 Firestore 에 직접 쓸 수 있어야 한다.
+ */
+
+function sanitizeNotification(notification) {
+    if (!notification) return undefined;
+    if (typeof notification !== 'object') return undefined;
+    // 빈 객체나 title/body 누락 케이스는 factory 에서 포함 여부를 결정하지 않고
+    // hasNotification 가드로 caller 가 판단하게 한다.
+    // factory 는 전달된 notification 을 그대로 spread 한다.
+    return notification;
+}
+
+const AiJobResult = {
+    /**
+     * @param {string} text
+     * @param {{ title: string, body: string } | null | undefined} notification
+     * @returns {object}
+     */
+    done(text, notification) {
+        const n = sanitizeNotification(notification);
+        return {
+            type: 'DONE',
+            text,
+            ...(n ? { notification: n } : {})
+        };
+    },
+
+    /**
+     * @param {string} text
+     * @param {object} action
+     * @param {{ title: string, body: string } | null | undefined} notification
+     * @returns {object}
+     */
+    confirm(text, action, notification) {
+        const n = sanitizeNotification(notification);
+        return {
+            type: 'CONFIRM',
+            text,
+            action,
+            ...(n ? { notification: n } : {})
+        };
+    },
+
+    /**
+     * @param {string} reason
+     * @param {{ title: string, body: string } | null | undefined} notification
+     * @returns {object}
+     */
+    failed(reason, notification) {
+        const n = sanitizeNotification(notification);
+        return {
+            type: 'FAILED',
+            reason,
+            ...(n ? { notification: n } : {})
+        };
+    },
+
+    /**
+     * result 에 실제로 사용 가능한 notification 이 있는지 판별.
+     * title 과 body 가 모두 non-empty string 이어야 true.
+     * trigger 가 push notification fallback 분기에 사용.
+     *
+     * @param {object | null} result
+     * @returns {boolean}
+     */
+    hasNotification(result) {
+        if (!result) return false;
+        const n = result.notification;
+        if (!n || typeof n !== 'object') return false;
+        return typeof n.title === 'string' && n.title.length > 0 &&
+               typeof n.body === 'string' && n.body.length > 0;
+    }
+};
+
+module.exports = AiJobResult;

--- a/functions/repositories/ai/jobRepository.js
+++ b/functions/repositories/ai/jobRepository.js
@@ -1,0 +1,91 @@
+
+
+const { getFirestore, FieldValue, Timestamp } = require('firebase-admin/firestore');
+const AiJob = require('../../models/ai/AiJob');
+
+const db = getFirestore();
+const collectionRef = db.collection('ai_jobs');
+
+class JobRepository {
+
+    /**
+     * jobId 로 지정된 doc 을 생성한다. createdAt/updatedAt 은 본 메서드가 serverTimestamp 로
+     * 채우고 (spec §4 server timestamp), expireAt 은 caller 가 준 Date 를
+     * Timestamp.fromDate 로 명시 변환 — 잘못된 타입이 들어오면 repo 경계에서 즉시 fail.
+     *
+     * caller 는 시간 필드를 만들지 말 것 (jobService.createJob 참고).
+     *
+     * @param {string} jobId
+     * @param {{ userId, deviceId, commandText, status, result, expireAt: Date }} data plain object
+     */
+    async put(jobId, data) {
+        const { expireAt, ...rest } = data;
+        const payload = {
+            ...rest,
+            createdAt: FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
+            expireAt: Timestamp.fromDate(expireAt)
+        };
+        await collectionRef.doc(jobId).set(payload);
+    }
+
+    /**
+     * jobId 로 doc 을 읽어 AiJob 인스턴스로 반환한다.
+     * 존재하지 않으면 null 반환.
+     *
+     * @param {string} jobId
+     * @returns {AiJob | null}
+     */
+    async load(jobId) {
+        const snapshot = await collectionRef.doc(jobId).get();
+        if (!snapshot.exists) return null;
+        return AiJob.fromData(jobId, snapshot.data());
+    }
+
+    /**
+     * PENDING → RUNNING 상태 전이. transaction 으로 원자적 수행.
+     * 현재 status 가 PENDING 이 아니면 false 반환 (전이 실패).
+     *
+     * @param {string} jobId
+     * @returns {boolean}
+     */
+    async transitionToRunning(jobId) {
+        const docRef = collectionRef.doc(jobId);
+        return db.runTransaction(async (tx) => {
+            const snapshot = await tx.get(docRef);
+            if (!snapshot.exists) return false;
+            if (snapshot.data().status !== AiJob.STATUS.PENDING) return false;
+            tx.update(docRef, {
+                status: AiJob.STATUS.RUNNING,
+                updatedAt: FieldValue.serverTimestamp()
+            });
+            return true;
+        });
+    }
+
+    /**
+     * RUNNING → 종결 상태(DONE/CONFIRM/FAILED) 전이 + result 저장. transaction 으로 원자적 수행.
+     * 현재 status 가 RUNNING 이 아니면 false 반환 (전이 실패).
+     * result 는 AiJobResult factory 가 만든 plain object — Firestore 직접 저장 가능.
+     *
+     * @param {string} jobId
+     * @param {object} result plain object (AiJobResult.done/confirm/failed 반환값)
+     * @returns {boolean}
+     */
+    async completeWith(jobId, result) {
+        const docRef = collectionRef.doc(jobId);
+        return db.runTransaction(async (tx) => {
+            const snapshot = await tx.get(docRef);
+            if (!snapshot.exists) return false;
+            if (snapshot.data().status !== AiJob.STATUS.RUNNING) return false;
+            tx.update(docRef, {
+                status: result.type,
+                result,
+                updatedAt: FieldValue.serverTimestamp()
+            });
+            return true;
+        });
+    }
+}
+
+module.exports = JobRepository;

--- a/functions/routes/ai/aiRoutes.js
+++ b/functions/routes/ai/aiRoutes.js
@@ -1,0 +1,15 @@
+
+const express = require('express');
+const JobRepository = require('../../repositories/ai/jobRepository');
+const JobService = require('../../services/ai/jobService');
+const AiController = require('../../controllers/ai/aiController');
+
+const jobRepository = new JobRepository();
+const jobService = new JobService(jobRepository);
+const controller = new AiController(jobService);
+
+const router = express.Router();
+router.post('/command', (req, res) => controller.postCommand(req, res));
+router.get('/jobs/:id', (req, res) => controller.getJob(req, res));
+
+module.exports = router;

--- a/functions/secrets/.env.test.example
+++ b/functions/secrets/.env.test.example
@@ -53,3 +53,7 @@ OAUTH_CLIENT_CLEANUP_AGE_DAYS=30
 # production 에선 위 변수 제거하면 코드 기본값(5/30) 적용.
 OAUTH_RATE_LIMIT_REGISTER_MAX_PER_MINUTE=10000
 OAUTH_RATE_LIMIT_REGISTER_MAX_PER_HOUR=10000
+
+# AI stub agentLoop delay (ms). 0 = 즉시 완료 (E2E 빠른 실행용).
+# production 에선 불필요 (기본 1000ms). #154 머지 시 제거 가능.
+AI_STUB_DELAY_MS=0

--- a/functions/services/ai/agentLoopStubService.js
+++ b/functions/services/ai/agentLoopStubService.js
@@ -1,0 +1,34 @@
+
+'use strict';
+
+const AiJobResult = require('../../models/ai/AiJobResult');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class AgentLoopStubService {
+
+    /**
+     * @param {{ delayMs?: number }} [options]
+     */
+    constructor({ delayMs } = {}) {
+        this.delayMs = delayMs ?? parseInt(process.env.AI_STUB_DELAY_MS ?? '1000', 10);
+    }
+
+    /**
+     * @param {string} commandText
+     * @returns {Promise<object>} AiJobResult plain object (Firestore-safe)
+     */
+    async run(commandText) {
+        await sleep(this.delayMs);
+
+        if (commandText.includes('[stub:CONFIRM]')) {
+            return AiJobResult.confirm('stub confirm', { stub: true });
+        }
+        if (commandText.includes('[stub:FAILED]')) {
+            return AiJobResult.failed('stub failed');
+        }
+        return AiJobResult.done('stub done');
+    }
+}
+
+module.exports = AgentLoopStubService;

--- a/functions/services/ai/jobService.js
+++ b/functions/services/ai/jobService.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const crypto = require('crypto');
+const AiJob = require('../../models/ai/AiJob');
+
+class JobService {
+
+    constructor(jobRepository) {
+        this.jobRepository = jobRepository;
+    }
+
+    /**
+     * 새 job 을 생성하고 jobId 를 반환한다.
+     * createdAt / updatedAt 은 jobRepository 가 serverTimestamp 로 채움 — 본 서비스는
+     * 시간 필드를 만들지 않음. expireAt 만 24h 후 Date 로 caller 가 결정.
+     *
+     * @param {{ userId: string, deviceId: string, commandText: string }} params
+     * @returns {Promise<string>} jobId
+     */
+    async createJob({ userId, deviceId, commandText }) {
+        const jobId = crypto.randomUUID();
+        const expireAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+        const data = {
+            userId,
+            deviceId,
+            commandText,
+            status: AiJob.STATUS.PENDING,
+            result: null,
+            expireAt
+        };
+
+        await this.jobRepository.put(jobId, data);
+        return jobId;
+    }
+
+    /**
+     * jobId 로 job 을 로드한다. 없으면 null.
+     *
+     * @param {string} jobId
+     * @returns {Promise<AiJob|null>}
+     */
+    async loadJob(jobId) {
+        return this.jobRepository.load(jobId);
+    }
+
+    /**
+     * PENDING → RUNNING 상태 전이 (CAS).
+     *
+     * @param {string} jobId
+     * @returns {Promise<boolean>} 전이 성공 여부
+     */
+    async transitionToRunning(jobId) {
+        return this.jobRepository.transitionToRunning(jobId);
+    }
+
+    /**
+     * RUNNING → 종결 상태 전이.
+     *
+     * @param {string} jobId
+     * @param {{ type: 'DONE'|'CONFIRM'|'FAILED', [key: string]: any }} result
+     * @returns {Promise<boolean>} 전이 성공 여부
+     */
+    async completeWith(jobId, result) {
+        return this.jobRepository.completeWith(jobId, result);
+    }
+}
+
+module.exports = JobService;

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -1,0 +1,184 @@
+
+const assert = require('assert');
+const AiController = require('../../../controllers/ai/aiController');
+const Errors = require('../../../models/Errors');
+const StubAiJobService = require('../../doubles/stubAiJobService');
+const AiJob = require('../../../models/ai/AiJob');
+
+
+function makeRes() {
+    return {
+        statusCode: null,
+        body: null,
+        status(code) { this.statusCode = code; return this; },
+        send(data) { this.body = data; return this; }
+    };
+}
+
+function makePostReq({ uid = 'user-1', deviceId = 'device-1', commandText = '오늘 할일 추가해줘' } = {}) {
+    return {
+        auth: { uid },
+        header: (name) => name === 'device_id' ? deviceId : null,
+        body: { command_text: commandText }
+    };
+}
+
+function makeGetReq({ uid = 'user-1', jobId = 'job-123' } = {}) {
+    return {
+        auth: { uid },
+        params: { id: jobId }
+    };
+}
+
+function makeJob({ jobId = 'job-123', userId = 'user-1' } = {}) {
+    return new AiJob({
+        jobId,
+        userId,
+        deviceId: 'device-1',
+        commandText: '오늘 할일 추가해줘',
+        status: AiJob.STATUS.PENDING,
+        result: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        expireAt: null
+    });
+}
+
+
+describe('AiController', () => {
+
+    let stubService;
+    let controller;
+
+    beforeEach(() => {
+        stubService = new StubAiJobService();
+        controller = new AiController(stubService);
+    });
+
+
+    // MARK: - postCommand
+
+    describe('postCommand', () => {
+
+        it('정상 — 202 + job_id 응답, jobService 인자 검증', async () => {
+            const req = makePostReq();
+            const res = makeRes();
+
+            await controller.postCommand(req, res);
+
+            assert.equal(res.statusCode, 202);
+            assert.deepEqual(res.body, { job_id: 'job-123' });
+            assert.deepEqual(stubService.lastCreateJobArgs, {
+                userId: 'user-1',
+                deviceId: 'device-1',
+                commandText: '오늘 할일 추가해줘'
+            });
+        });
+
+        it('device_id 헤더 누락 → 400 BadRequest', async () => {
+            const req = makePostReq({ deviceId: null });
+            const res = makeRes();
+
+            try {
+                await controller.postCommand(req, res);
+                assert.fail('에러가 발생해야 합니다');
+            } catch (error) {
+                assert.ok(error instanceof Errors.BadRequest);
+                assert.equal(error.status, 400);
+                assert.equal(error.message, 'device_id header is required');
+            }
+        });
+
+        it('device_id 빈 문자열 → 400 BadRequest', async () => {
+            const req = makePostReq({ deviceId: '' });
+            const res = makeRes();
+
+            try {
+                await controller.postCommand(req, res);
+                assert.fail('에러가 발생해야 합니다');
+            } catch (error) {
+                assert.ok(error instanceof Errors.BadRequest);
+                assert.equal(error.status, 400);
+            }
+        });
+
+        it('command_text 누락 → 400 BadRequest', async () => {
+            const req = {
+                auth: { uid: 'user-1' },
+                header: (name) => name === 'device_id' ? 'device-1' : null,
+                body: {}
+            };
+            const res = makeRes();
+
+            try {
+                await controller.postCommand(req, res);
+                assert.fail('에러가 발생해야 합니다');
+            } catch (error) {
+                assert.ok(error instanceof Errors.BadRequest);
+                assert.equal(error.status, 400);
+                assert.equal(error.message, 'command_text is required');
+            }
+        });
+
+        it('command_text 빈 문자열 → 400 BadRequest', async () => {
+            const req = makePostReq({ commandText: '' });
+            const res = makeRes();
+
+            try {
+                await controller.postCommand(req, res);
+                assert.fail('에러가 발생해야 합니다');
+            } catch (error) {
+                assert.ok(error instanceof Errors.BadRequest);
+                assert.equal(error.status, 400);
+            }
+        });
+    });
+
+
+    // MARK: - getJob
+
+    describe('getJob', () => {
+
+        it('본인 job → 200 + job 직렬화 응답', async () => {
+            const job = makeJob({ jobId: 'job-123', userId: 'user-1' });
+            stubService.seedJob(job);
+            const req = makeGetReq({ uid: 'user-1', jobId: 'job-123' });
+            const res = makeRes();
+
+            await controller.getJob(req, res);
+
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, job.toJSON());
+        });
+
+        it('타인 job → 403 Forbidden throw (auth middleware 와 일관)', async () => {
+            const job = makeJob({ jobId: 'job-123', userId: 'other-user' });
+            stubService.seedJob(job);
+            const req = makeGetReq({ uid: 'user-1', jobId: 'job-123' });
+            const res = makeRes();
+
+            try {
+                await controller.getJob(req, res);
+                assert.fail('에러가 발생해야 합니다');
+            } catch (error) {
+                assert.ok(error instanceof Errors.Base);
+                assert.equal(error.status, 403);
+                assert.equal(error.code, 'Forbidden');
+            }
+        });
+
+        it('미존재 job → 404 NotFound', async () => {
+            const req = makeGetReq({ uid: 'user-1', jobId: 'nonexistent' });
+            const res = makeRes();
+
+            try {
+                await controller.getJob(req, res);
+                assert.fail('에러가 발생해야 합니다');
+            } catch (error) {
+                assert.ok(error instanceof Errors.NotFound);
+                assert.equal(error.status, 404);
+                assert.equal(error.message, 'job not found');
+            }
+        });
+    });
+});

--- a/functions/test/doubles/stubAiJobRepository.js
+++ b/functions/test/doubles/stubAiJobRepository.js
@@ -1,0 +1,103 @@
+
+'use strict';
+
+const AiJob = require('../../models/ai/AiJob');
+
+/**
+ * StubAiJobRepository — jobService / aiController / trigger 단위 테스트용 인메모리 stub.
+ *
+ * 인터페이스는 실 구현체(repositories/ai/jobRepository.js)와 동일.
+ *
+ * Record-only 정책: 검증/throw 로직은 shouldFail* flag 외에는 두지 않는다.
+ * lastXxx 프로퍼티에 raw 인자를 기록해 두면 테스트 케이스가 직접 assert 한다.
+ */
+class StubAiJobRepository {
+
+    constructor() {
+        /** @type {Map<string, object>} jobId → plain data */
+        this._store = new Map();
+
+        // failure flags
+        this.shouldFailLoad = false;
+        this.shouldFailPut = false;
+
+        // recorders
+        this.lastPutPayload = null;       // { jobId, data }
+        this.lastTransitionAttempt = null; // jobId (most recent call)
+    }
+
+    /**
+     * job 데이터를 Map 에 저장한다.
+     * lastPutPayload 에 raw 인자({ jobId, data })를 보관해
+     * 테스트에서 Object.getPrototypeOf(data) === Object.prototype 등을 직접 검증 가능.
+     *
+     * @param {string} jobId
+     * @param {object} data — plain object (custom prototype 금지)
+     */
+    async put(jobId, data) {
+        if (this.shouldFailPut) {
+            throw { message: 'stub put failed' };
+        }
+        this.lastPutPayload = { jobId, data };
+        this._store.set(jobId, Object.assign({}, data));
+    }
+
+    /**
+     * jobId 에 해당하는 job 을 AiJob 인스턴스로 반환한다.
+     * 없으면 null.
+     *
+     * @param {string} jobId
+     * @returns {Promise<AiJob|null>}
+     */
+    async load(jobId) {
+        if (this.shouldFailLoad) {
+            throw { message: 'stub load failed' };
+        }
+        const data = this._store.get(jobId);
+        if (!data) return null;
+        return AiJob.fromData(jobId, data);
+    }
+
+    /**
+     * PENDING → RUNNING 상태 전이 (Compare-And-Swap 시뮬레이션).
+     * 현재 status 가 PENDING 이면 RUNNING 으로 갱신하고 true 반환.
+     * 아니면 false (이미 RUNNING 이거나 terminal 상태인 경우 포함).
+     *
+     * lastTransitionAttempt 에 jobId 를 기록한다.
+     *
+     * @param {string} jobId
+     * @returns {Promise<boolean>}
+     */
+    async transitionToRunning(jobId) {
+        this.lastTransitionAttempt = jobId;
+        const data = this._store.get(jobId);
+        if (!data || data.status !== AiJob.STATUS.PENDING) {
+            return false;
+        }
+        data.status = AiJob.STATUS.RUNNING;
+        return true;
+    }
+
+    /**
+     * RUNNING → 종결 상태(result.type 매핑) 전이.
+     * 현재 status 가 RUNNING 이면 전이 + result 저장 후 true 반환.
+     * 아니면 false (재진입 / 잘못된 순서 방어).
+     *
+     * result.type 이 AiJob.STATUS 의 terminal 값(DONE/CONFIRM/FAILED)과 1:1 매핑.
+     *
+     * @param {string} jobId
+     * @param {{ type: 'DONE'|'CONFIRM'|'FAILED', [key: string]: any }} result
+     * @returns {Promise<boolean>}
+     */
+    async completeWith(jobId, result) {
+        const data = this._store.get(jobId);
+        if (!data || data.status !== AiJob.STATUS.RUNNING) {
+            return false;
+        }
+        data.status = result.type;   // 'DONE' | 'CONFIRM' | 'FAILED'
+        data.result = result;
+        return true;
+    }
+}
+
+module.exports = StubAiJobRepository;

--- a/functions/test/doubles/stubAiJobService.js
+++ b/functions/test/doubles/stubAiJobService.js
@@ -1,0 +1,31 @@
+
+
+const AiJob = require('../../models/ai/AiJob');
+
+
+class StubAiJobService {
+
+    constructor() {
+        this.shouldFail = false;
+        this.lastCreateJobArgs = null;
+        this._jobs = {};
+        this._nextJobId = 'job-123';
+    }
+
+    seedJob(job) {
+        this._jobs[job.jobId] = job;
+    }
+
+    async createJob({ userId, deviceId, commandText }) {
+        if (this.shouldFail) throw { message: 'service failed' };
+        this.lastCreateJobArgs = { userId, deviceId, commandText };
+        return this._nextJobId;
+    }
+
+    async loadJob(jobId) {
+        if (this.shouldFail) throw { message: 'service failed' };
+        return this._jobs[jobId] ?? null;
+    }
+}
+
+module.exports = StubAiJobService;

--- a/functions/test/e2e/ai-frontapi.e2e.js
+++ b/functions/test/e2e/ai-frontapi.e2e.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const assert = require('assert');
+const axios = require('axios');
+const admin = require('firebase-admin');
+
+const { authedClient } = require('./helpers/request');
+const { BASE_URL } = require('./helpers/request');
+
+const AUTH_EMULATOR_URL = 'http://127.0.0.1:9099';
+const PROJECT_ID = 'todocalendar-1707723626269';
+
+// ──────────────────────────────────────────────────────────────────────────
+// pollJob — terminal 상태(DONE/CONFIRM/FAILED)가 될 때까지 GET 반복
+// ──────────────────────────────────────────────────────────────────────────
+async function pollJob(client, jobId, { timeoutMs = 5000, intervalMs = 100 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const res = await client.get(`/v1/ai/jobs/${jobId}`);
+        if (res.status === 200 && ['DONE', 'CONFIRM', 'FAILED'].includes(res.data.status)) {
+            return res.data;
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error(`pollJob timeout (${timeoutMs}ms) — jobId: ${jobId}`);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// second user — Auth emulator 에서 발급
+// ──────────────────────────────────────────────────────────────────────────
+const SECOND_USER_UID = 'e2e-test-user-002';
+const SECOND_USER_EMAIL = 'e2e-test2@example.com';
+
+async function createSecondUserClient() {
+    try {
+        await admin.auth().deleteUser(SECOND_USER_UID);
+    } catch (_) {
+        // 없으면 무시
+    }
+    await admin.auth().createUser({
+        uid: SECOND_USER_UID,
+        email: SECOND_USER_EMAIL,
+        password: 'test-password-456'
+    });
+    const customToken = await admin.auth().createCustomToken(SECOND_USER_UID);
+    const response = await axios.post(
+        `${AUTH_EMULATOR_URL}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake-api-key`,
+        { token: customToken, returnSecureToken: true }
+    );
+    const idToken = response.data.idToken;
+    return axios.create({
+        baseURL: BASE_URL,
+        headers: { Authorization: `Bearer ${idToken}` },
+        validateStatus: () => true
+    });
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+describe('aiFrontAPI /v1/ai', function () {
+
+    let client;
+    let secondClient;
+
+    before(async function () {
+        this.timeout(15000);
+        client = authedClient();
+        secondClient = await createSecondUserClient();
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    describe('POST /v1/ai/command', function () {
+
+        it('device_id 헤더 누락 → 400', async function () {
+            const res = await client.post('/v1/ai/command', { command_text: 'hello' });
+            assert.strictEqual(res.status, 400);
+        });
+
+        it('DONE 골든 패스 — 202 → 폴링 → status DONE + result.type DONE', async function () {
+            this.timeout(10000);
+            const res = await client.post(
+                '/v1/ai/command',
+                { command_text: 'plain text' },
+                { headers: { device_id: 'e2e-device-001' } }
+            );
+            assert.strictEqual(res.status, 202);
+            assert.ok(res.data.job_id, 'job_id 가 응답에 있어야 함');
+
+            const job = await pollJob(client, res.data.job_id);
+            assert.strictEqual(job.status, 'DONE');
+            assert.strictEqual(job.result.type, 'DONE');
+        });
+
+        it('CONFIRM — command_text 에 [stub:CONFIRM] 포함 → 폴링 → status CONFIRM + result.action 존재', async function () {
+            this.timeout(10000);
+            const res = await client.post(
+                '/v1/ai/command',
+                { command_text: '[stub:CONFIRM] do something' },
+                { headers: { device_id: 'e2e-device-001' } }
+            );
+            assert.strictEqual(res.status, 202);
+
+            const job = await pollJob(client, res.data.job_id);
+            assert.strictEqual(job.status, 'CONFIRM');
+            assert.ok(job.result.action, 'result.action 이 존재해야 함');
+        });
+
+        it('FAILED — command_text 에 [stub:FAILED] 포함 → 폴링 → status FAILED + result.reason 존재', async function () {
+            this.timeout(10000);
+            const res = await client.post(
+                '/v1/ai/command',
+                { command_text: '[stub:FAILED] bad command' },
+                { headers: { device_id: 'e2e-device-001' } }
+            );
+            assert.strictEqual(res.status, 202);
+
+            const job = await pollJob(client, res.data.job_id);
+            assert.strictEqual(job.status, 'FAILED');
+            assert.ok(job.result.reason, 'result.reason 이 존재해야 함');
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    describe('GET /v1/ai/jobs/:id', function () {
+
+        it('타인 접근 — userA job 을 userB 토큰으로 조회 → 403', async function () {
+            this.timeout(10000);
+            // userA(기본 테스트 유저)가 job 생성
+            const postRes = await client.post(
+                '/v1/ai/command',
+                { command_text: 'test job for auth check' },
+                { headers: { device_id: 'e2e-device-001' } }
+            );
+            assert.strictEqual(postRes.status, 202);
+            const jobId = postRes.data.job_id;
+
+            // userB 토큰으로 조회
+            const getRes = await secondClient.get(`/v1/ai/jobs/${jobId}`);
+            assert.strictEqual(getRes.status, 403);
+        });
+    });
+});

--- a/functions/test/e2e/setup.js
+++ b/functions/test/e2e/setup.js
@@ -9,6 +9,15 @@ process.env.FIREBASE_AUTH_EMULATOR_HOST = '127.0.0.1:9099';
 // 읽어 양쪽이 동일한 값으로 동기화되게 한다.
 require('dotenv').config({ path: './secrets/.env.test' });
 
+// .env.test 로드 직후 환경 준비 확인 — before 훅 안에서 throw 하면 mocha 셋업 후에야
+// 에러가 보이지만, 모듈 로드 시점에 throw 하면 즉시 종료돼 피드백이 빠름.
+if (process.env.AI_STUB_DELAY_MS === undefined) {
+    throw new Error(
+        '[E2E setup] AI_STUB_DELAY_MS is not set. ' +
+        'Run: cp secrets/.env.test.example secrets/.env.test'
+    );
+}
+
 const admin = require('firebase-admin');
 const axios = require('axios');
 const { setAuthToken } = require('./helpers/request');
@@ -24,6 +33,7 @@ before(async function () {
     this.timeout(30000);
 
     // clear previous data (for manual emulator mode where data persists)
+    // 모든 컬렉션 전체 삭제 — ai_jobs 포함 (개별 컬렉션 cleanup 불필요).
     await clearFirestoreData();
 
     // create test user in Auth emulator (ignore if already exists)

--- a/functions/test/models/ai/AiJob.test.js
+++ b/functions/test/models/ai/AiJob.test.js
@@ -1,0 +1,188 @@
+
+const assert = require('assert');
+const AiJob = require('../../../models/ai/AiJob');
+
+describe('AiJob', () => {
+
+    describe('STATUS enum', () => {
+        it('5개 상태 상수가 모두 존재함', () => {
+            assert.strictEqual(AiJob.STATUS.PENDING, 'PENDING');
+            assert.strictEqual(AiJob.STATUS.RUNNING, 'RUNNING');
+            assert.strictEqual(AiJob.STATUS.DONE, 'DONE');
+            assert.strictEqual(AiJob.STATUS.CONFIRM, 'CONFIRM');
+            assert.strictEqual(AiJob.STATUS.FAILED, 'FAILED');
+        });
+    });
+
+    describe('isTerminal', () => {
+        it('DONE 은 terminal', () => {
+            assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.DONE), true);
+        });
+
+        it('CONFIRM 은 terminal', () => {
+            assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.CONFIRM), true);
+        });
+
+        it('FAILED 는 terminal', () => {
+            assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.FAILED), true);
+        });
+
+        it('PENDING 은 terminal 아님', () => {
+            assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.PENDING), false);
+        });
+
+        it('RUNNING 은 terminal 아님', () => {
+            assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.RUNNING), false);
+        });
+    });
+
+    describe('fromData', () => {
+        it('기본 필드로 AiJob 생성', () => {
+            const now = new Date('2026-05-17T00:00:00.000Z');
+            const data = {
+                userId: 'user-1',
+                deviceId: 'device-1',
+                commandText: 'test command',
+                status: AiJob.STATUS.PENDING,
+                result: null,
+                createdAt: now,
+                updatedAt: now,
+                expireAt: now
+            };
+            const job = AiJob.fromData('job-1', data);
+            assert.strictEqual(job.jobId, 'job-1');
+            assert.strictEqual(job.userId, 'user-1');
+            assert.strictEqual(job.deviceId, 'device-1');
+            assert.strictEqual(job.commandText, 'test command');
+            assert.strictEqual(job.status, AiJob.STATUS.PENDING);
+            assert.strictEqual(job.result, null);
+            assert.strictEqual(job.createdAt, now.toISOString());
+            assert.strictEqual(job.updatedAt, now.toISOString());
+            assert.strictEqual(job.expireAt, now.toISOString());
+        });
+
+        it('Firestore Timestamp 객체를 ISO string 으로 변환', () => {
+            const isoStr = '2026-05-17T12:00:00.000Z';
+            const fakeTimestamp = { toDate: () => new Date(isoStr) };
+            const data = {
+                userId: 'user-1',
+                deviceId: 'device-1',
+                commandText: 'command',
+                status: AiJob.STATUS.RUNNING,
+                result: null,
+                createdAt: fakeTimestamp,
+                updatedAt: fakeTimestamp,
+                expireAt: fakeTimestamp
+            };
+            const job = AiJob.fromData('job-2', data);
+            assert.strictEqual(job.createdAt, isoStr);
+            assert.strictEqual(job.updatedAt, isoStr);
+            assert.strictEqual(job.expireAt, isoStr);
+        });
+
+        it('ISO string 형태의 날짜도 안전하게 처리', () => {
+            const isoStr = '2026-05-17T12:00:00.000Z';
+            const data = {
+                userId: 'user-1',
+                deviceId: 'device-1',
+                commandText: 'command',
+                status: AiJob.STATUS.DONE,
+                result: { type: 'DONE', text: 'done' },
+                createdAt: isoStr,
+                updatedAt: isoStr,
+                expireAt: isoStr
+            };
+            const job = AiJob.fromData('job-3', data);
+            assert.strictEqual(job.createdAt, isoStr);
+            assert.strictEqual(job.updatedAt, isoStr);
+        });
+
+        it('result 가 있을 때 그대로 보존', () => {
+            const result = { type: 'DONE', text: '완료됐어' };
+            const now = new Date();
+            const data = {
+                userId: 'user-1',
+                deviceId: 'device-1',
+                commandText: 'command',
+                status: AiJob.STATUS.DONE,
+                result,
+                createdAt: now,
+                updatedAt: now,
+                expireAt: now
+            };
+            const job = AiJob.fromData('job-4', data);
+            assert.deepStrictEqual(job.result, result);
+        });
+    });
+
+    describe('toJSON', () => {
+        function makeJob(overrides = {}) {
+            const now = new Date('2026-05-17T00:00:00.000Z');
+            return AiJob.fromData('job-1', {
+                userId: 'user-1',
+                deviceId: 'device-1',
+                commandText: 'test command',
+                status: AiJob.STATUS.PENDING,
+                result: null,
+                createdAt: now,
+                updatedAt: now,
+                expireAt: now,
+                ...overrides
+            });
+        }
+
+        it('snake_case 필드로 직렬화', () => {
+            const job = makeJob();
+            const json = job.toJSON();
+            assert.strictEqual(json.job_id, 'job-1');
+            assert.strictEqual(json.user_id, 'user-1');
+            assert.strictEqual(json.device_id, 'device-1');
+            assert.strictEqual(json.command_text, 'test command');
+            assert.strictEqual(json.status, AiJob.STATUS.PENDING);
+            assert.strictEqual(json.result, null);
+            assert.strictEqual(json.created_at, '2026-05-17T00:00:00.000Z');
+            assert.strictEqual(json.updated_at, '2026-05-17T00:00:00.000Z');
+        });
+
+        it('expire_at 은 응답에 포함되지 않음', () => {
+            const job = makeJob();
+            const json = job.toJSON();
+            assert.strictEqual(json.expire_at, undefined);
+            assert.strictEqual(json.expireAt, undefined);
+        });
+
+        it('result 가 있을 때 포함됨', () => {
+            const result = { type: 'DONE', text: '결과 텍스트' };
+            const now = new Date();
+            const job = makeJob({ result, status: AiJob.STATUS.DONE });
+            const json = job.toJSON();
+            assert.deepStrictEqual(json.result, result);
+        });
+
+        it('fromData → toJSON 라운드트립 — 핵심 필드 누락 없음', () => {
+            const now = new Date('2026-05-17T09:00:00.000Z');
+            const data = {
+                userId: 'user-rt',
+                deviceId: 'device-rt',
+                commandText: 'round trip command',
+                status: AiJob.STATUS.RUNNING,
+                result: null,
+                createdAt: now,
+                updatedAt: now,
+                expireAt: now
+            };
+            const job = AiJob.fromData('job-rt', data);
+            const json = job.toJSON();
+
+            assert.strictEqual(json.job_id, 'job-rt');
+            assert.strictEqual(json.user_id, 'user-rt');
+            assert.strictEqual(json.device_id, 'device-rt');
+            assert.strictEqual(json.command_text, 'round trip command');
+            assert.strictEqual(json.status, AiJob.STATUS.RUNNING);
+            assert.strictEqual(json.result, null);
+            assert.strictEqual(json.created_at, now.toISOString());
+            assert.strictEqual(json.updated_at, now.toISOString());
+            assert.strictEqual(json.expire_at, undefined);
+        });
+    });
+});

--- a/functions/test/models/ai/AiJobResult.test.js
+++ b/functions/test/models/ai/AiJobResult.test.js
@@ -1,0 +1,131 @@
+
+const assert = require('assert');
+const AiJobResult = require('../../../models/ai/AiJobResult');
+
+describe('AiJobResult', () => {
+
+    describe('plain object 보장', () => {
+        it('done() 이 plain object 를 반환', () => {
+            const result = AiJobResult.done('텍스트');
+            assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+        });
+
+        it('confirm() 이 plain object 를 반환', () => {
+            const result = AiJobResult.confirm('텍스트', { type: 'add_todo' });
+            assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+        });
+
+        it('failed() 이 plain object 를 반환', () => {
+            const result = AiJobResult.failed('reason');
+            assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+        });
+    });
+
+    describe('done()', () => {
+        it('notification 없이 생성', () => {
+            const result = AiJobResult.done('완료 텍스트');
+            assert.strictEqual(result.type, 'DONE');
+            assert.strictEqual(result.text, '완료 텍스트');
+            assert.strictEqual(result.notification, undefined);
+        });
+
+        it('notification 있으면 포함', () => {
+            const notification = { title: '제목', body: '내용' };
+            const result = AiJobResult.done('완료 텍스트', notification);
+            assert.strictEqual(result.type, 'DONE');
+            assert.strictEqual(result.text, '완료 텍스트');
+            assert.deepStrictEqual(result.notification, notification);
+        });
+
+        it('notification null 이면 포함 안 됨', () => {
+            const result = AiJobResult.done('텍스트', null);
+            assert.strictEqual(result.notification, undefined);
+        });
+    });
+
+    describe('confirm()', () => {
+        it('notification 없이 생성', () => {
+            const action = { type: 'add_todo', payload: { name: 'test' } };
+            const result = AiJobResult.confirm('확인 텍스트', action);
+            assert.strictEqual(result.type, 'CONFIRM');
+            assert.strictEqual(result.text, '확인 텍스트');
+            assert.deepStrictEqual(result.action, action);
+            assert.strictEqual(result.notification, undefined);
+        });
+
+        it('notification 있으면 포함', () => {
+            const action = { type: 'add_schedule' };
+            const notification = { title: '확인해', body: '일정 추가할까?' };
+            const result = AiJobResult.confirm('텍스트', action, notification);
+            assert.strictEqual(result.type, 'CONFIRM');
+            assert.deepStrictEqual(result.notification, notification);
+        });
+
+        it('notification null 이면 포함 안 됨', () => {
+            const result = AiJobResult.confirm('텍스트', { type: 'noop' }, null);
+            assert.strictEqual(result.notification, undefined);
+        });
+    });
+
+    describe('failed()', () => {
+        it('notification 없이 생성', () => {
+            const result = AiJobResult.failed('처리 중 오류');
+            assert.strictEqual(result.type, 'FAILED');
+            assert.strictEqual(result.reason, '처리 중 오류');
+            assert.strictEqual(result.notification, undefined);
+        });
+
+        it('notification 있으면 포함', () => {
+            const notification = { title: '실패', body: '다시 시도해봐' };
+            const result = AiJobResult.failed('오류', notification);
+            assert.strictEqual(result.type, 'FAILED');
+            assert.deepStrictEqual(result.notification, notification);
+        });
+
+        it('notification null 이면 포함 안 됨', () => {
+            const result = AiJobResult.failed('오류', null);
+            assert.strictEqual(result.notification, undefined);
+        });
+    });
+
+    describe('hasNotification()', () => {
+        it('title 과 body 모두 non-empty string 이면 true', () => {
+            const result = AiJobResult.done('텍스트', { title: '제목', body: '내용' });
+            assert.strictEqual(AiJobResult.hasNotification(result), true);
+        });
+
+        it('notification 자체가 없으면 false', () => {
+            const result = AiJobResult.done('텍스트');
+            assert.strictEqual(AiJobResult.hasNotification(result), false);
+        });
+
+        it('빈 객체이면 false', () => {
+            const result = { type: 'DONE', text: '텍스트', notification: {} };
+            assert.strictEqual(AiJobResult.hasNotification(result), false);
+        });
+
+        it('title 이 빈 string 이면 false', () => {
+            const result = { type: 'DONE', text: '텍스트', notification: { title: '', body: '내용' } };
+            assert.strictEqual(AiJobResult.hasNotification(result), false);
+        });
+
+        it('body 가 빈 string 이면 false', () => {
+            const result = { type: 'DONE', text: '텍스트', notification: { title: '제목', body: '' } };
+            assert.strictEqual(AiJobResult.hasNotification(result), false);
+        });
+
+        it('title 만 있고 body 누락이면 false', () => {
+            const result = { type: 'DONE', text: '텍스트', notification: { title: '제목' } };
+            assert.strictEqual(AiJobResult.hasNotification(result), false);
+        });
+
+        it('body 만 있고 title 누락이면 false', () => {
+            const result = { type: 'DONE', text: '텍스트', notification: { body: '내용' } };
+            assert.strictEqual(AiJobResult.hasNotification(result), false);
+        });
+
+        it('result 자체가 null 이면 false', () => {
+            assert.strictEqual(AiJobResult.hasNotification(null), false);
+        });
+    });
+});

--- a/functions/test/services/ai/jobService.test.js
+++ b/functions/test/services/ai/jobService.test.js
@@ -1,0 +1,223 @@
+
+'use strict';
+
+const assert = require('assert');
+const JobService = require('../../../services/ai/jobService');
+const StubAiJobRepository = require('../../doubles/stubAiJobRepository');
+const AiJob = require('../../../models/ai/AiJob');
+const AiJobResult = require('../../../models/ai/AiJobResult');
+
+describe('JobService', () => {
+
+    let service;
+    let stubRepo;
+
+    beforeEach(() => {
+        stubRepo = new StubAiJobRepository();
+        service = new JobService(stubRepo);
+    });
+
+    // ------------------------------------------------------------------ //
+    // createJob
+    // ------------------------------------------------------------------ //
+
+    describe('createJob', () => {
+
+        it('repository 로 PENDING / null result / 24h 후 expireAt 인 plain object 가 넘어가고 jobId 가 반환됨', async () => {
+            const userId = 'user-1';
+            const deviceId = 'device-1';
+            const commandText = '내일 일정 알려줘';
+
+            const before = Date.now();
+            const jobId = await service.createJob({ userId, deviceId, commandText });
+            const after = Date.now();
+
+            assert.ok(typeof jobId === 'string' && jobId.length > 0, 'jobId 는 non-empty string');
+
+            const { jobId: storedJobId, data } = stubRepo.lastPutPayload;
+            assert.strictEqual(storedJobId, jobId);
+
+            // plain prototype 검증 (Firestore custom-prototype 거부 회피)
+            assert.strictEqual(
+                Object.getPrototypeOf(data),
+                Object.prototype,
+                'put data 는 plain object 여야 함'
+            );
+
+            // 필드값 검증
+            assert.strictEqual(data.userId, userId);
+            assert.strictEqual(data.deviceId, deviceId);
+            assert.strictEqual(data.commandText, commandText);
+            assert.strictEqual(data.status, AiJob.STATUS.PENDING);
+            assert.strictEqual(data.result, null);
+
+            // createdAt / updatedAt 은 본 서비스가 만들지 않음 (repo 가 serverTimestamp 로 채움)
+            assert.strictEqual(data.createdAt, undefined, 'createdAt 미포함');
+            assert.strictEqual(data.updatedAt, undefined, 'updatedAt 미포함');
+
+            // expireAt = now + 24h ± 1초
+            assert.ok(data.expireAt instanceof Date, 'expireAt 은 Date');
+            const expected24hLater = before + 24 * 60 * 60 * 1000;
+            const drift = data.expireAt.getTime() - expected24hLater;
+            assert.ok(
+                drift >= 0 && drift <= (after - before) + 1000,
+                `expireAt 이 now+24h 근처여야 함 (drift: ${drift}ms)`
+            );
+        });
+
+        it('repository put 이 실패하면 에러를 그대로 propagate', async () => {
+            stubRepo.shouldFailPut = true;
+            await assert.rejects(
+                () => service.createJob({ userId: 'u', deviceId: 'd', commandText: 'cmd' })
+            );
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // loadJob
+    // ------------------------------------------------------------------ //
+
+    describe('loadJob', () => {
+
+        it('존재하는 jobId → AiJob 인스턴스 반환', async () => {
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd'
+            });
+
+            const job = await service.loadJob(jobId);
+            assert.ok(job instanceof AiJob, 'AiJob 인스턴스 여야 함');
+            assert.strictEqual(job.jobId, jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.PENDING);
+        });
+
+        it('없는 jobId → null 반환', async () => {
+            const result = await service.loadJob('non-existent-id');
+            assert.strictEqual(result, null);
+        });
+
+        it('repository load 가 실패하면 에러를 그대로 propagate', async () => {
+            stubRepo.shouldFailLoad = true;
+            await assert.rejects(
+                () => service.loadJob('any-id')
+            );
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // transitionToRunning
+    // ------------------------------------------------------------------ //
+
+    describe('transitionToRunning', () => {
+
+        it('PENDING 인 job → true + status RUNNING 으로 전이', async () => {
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd'
+            });
+
+            const result = await service.transitionToRunning(jobId);
+            assert.strictEqual(result, true);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.RUNNING);
+        });
+
+        it('이미 RUNNING 인 job → false', async () => {
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd'
+            });
+            await service.transitionToRunning(jobId); // PENDING → RUNNING
+
+            const result = await service.transitionToRunning(jobId); // RUNNING → false
+            assert.strictEqual(result, false);
+        });
+
+        it('terminal(DONE) 상태인 job → false', async () => {
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd'
+            });
+            await service.transitionToRunning(jobId);
+            await service.completeWith(jobId, AiJobResult.done('완료'));
+
+            const result = await service.transitionToRunning(jobId);
+            assert.strictEqual(result, false);
+        });
+
+        it('race 시뮬레이션 — 같은 jobId 에 두 번 호출 시 첫 번째 true, 두 번째 false', async () => {
+            // 본 케이스는 stub 의 in-memory 동기 mutation 에 의존한 service 계약 검증
+            // (jobService 가 결과를 그대로 위임하고 변형하지 않는다). 실제 Firestore
+            // transaction 의 CAS 보장은 emulator E2E (Task 11) 에서 검증.
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd'
+            });
+
+            const [first, second] = await Promise.all([
+                service.transitionToRunning(jobId),
+                service.transitionToRunning(jobId)
+            ]);
+
+            // 둘 중 하나는 true, 하나는 false
+            assert.ok(first === true || second === true, '적어도 하나는 true');
+            assert.ok(first !== second, 'race 시 결과가 달라야 함');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // completeWith
+    // ------------------------------------------------------------------ //
+
+    describe('completeWith', () => {
+
+        async function setupRunningJob() {
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd'
+            });
+            await service.transitionToRunning(jobId);
+            return jobId;
+        }
+
+        it('done result → status DONE + result.type DONE', async () => {
+            const jobId = await setupRunningJob();
+            const result = AiJobResult.done('작업 완료');
+
+            const success = await service.completeWith(jobId, result);
+            assert.strictEqual(success, true);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.DONE);
+            assert.strictEqual(job.result.type, 'DONE');
+        });
+
+        it('confirm result → status CONFIRM + result.type CONFIRM', async () => {
+            const jobId = await setupRunningJob();
+            const result = AiJobResult.confirm('확인 요청', { action: 'create_todo', payload: {} });
+
+            const success = await service.completeWith(jobId, result);
+            assert.strictEqual(success, true);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.CONFIRM);
+            assert.strictEqual(job.result.type, 'CONFIRM');
+        });
+
+        it('failed result → status FAILED + result.type FAILED', async () => {
+            const jobId = await setupRunningJob();
+            const result = AiJobResult.failed('처리 실패 이유');
+
+            const success = await service.completeWith(jobId, result);
+            assert.strictEqual(success, true);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.FAILED);
+            assert.strictEqual(job.result.type, 'FAILED');
+        });
+
+        it('PENDING 상태에서 completeWith → false (RUNNING 이 아님)', async () => {
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd'
+            });
+
+            const success = await service.completeWith(jobId, AiJobResult.done('text'));
+            assert.strictEqual(success, false);
+        });
+    });
+});

--- a/functions/test/triggers/ai/agentLoopTrigger.test.js
+++ b/functions/test/triggers/ai/agentLoopTrigger.test.js
@@ -1,0 +1,294 @@
+'use strict';
+
+const assert = require('assert');
+const AgentLoopHandler = require('../../../triggers/ai/agentLoopHandler');
+const { FALLBACK_NOTIFICATION } = require('../../../triggers/ai/agentLoopHandler');
+const StubAiJobRepository = require('../../doubles/stubAiJobRepository');
+const JobService = require('../../../services/ai/jobService');
+const AiJob = require('../../../models/ai/AiJob');
+const AiJobResult = require('../../../models/ai/AiJobResult');
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeEvent(jobId, rawData) {
+    return {
+        params: { jobId },
+        data: { data: () => rawData }
+    };
+}
+
+const BASE_JOB_DATA = {
+    userId: 'user-1',
+    deviceId: 'device-1',
+    commandText: 'hello',
+    status: AiJob.STATUS.PENDING,
+    result: null,
+    expireAt: new Date(Date.now() + 86400_000)
+};
+
+const BASE_DEVICE = {
+    deviceId: 'device-1',
+    userId: 'user-1',
+    pushToken: 'fcm-token-abc',
+    deviceModel: 'iPhone'
+};
+
+// ── stub factories ────────────────────────────────────────────────────────────
+
+function makeMessaging() {
+    return {
+        lastSendPayload: null,
+        sendCalled: 0,
+        async send(payload) {
+            this.lastSendPayload = payload;
+            this.sendCalled += 1;
+        }
+    };
+}
+
+function makeUserRepository(device) {
+    return {
+        async loadUserDevice(_deviceId) {
+            return device ?? null;
+        }
+    };
+}
+
+function makeAgentLoopService(resultOverride) {
+    return {
+        async run(_commandText) {
+            return resultOverride ?? AiJobResult.done('stub done');
+        }
+    };
+}
+
+// warn/error 로그 캡처
+function captureLogger() {
+    const warns = [];
+    const errors = [];
+    return {
+        warns,
+        errors,
+        logger: {
+            warn(...args) { warns.push(args); },
+            error(...args) { errors.push(args); },
+            info(...args) {}
+        }
+    };
+}
+
+// seeded stub repo (PENDING 상태 job 미리 저장)
+function seededRepo(jobId = 'job-1', data = BASE_JOB_DATA) {
+    const repo = new StubAiJobRepository();
+    repo._store.set(jobId, Object.assign({}, data));
+    return repo;
+}
+
+function makeHandler({ jobService, agentLoopService, userRepository, messaging, logger }) {
+    return new AgentLoopHandler({ jobService, agentLoopService, userRepository, messaging, logger });
+}
+
+// ── cases ─────────────────────────────────────────────────────────────────────
+
+describe('AgentLoopHandler', () => {
+
+    it('정상 발화 — result.notification 없을 때 fallback DONE 카피로 FCM 발송', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(AiJobResult.done('stub done')); // no notification
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 1, 'FCM send 1회');
+        const payload = messaging.lastSendPayload;
+        assert.strictEqual(payload.token, BASE_DEVICE.pushToken);
+        assert.strictEqual(payload.notification.title, FALLBACK_NOTIFICATION.DONE.title);
+        assert.strictEqual(payload.notification.body, FALLBACK_NOTIFICATION.DONE.body);
+        assert.strictEqual(payload.data.jobId, 'job-1');
+        assert.strictEqual(payload.data.status, 'DONE');
+    });
+
+    it('정상 발화 — result.notification 있으면 그 값으로 FCM 발송', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const customNotification = { title: '커스텀 제목', body: '커스텀 본문' };
+        const agentLoopService = makeAgentLoopService(AiJobResult.done('stub done', customNotification));
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 1);
+        const payload = messaging.lastSendPayload;
+        assert.strictEqual(payload.notification.title, customNotification.title);
+        assert.strictEqual(payload.notification.body, customNotification.body);
+    });
+
+    it('같은 job 두 번째 발화 — transition CAS 실패로 agentLoop / FCM 모두 skip', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        let runCalled = 0;
+        const agentLoopService = {
+            async run() { runCalled += 1; return AiJobResult.done('x'); }
+        };
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));  // 1st — succeeds
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));  // 2nd — transition false
+
+        assert.strictEqual(runCalled, 1, 'agentLoop.run 은 1번만');
+        assert.strictEqual(messaging.sendCalled, 1, 'FCM 은 1번만');
+    });
+
+    it('device 미존재 — completeWith 까지는 호출, FCM skip + warn 로그', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService();
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(null); // device 없음
+        const { warns, logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        const stored = repo._store.get('job-1');
+        assert.strictEqual(stored.status, 'DONE', 'job 이 DONE 으로 종결');
+        assert.strictEqual(messaging.sendCalled, 0, 'FCM 미호출');
+        assert.ok(warns.length > 0, 'warn 로그 존재');
+    });
+
+    it('device.userId 가 job.userId 와 다르면 (기기 재할당) FCM skip + warn 로그', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService();
+        const messaging = makeMessaging();
+        const mismatchDevice = { ...BASE_DEVICE, userId: 'other-user' };
+        const userRepo = makeUserRepository(mismatchDevice);
+        const { warns, logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        const stored = repo._store.get('job-1');
+        assert.strictEqual(stored.status, 'DONE', 'job 이 DONE 으로 종결');
+        assert.strictEqual(messaging.sendCalled, 0, 'FCM 미호출');
+        assert.ok(warns.length > 0, 'warn 로그 존재');
+    });
+
+    it('result.type 이 CONFIRM 일 때 FCM 에 fallback CONFIRM 카피 사용', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(AiJobResult.confirm('stub confirm', { stub: true })); // no notification
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 1);
+        assert.strictEqual(messaging.lastSendPayload.notification.title, FALLBACK_NOTIFICATION.CONFIRM.title);
+        assert.strictEqual(messaging.lastSendPayload.data.status, 'CONFIRM');
+    });
+
+    it('result.type 이 FAILED 일 때 FCM 에 fallback FAILED 카피 사용', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(AiJobResult.failed('stub failed')); // no notification
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 1);
+        assert.strictEqual(messaging.lastSendPayload.notification.title, FALLBACK_NOTIFICATION.FAILED.title);
+        assert.strictEqual(messaging.lastSendPayload.data.status, 'FAILED');
+    });
+
+    it('result.notification 의 title 이 빈 문자열이면 hasNotification false → fallback 사용', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const partialNotification = { title: '', body: '본문은 있음' };
+        const agentLoopService = makeAgentLoopService(AiJobResult.done('stub done', partialNotification));
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 1);
+        assert.strictEqual(messaging.lastSendPayload.notification.title, FALLBACK_NOTIFICATION.DONE.title);
+    });
+
+    it('FCM 발송 중 네트워크 오류로 throw 가 발생해도 핸들러는 정상 종료', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService();
+        const failMessaging = {
+            async send() { throw new Error('FCM network error'); }
+        };
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { errors, logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging: failMessaging, logger });
+
+        await assert.doesNotReject(() => handler.handle(makeEvent('job-1', BASE_JOB_DATA)));
+        assert.ok(errors.length > 0, 'error 로그 기록');
+    });
+
+    it('agentLoopService.run 이 throw 하면 RUNNING 고착 대신 FAILED 로 종결 + FCM 발송', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const throwingLoop = {
+            async run(_commandText) { throw new Error('claude api timeout'); }
+        };
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { errors, logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService: throwingLoop, userRepository: userRepo, messaging, logger });
+
+        await assert.doesNotReject(() => handler.handle(makeEvent('job-1', BASE_JOB_DATA)));
+
+        const stored = repo._store.get('job-1');
+        assert.strictEqual(stored.status, AiJob.STATUS.FAILED);
+        assert.strictEqual(stored.result.type, 'FAILED');
+
+        assert.strictEqual(messaging.sendCalled, 1);
+        assert.strictEqual(messaging.lastSendPayload.notification.title, FALLBACK_NOTIFICATION.FAILED.title);
+        assert.strictEqual(messaging.lastSendPayload.data.status, 'FAILED');
+
+        assert.ok(errors.length > 0, 'agentLoop 실패 error 로그');
+    });
+
+    it('completeWith 가 false 를 반환하면 (외부 race) FCM 발송 skip + warn 로그', async () => {
+        const repo = seededRepo();
+        // jobService stub — transitionToRunning 은 true, completeWith 는 false 로 강제
+        const jobService = {
+            async transitionToRunning(_jobId) { return true; },
+            async completeWith(_jobId, _result) { return false; }
+        };
+        const agentLoopService = makeAgentLoopService();
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { warns, logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 0, 'FCM 미호출');
+        assert.ok(warns.length > 0, 'race warn 로그');
+    });
+});

--- a/functions/triggers/ai/agentLoopHandler.js
+++ b/functions/triggers/ai/agentLoopHandler.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const defaultLogger = require('firebase-functions/logger');
+const AiJob = require('../../models/ai/AiJob');
+const AiJobResult = require('../../models/ai/AiJobResult');
+
+// status 별 fallback notification — result.notification 이 비어 있을 때 사용.
+// Agent Loop 이 컨텍스트 기반 맞춤 메시지를 못 만들 때만 진입하는 path.
+// 다른 모듈에서 재사용 의도 없음 — handler 내부 private 상수.
+const FALLBACK_NOTIFICATION = Object.freeze({
+    DONE: Object.freeze({ title: 'AI 작업이 완료됐어요', body: '탭해서 결과를 확인해보세요' }),
+    CONFIRM: Object.freeze({ title: '확인이 필요해요', body: 'AI 가 작업 전 확인을 요청합니다' }),
+    FAILED: Object.freeze({ title: '처리에 실패했어요', body: '탭해서 자세히 확인해보세요' })
+});
+
+class AgentLoopHandler {
+
+    /**
+     * @param {{
+     *   jobService: import('../../services/ai/jobService'),
+     *   agentLoopService: { run(commandText: string): Promise<object> },
+     *   userRepository: { loadUserDevice(deviceId: string): Promise<object|null> },
+     *   messaging: { send(message: object): Promise<any> },
+     *   logger?: object
+     * }} deps
+     */
+    constructor({ jobService, agentLoopService, userRepository, messaging, logger }) {
+        this.jobService = jobService;
+        this.agentLoopService = agentLoopService;
+        this.userRepository = userRepository;
+        this.messaging = messaging;
+        this.log = logger ?? defaultLogger;
+    }
+
+    async handle(event) {
+        const jobId = event.params.jobId;
+        const rawData = event.data.data();
+        const job = AiJob.fromData(jobId, rawData);
+
+        // at-least-once 대응 — PENDING 이 아니면 (이미 RUNNING 이거나 종결) 즉시 반환
+        const acquired = await this.jobService.transitionToRunning(jobId);
+        if (!acquired) return;
+
+        // agentLoopService.run 이 throw 하면 job 이 RUNNING 에 영구 고착됨
+        // (다음 trigger 발화도 transition CAS 가 false 라 skip). 반드시 catch 해서
+        // FAILED 결과로 종결시켜야 함. #154 의 실제 Agent Loop 이 Claude API /
+        // MCP 호출 실패 시 throw 할 수 있음 — 본 stub 단계부터 인터페이스 잠금.
+        let result;
+        try {
+            result = await this.agentLoopService.run(job.commandText);
+        } catch (err) {
+            this.log.error('AI trigger — agentLoop 실패', { jobId, err });
+            result = AiJobResult.failed('agent loop error');
+        }
+
+        // completeWith false = 외부 process 가 이미 종결시킨 race. 우리가 만든 result 가
+        // 저장되지 않은 상태로 FCM 만 발송하면 클라가 보는 DB 상태와 알림이 엇갈림.
+        // RUNNING 가드 실패하면 발송 skip.
+        const completed = await this.jobService.completeWith(jobId, result);
+        if (!completed) {
+            this.log.warn('AI trigger — completeWith 가드 실패 (외부 race), FCM skip', { jobId });
+            return;
+        }
+
+        await this._sendFcm(job, result);
+    }
+
+    // _sendFcm — 보안 가드:
+    // (1) device 미존재 (사용자 로그아웃 / 기기 해지) → skip.
+    // (2) device.userId !== job.userId — 같은 deviceId 가 다른 사용자에게
+    //     재할당된 케이스. 본 가드 없이 발송하면 다른 유저 기기로 결과 메시지가
+    //     누출됨. 절대 제거하지 말 것.
+    async _sendFcm(job, result) {
+        const device = await this.userRepository.loadUserDevice(job.deviceId);
+        if (!device) {
+            this.log.warn('AI trigger — device 없음', { jobId: job.jobId, deviceId: job.deviceId });
+            return;
+        }
+        if (device.userId !== job.userId) {
+            this.log.warn('AI trigger — device.userId 불일치 (기기 재할당 가능성)', {
+                jobId: job.jobId,
+                jobUserId: job.userId,
+                deviceUserId: device.userId
+            });
+            return;
+        }
+
+        const notification = AiJobResult.hasNotification(result)
+            ? result.notification
+            : FALLBACK_NOTIFICATION[result.type];
+
+        if (!notification) {
+            this.log.warn('AI trigger — notification 없음 (알 수 없는 status)', { jobId: job.jobId, status: result.type });
+            return;
+        }
+
+        try {
+            await this.messaging.send({
+                token: device.pushToken,
+                notification: { title: notification.title, body: notification.body },
+                data: { jobId: job.jobId, status: result.type }
+            });
+        } catch (err) {
+            this.log.error('AI trigger — FCM 발송 실패', { jobId: job.jobId, err });
+        }
+    }
+}
+
+module.exports = AgentLoopHandler;
+module.exports.FALLBACK_NOTIFICATION = FALLBACK_NOTIFICATION;

--- a/functions/triggers/ai/agentLoopTrigger.js
+++ b/functions/triggers/ai/agentLoopTrigger.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/**
+ * agentLoopTrigger — ai_jobs/{jobId} onCreate Firestore 트리거 (composition root).
+ *
+ * Firebase Admin SDK 초기화(initializeApp) 가 index.js 에서 완료된 뒤에
+ * 이 파일이 require 되도록 index.js 에서 lazy-require 로 등록한다.
+ *
+ * 단위 테스트는 agentLoopHandler.js 의 AgentLoopHandler 클래스를 직접 import 해
+ * 의존성을 stub 으로 주입한다 — Firebase Admin SDK 초기화 불필요.
+ */
+
+const { onDocumentCreated } = require('firebase-functions/v2/firestore');
+const { getMessaging } = require('firebase-admin/messaging');
+
+const AgentLoopHandler = require('./agentLoopHandler');
+const JobRepository = require('../../repositories/ai/jobRepository');
+const JobService = require('../../services/ai/jobService');
+const AgentLoopStubService = require('../../services/ai/agentLoopStubService');
+const UserRepository = require('../../repositories/userRepository');
+
+const handler = new AgentLoopHandler({
+    jobService: new JobService(new JobRepository()),
+    agentLoopService: new AgentLoopStubService({
+        delayMs: parseInt(process.env.AI_STUB_DELAY_MS ?? '1000', 10)
+    }),
+    userRepository: new UserRepository(),
+    messaging: getMessaging()
+    // logger 생략 → AgentLoopHandler 내부에서 firebase-functions/logger 사용
+});
+
+module.exports = onDocumentCreated({
+    document: 'ai_jobs/{jobId}',
+    timeoutSeconds: 540,
+    memory: '1GiB'
+}, (event) => handler.handle(event));


### PR DESCRIPTION
## Summary

- 앱이 직접 호출하는 자연어 명령 진입점 `/v1/ai/*` 골격 구축. `POST /v1/ai/command` 가 jobId 즉시 반환 후 백그라운드에서 비동기 Job 진행.
- Agent Loop 은 stub — 가짜 결과(DONE/CONFIRM/FAILED) 를 일정 지연 후 저장. 실제 Claude API + MCP 호출은 #154 가 같은 자리에 끼워듦.
- Firestore onCreate trigger (`aiAgentLoop`, 540s/1GB) 가 별도 export 로 분리. HTTPS 부분은 가벼우니 기존 `apiV2` 에 합침 (1st gen `api` 는 일몰 예정이라 비대응).

## 작업 배경

부모 이슈 #151 의 1단계 MVP 중 aiFrontAPI 측. 자매 작업 #152 (openAPI MVP) 는 머지 완료. 본 PR 머지 후 #154 (실제 Agent Loop) 가 stub 자리만 갈아끼우면 됨.

## 주요 설계 결정

| 결정 | 이유 |
|---|---|
| Firestore onCreate trigger 로 Agent Loop 진입 | HTTPS 함수가 응답 후에도 무거운 작업을 도는 건 Cloud Functions 모델에 안 맞음. trigger 함수가 긴 timeout (540s) + 큰 memory (1GB) 가져감 |
| HTTPS 부분은 `apiV2` 에 합침 (별도 export X) | jobId 즉시 반환만 하니 가벼움. 1st gen `api` 는 일몰 예정이라 라우트 미러링 안 함 |
| `ai_jobs/{jobId}` 단일 컬렉션 (PENDING/RUNNING/DONE/CONFIRM/FAILED) | 결과/처리중 분리는 클라 race + transaction 필요. YAGNI |
| at-least-once 대응 = `PENDING → RUNNING` transaction CAS | trigger 가 같은 doc 두 번 발화 가능. 두 번째는 transition 실패로 즉시 종료. stub 단계부터 같은 패턴 정착해 #154 가 그대로 재사용 |
| FCM 발송 대상 = 요청 시 `device_id` 헤더의 device 한 곳 | 명령 보낸 클라에만 알림 (다른 device 중복 알림 X). 기존 `user_device/{deviceId}` 활용 |
| FCM 보안 가드 = `device.userId === job.userId` 검증 | 기기 재할당 시 다른 유저로 결과 누출 차단. 코드 주석에 의도 명시 (제거 방지) |
| Result `notification` 우선순위 = `result.notification` → status 별 fallback | Agent Loop 이 맥락 반영한 맞춤 메시지 만들면 그것 사용, 없으면 한국어 정형 fallback |
| agentLoopService.run() throw 시 FAILED 종결 | stub 은 throw 안 하지만 #154 의 Claude/MCP 호출 실패 대비 인터페이스 잠금. RUNNING 고착 방지 |

## 구조

```
functions/
├── models/ai/        AiJob, AiJobResult (Result union + hasNotification 가드)
├── repositories/ai/  jobRepository (Firestore transaction CAS)
├── services/ai/      jobService, agentLoopStubService, aiNotificationFallback
├── controllers/ai/   aiController (postCommand + getJob 한 컨트롤러)
├── routes/ai/        aiRoutes (composition root)
└── triggers/ai/      agentLoopHandler (factory) + agentLoopTrigger (Firebase wiring)
```

테스트는 미러:
- 단위: `test/{models,services,controllers,triggers}/ai/` (~70 케이스)
- E2E: `test/e2e/ai-frontapi.e2e.js` (5 시나리오 — DONE/CONFIRM/FAILED + device_id 누락 + 타인 접근)
- Stubs: `test/doubles/stubAiJobRepository.js`, `stubAiJobService.js` (record-only)

## API

### `POST /v1/ai/command`
- Auth: Firebase ID token
- Headers: `device_id` (필수)
- Body: `{ "command_text": string }`
- Response: `202 { "job_id": "..." }` / `400` (device_id 또는 command_text 누락)

### `GET /v1/ai/jobs/:id`
- Auth: Firebase ID token
- Response: `200` (job JSON, status + result) / `404` / `403` (타인 job)

### Stub 마커 (E2E 검증 용)
- `command_text` 에 `[stub:CONFIRM]` 포함 → CONFIRM 결과
- `command_text` 에 `[stub:FAILED]` 포함 → FAILED 결과
- 그 외 → DONE 결과

## 머지/배포 전 외부 수동 작업

1. **Firestore TTL policy 설정** (배포 직후 1회):
   \`\`\`
   gcloud firestore fields ttls update expireAt --collection-group=ai_jobs --enable-ttl --project=<project-id>
   \`\`\`
   (Firebase 콘솔에서도 가능)
2. **E2E 실행 전 env 셋업** (기존 환경 그대로 가능):
   \`\`\`
   cp functions/secrets/.env.test.example functions/secrets/.env.test
   \`\`\`
   (`AI_STUB_DELAY_MS=0` 포함 — 누락 시 setup.js 가 모듈 로드 시점에 throw)

## Test plan

- [x] 단위 테스트 — `cd functions && npm test` (1007 passing, 회귀 없음)
- [x] E2E 5 시나리오 — `cd functions && npm run test:e2e:run` (DONE/CONFIRM/FAILED + device_id 누락 + 타인 접근)
- [ ] (배포 후) 실환경 smoke — `command_text` POST → FCM 수신 확인 + GET 조회
- [ ] (배포 후) TTL policy 설정 후 24h 지난 doc 자동 삭제 확인

## 비범위 (의도적 제외 — 후속 이슈)

- 실제 Agent Loop 구현 (#154)
- 토큰 사용량 추적 (#156)
- 플랜별 한도 (#157)
- CONFIRM action HMAC 서명 (#158)
- Prompt Injection 방어 (#159)
- 민감정보 마스킹 로깅 (#160)
- Rate Limit (#161, 외부 공개 단계)
- Job list endpoint (`GET /v1/ai/jobs`)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)