### PR TITLE
[#156] 토큰 사용량 일별 추적 — AiUsage record + GET /v1/ai/usage

### DIFF
--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -13,8 +13,9 @@ function isValidTimezone(tz) {
 
 class AiController {
 
-    constructor(jobService) {
+    constructor(jobService, aiUsageService) {
         this.jobService = jobService;
+        this.aiUsageService = aiUsageService;
     }
 
     async postCommand(req, res) {
@@ -53,6 +54,11 @@ class AiController {
         }
 
         res.status(200).send(job.toJSON());
+    }
+
+    async getUsage(req, res) {
+        const usage = await this.aiUsageService.getTodayUsage(req.auth.uid);
+        res.status(200).send(usage.toJSON());
     }
 }
 

--- a/functions/models/ai/AiJob.js
+++ b/functions/models/ai/AiJob.js
@@ -1,26 +1,6 @@
 
 
-/**
- * Firestore Timestamp 객체, Date 인스턴스, ISO string 을 모두 ISO string 으로 정규화.
- * Firestore snapshot 의 Timestamp 타입에는 toDate() 메서드가 있다.
- *
- * 호출 경계: 본 모델의 시간 필드(createdAt/updatedAt/expireAt) 는 항상
- * Firestore Timestamp 로 저장됨 (jobRepository 가 FieldValue.serverTimestamp /
- * Timestamp.fromDate 만 사용). Date / ISO string 분기는 테스트 편의용 입력 케이스.
- * 그 외 타입(숫자 timestamp, 잘못된 형식 string 등) 은 caller 보장 — 정규화 안 함.
- */
-function toISOString(value) {
-    if (!value) return null;
-    if (typeof value.toDate === 'function') {
-        // Firestore Timestamp
-        return value.toDate().toISOString();
-    }
-    if (value instanceof Date) {
-        return value.toISOString();
-    }
-    // ISO string 가정 — 그 외 primitive 는 caller 보장
-    return value;
-}
+const { toISOString } = require('./_timestamp');
 
 class AiJob {
     constructor({ jobId, userId, deviceId, commandText, timezone, status, result, createdAt, updatedAt, expireAt }) {

--- a/functions/models/ai/AiUsage.js
+++ b/functions/models/ai/AiUsage.js
@@ -1,0 +1,40 @@
+
+
+const { toISOString } = require('./_timestamp');
+
+class AiUsage {
+    constructor({ dateKey, inputTokens, outputTokens, updatedAt }) {
+        this.dateKey = dateKey;
+        this.inputTokens = inputTokens ?? 0;
+        this.outputTokens = outputTokens ?? 0;
+        this.updatedAt = updatedAt ?? null;
+    }
+
+    static fromData(dateKey, data) {
+        return new AiUsage({
+            dateKey,
+            inputTokens: data.input_tokens ?? 0,
+            outputTokens: data.output_tokens ?? 0,
+            updatedAt: toISOString(data.updated_at)
+        });
+    }
+
+    /**
+     * 오늘 사용량이 아직 없는 사용자 조회 시 service 가 반환하는 빈 인스턴스.
+     * caller 가 null 분기 안 하게 만들어 API 응답에 항상 같은 shape 유지.
+     */
+    static empty(dateKey) {
+        return new AiUsage({ dateKey, inputTokens: 0, outputTokens: 0, updatedAt: null });
+    }
+
+    toJSON() {
+        return {
+            date: this.dateKey,
+            input_tokens: this.inputTokens,
+            output_tokens: this.outputTokens,
+            updated_at: this.updatedAt
+        };
+    }
+}
+
+module.exports = AiUsage;

--- a/functions/models/ai/_timestamp.js
+++ b/functions/models/ai/_timestamp.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * Firestore Timestamp / Date / ISO string 을 모두 ISO string 으로 정규화하는 공통 helper.
+ *
+ * 호출 경계: AI 모델들의 시간 필드 (createdAt / updatedAt / expireAt 등) 는 모두
+ * repository 가 FieldValue.serverTimestamp 또는 Timestamp.fromDate 로 저장하므로 snapshot
+ * 인입 시 Firestore Timestamp. Date / ISO string 분기는 테스트 편의용 입력 케이스.
+ * 그 외 타입(숫자 timestamp, 잘못된 형식 string 등) 은 caller 보장 — 정규화 안 함.
+ */
+function toISOString(value) {
+    if (!value) return null;
+    if (typeof value.toDate === 'function') {
+        // Firestore Timestamp
+        return value.toDate().toISOString();
+    }
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    return value;
+}
+
+module.exports = { toISOString };

--- a/functions/repositories/ai/aiUsageRepository.js
+++ b/functions/repositories/ai/aiUsageRepository.js
@@ -1,0 +1,52 @@
+
+
+const { getFirestore, FieldValue } = require('firebase-admin/firestore');
+const AiUsage = require('../../models/ai/AiUsage');
+
+const db = getFirestore();
+
+/**
+ * aiUsage/{userId}/dailyUsage/{YYYY-MM-DD} 의 일별 토큰 사용량 누적·조회.
+ *
+ * top-level collection `aiUsage` 아래 userId 별 doc, 그 안에 dailyUsage subcollection.
+ * AI 사용량 데이터를 사용자 프로파일(`users`) 과 분리해 독립적인 lifecycle / 권한 / 백업
+ * 정책을 갖게 함 — 사용자 doc 의 책임은 프로파일에 한정.
+ *
+ * dateKey 는 caller (aiUsageService) 가 server UTC 기준으로 만들어 넘김 — 본 repo 는
+ * 시간대 해석에 무지.
+ */
+class AiUsageRepository {
+
+    _docRef(userId, dateKey) {
+        return db.collection('aiUsage').doc(userId).collection('dailyUsage').doc(dateKey);
+    }
+
+    /**
+     * FieldValue.increment 로 atomic 누적. doc 미존재 시 set({merge:true}) 가
+     * 0 + inc 로 신규 생성. 동시 호출 (같은 user 의 병렬 job) 도 race 없이 합산.
+     *
+     * @param {string} userId
+     * @param {string} dateKey  'YYYY-MM-DD' (UTC)
+     * @param {{ inputTokens: number, outputTokens: number }} tokens
+     */
+    async increment(userId, dateKey, { inputTokens, outputTokens }) {
+        await this._docRef(userId, dateKey).set({
+            input_tokens: FieldValue.increment(inputTokens),
+            output_tokens: FieldValue.increment(outputTokens),
+            updated_at: FieldValue.serverTimestamp()
+        }, { merge: true });
+    }
+
+    /**
+     * @param {string} userId
+     * @param {string} dateKey
+     * @returns {Promise<AiUsage | null>}  doc 미존재 시 null
+     */
+    async load(userId, dateKey) {
+        const snapshot = await this._docRef(userId, dateKey).get();
+        if (!snapshot.exists) return null;
+        return AiUsage.fromData(dateKey, snapshot.data());
+    }
+}
+
+module.exports = AiUsageRepository;

--- a/functions/routes/ai/aiRoutes.js
+++ b/functions/routes/ai/aiRoutes.js
@@ -2,14 +2,19 @@
 const express = require('express');
 const JobRepository = require('../../repositories/ai/jobRepository');
 const JobService = require('../../services/ai/jobService');
+const AiUsageRepository = require('../../repositories/ai/aiUsageRepository');
+const AiUsageService = require('../../services/ai/aiUsageService');
 const AiController = require('../../controllers/ai/aiController');
 
 const jobRepository = new JobRepository();
 const jobService = new JobService(jobRepository);
-const controller = new AiController(jobService);
+const aiUsageRepository = new AiUsageRepository();
+const aiUsageService = new AiUsageService({ repository: aiUsageRepository });
+const controller = new AiController(jobService, aiUsageService);
 
 const router = express.Router();
 router.post('/command', (req, res) => controller.postCommand(req, res));
 router.get('/jobs/:id', (req, res) => controller.getJob(req, res));
+router.get('/usage', (req, res) => controller.getUsage(req, res));
 
 module.exports = router;

--- a/functions/services/ai/agentLoopService.js
+++ b/functions/services/ai/agentLoopService.js
@@ -91,13 +91,20 @@ class AgentLoopService {
     /**
      * @param {string} commandText
      * @param {{ userId: string, timezone: string }} context
-     * @returns {Promise<object>}  AiJobResult plain object
+     * @returns {Promise<{ result: object, usage: { inputTokens: number, outputTokens: number } }>}
+     *   result: AiJobResult plain object
+     *   usage: 호출 누적 토큰 — caller (AgentLoopHandler) 가 일별 record 입력으로 사용.
+     *          inputTokens 는 **마지막 createMessage 호출의 input_tokens** (Anthropic 가
+     *          매 호출에 누적 prompt 전체를 input_tokens 로 보고하기 때문 — turn 별 합산
+     *          시 double count 됨). outputTokens 는 모든 turn 합산.
+     *          throw 경로는 catch 안 함 → caller 가 0/0 으로 처리 (acceptable loss).
      */
     async run(commandText, { userId, timezone }) {
         const auth = { userId, scopes: this.scopes };
         const messages = [{ role: 'user', content: commandText }];
         let sumOutputTokens = 0;
         let lastInputTokens = 0;
+        const usage = () => ({ inputTokens: lastInputTokens, outputTokens: sumOutputTokens });
         const systemBlocks = [{
             type: 'text',
             text: this.systemPromptBuilder.build({ now: new Date(), timezone }),
@@ -128,35 +135,38 @@ class AgentLoopService {
             // Anthropic input_tokens includes all accumulated prompt tokens for the current call.
             // Summing input across turns would double-count. Use last call's input + cumulative output.
             if (lastInputTokens + sumOutputTokens > this.tokenCap) {
-                return AiJobResult.failed('token cap exceeded');
+                return { result: AiJobResult.failed('token cap exceeded'), usage: usage() };
             }
 
             messages.push({ role: 'assistant', content: resp.content });
             const toolUses = resp.content.filter(c => c.type === 'tool_use');
 
             if (toolUses.length === 0) {
-                return AiJobResult.failed('no tool_use returned');
+                return { result: AiJobResult.failed('no tool_use returned'), usage: usage() };
             }
 
             if (toolUses.length > 1) {
-                return AiJobResult.failed('multiple tool_uses in single turn');
+                return { result: AiJobResult.failed('multiple tool_uses in single turn'), usage: usage() };
             }
 
             const toolResults = [];
             for (const tu of toolUses) {
                 if (registry.isFinalize(tu.name)) {
-                    return this._mapFinalizeToResult(tu.input);
+                    return { result: this._mapFinalizeToResult(tu.input), usage: usage() };
                 }
                 try {
                     const result = await registry.execute(tu.name, tu.input, auth);
                     if (registry.isConfirmRequired(result)) {
                         const lang = detectLanguage(commandText);
                         const defaults = CONFIRM_DEFAULTS[lang];
-                        return AiJobResult.confirm(
-                            result.message || defaults.text,
-                            { tool: tu.name, args: tu.input, confirmToken: result.confirmToken },
-                            { title: getConfirmTitle(tu.name, lang), body: defaults.body }
-                        );
+                        return {
+                            result: AiJobResult.confirm(
+                                result.message || defaults.text,
+                                { tool: tu.name, args: tu.input, confirmToken: result.confirmToken },
+                                { title: getConfirmTitle(tu.name, lang), body: defaults.body }
+                            ),
+                            usage: usage()
+                        };
                     }
                     toolResults.push({
                         type: 'tool_result',
@@ -176,7 +186,7 @@ class AgentLoopService {
             messages.push({ role: 'user', content: toolResults });
         }
 
-        return AiJobResult.failed('loop cap exceeded');
+        return { result: AiJobResult.failed('loop cap exceeded'), usage: usage() };
     }
 }
 

--- a/functions/services/ai/aiUsageService.js
+++ b/functions/services/ai/aiUsageService.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const AiUsage = require('../../models/ai/AiUsage');
+
+/**
+ * 일별 토큰 사용량 record / 조회 정책.
+ *
+ * - dateKey 는 항상 **server UTC** 기준 'YYYY-MM-DD'.
+ *   클라 / 사용자 timezone 과 별개로 한 기준만 유지해 record / 조회의 일관성 보장.
+ * - record 는 양수 토큰이 하나라도 있을 때만 호출 — 빈 doc 생성 방지.
+ * - getTodayUsage 는 doc 미존재 시 0/0/null 빈 AiUsage 반환 (caller 의 null 분기 제거).
+ */
+class AiUsageService {
+
+    /**
+     * @param {{ repository: object, clock?: () => Date }} deps
+     *   clock: 테스트용 주입. 기본 () => new Date().
+     */
+    constructor({ repository, clock }) {
+        this.repository = repository;
+        this._clock = clock ?? (() => new Date());
+    }
+
+    _todayUtcKey() {
+        return this._clock().toISOString().slice(0, 10);
+    }
+
+    /**
+     * @param {string} userId
+     * @param {{ inputTokens: number | null | undefined, outputTokens: number | null | undefined }} tokens
+     */
+    async recordUsage(userId, { inputTokens, outputTokens }) {
+        const input = inputTokens || 0;
+        const output = outputTokens || 0;
+        if (input === 0 && output === 0) return;
+
+        const dateKey = this._todayUtcKey();
+        await this.repository.increment(userId, dateKey, { inputTokens: input, outputTokens: output });
+    }
+
+    /**
+     * @param {string} userId
+     * @returns {Promise<AiUsage>}  doc 미존재 시 빈 AiUsage (0/0/null)
+     */
+    async getTodayUsage(userId) {
+        const dateKey = this._todayUtcKey();
+        const usage = await this.repository.load(userId, dateKey);
+        return usage ?? AiUsage.empty(dateKey);
+    }
+}
+
+module.exports = AiUsageService;

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const AiController = require('../../../controllers/ai/aiController');
 const Errors = require('../../../models/Errors');
 const StubAiJobService = require('../../doubles/stubAiJobService');
+const StubAiUsageService = require('../../doubles/stubAiUsageService');
 const AiJob = require('../../../models/ai/AiJob');
 
 
@@ -48,11 +49,13 @@ function makeJob({ jobId = 'job-123', userId = 'user-1' } = {}) {
 describe('AiController', () => {
 
     let stubService;
+    let stubUsageService;
     let controller;
 
     beforeEach(() => {
         stubService = new StubAiJobService();
-        controller = new AiController(stubService);
+        stubUsageService = new StubAiUsageService();
+        controller = new AiController(stubService, stubUsageService);
     });
 
 
@@ -220,6 +223,47 @@ describe('AiController', () => {
                 assert.equal(error.status, 404);
                 assert.equal(error.message, 'job not found');
             }
+        });
+    });
+
+
+    // MARK: - getUsage
+
+    describe('getUsage', () => {
+
+        it('오늘 사용량 존재 — 200 + AiUsage.toJSON 응답', async () => {
+            stubUsageService.seedUsage('user-1', {
+                inputTokens: 1234,
+                outputTokens: 567,
+                updatedAt: new Date('2026-05-22T10:00:00.000Z'),
+                dateKey: '2026-05-22'
+            });
+            const req = { auth: { uid: 'user-1' } };
+            const res = makeRes();
+
+            await controller.getUsage(req, res);
+
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, {
+                date: '2026-05-22',
+                input_tokens: 1234,
+                output_tokens: 567,
+                updated_at: '2026-05-22T10:00:00.000Z'
+            });
+        });
+
+        it('오늘 사용량 doc 미존재 — 200 + 0/0/null 빈 응답 (caller 가 null 분기 안 하게)', async () => {
+            // seed 없음 → service 가 AiUsage.empty 반환
+            const req = { auth: { uid: 'user-no-history' } };
+            const res = makeRes();
+
+            await controller.getUsage(req, res);
+
+            assert.equal(res.statusCode, 200);
+            assert.equal(res.body.input_tokens, 0);
+            assert.equal(res.body.output_tokens, 0);
+            assert.equal(res.body.updated_at, null);
+            assert.ok(typeof res.body.date === 'string', 'date 필드는 비어있지 않음');
         });
     });
 });

--- a/functions/test/doubles/stubAiUsageRepository.js
+++ b/functions/test/doubles/stubAiUsageRepository.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const AiUsage = require('../../models/ai/AiUsage');
+
+/**
+ * StubAiUsageRepository — aiUsageService 단위 테스트용 인메모리 stub.
+ *
+ * 인터페이스는 실 구현체(repositories/ai/aiUsageRepository.js)와 동일.
+ *
+ * Record-only 정책: 검증/throw 로직은 shouldFail* flag 외에는 두지 않는다.
+ * 호출 인자는 lastIncrementPayload / allIncrementPayloads 에 raw 로 기록.
+ */
+class StubAiUsageRepository {
+
+    constructor() {
+        /** @type {Map<string, {input_tokens:number, output_tokens:number, updated_at:any}>} key: `${userId}/${dateKey}` */
+        this._store = new Map();
+
+        this.shouldFailIncrement = false;
+        this.shouldFailLoad = false;
+
+        // recorders
+        this.lastIncrementPayload = null;          // { userId, dateKey, tokens }
+        this.allIncrementPayloads = [];             // 호출 순서 보존
+    }
+
+    _key(userId, dateKey) {
+        return `${userId}/${dateKey}`;
+    }
+
+    async increment(userId, dateKey, { inputTokens, outputTokens }) {
+        if (this.shouldFailIncrement) {
+            throw { message: 'stub increment failed' };
+        }
+        const payload = { userId, dateKey, tokens: { inputTokens, outputTokens } };
+        this.lastIncrementPayload = payload;
+        this.allIncrementPayloads.push(payload);
+
+        const key = this._key(userId, dateKey);
+        const cur = this._store.get(key) || { input_tokens: 0, output_tokens: 0, updated_at: null };
+        this._store.set(key, {
+            input_tokens: cur.input_tokens + inputTokens,
+            output_tokens: cur.output_tokens + outputTokens,
+            updated_at: new Date()
+        });
+    }
+
+    async load(userId, dateKey) {
+        if (this.shouldFailLoad) {
+            throw { message: 'stub load failed' };
+        }
+        const data = this._store.get(this._key(userId, dateKey));
+        if (!data) return null;
+        return AiUsage.fromData(dateKey, data);
+    }
+
+    /**
+     * 테스트 셋업용 — load 결과를 직접 시드. increment 우회.
+     */
+    seed(userId, dateKey, { inputTokens, outputTokens, updatedAt = new Date() }) {
+        this._store.set(this._key(userId, dateKey), {
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            updated_at: updatedAt
+        });
+    }
+}
+
+module.exports = StubAiUsageRepository;

--- a/functions/test/doubles/stubAiUsageService.js
+++ b/functions/test/doubles/stubAiUsageService.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const AiUsage = require('../../models/ai/AiUsage');
+
+/**
+ * StubAiUsageService — aiController.getUsage 단위 테스트용 인메모리 stub.
+ *
+ * 인터페이스는 실 구현체(services/ai/aiUsageService.js)와 동일.
+ * Record-only 정책: 검증/throw 는 shouldFail* flag 외 두지 않음.
+ */
+class StubAiUsageService {
+
+    constructor() {
+        this._usageByUser = new Map();   // userId → AiUsage
+        this._defaultDateKey = '2026-05-22';
+
+        this.shouldFailGetTodayUsage = false;
+        this.shouldFailRecordUsage = false;
+
+        // recorders
+        this.allRecordCalls = [];
+        this.lastRecordCall = null;
+    }
+
+    /**
+     * 테스트 셋업용 — getTodayUsage 결과를 직접 시드.
+     */
+    seedUsage(userId, { inputTokens, outputTokens, updatedAt = new Date(), dateKey = this._defaultDateKey }) {
+        this._usageByUser.set(userId, new AiUsage({
+            dateKey,
+            inputTokens,
+            outputTokens,
+            updatedAt: updatedAt instanceof Date ? updatedAt.toISOString() : updatedAt
+        }));
+    }
+
+    async recordUsage(userId, tokens) {
+        if (this.shouldFailRecordUsage) {
+            throw { message: 'stub recordUsage failed' };
+        }
+        const call = { userId, tokens };
+        this.allRecordCalls.push(call);
+        this.lastRecordCall = call;
+    }
+
+    async getTodayUsage(userId) {
+        if (this.shouldFailGetTodayUsage) {
+            throw { message: 'stub getTodayUsage failed' };
+        }
+        return this._usageByUser.get(userId) ?? AiUsage.empty(this._defaultDateKey);
+    }
+}
+
+module.exports = StubAiUsageService;

--- a/functions/test/e2e/ai-usage.e2e.js
+++ b/functions/test/e2e/ai-usage.e2e.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const assert = require('assert');
+const axios = require('axios');
+const admin = require('firebase-admin');
+
+const { BASE_URL } = require('./helpers/request');
+
+const AUTH_EMULATOR_URL = 'http://127.0.0.1:9099';
+const PROJECT_ID = 'todocalendar-1707723626269';
+
+// 본 시나리오 전용 user — ai-frontapi.e2e.js 등 다른 e2e 가 건드린 ai_jobs / aiUsage
+// 누적 데이터와 격리되도록 별도 uid 사용. before 훅에서 매번 새로 생성.
+const USAGE_USER_UID = 'e2e-test-user-usage';
+const USAGE_USER_EMAIL = 'e2e-test-usage@example.com';
+
+// 사용량이 전혀 없는 user — 빈 응답 시나리오 전용.
+const EMPTY_USER_UID = 'e2e-test-user-empty';
+const EMPTY_USER_EMAIL = 'e2e-test-empty@example.com';
+
+// FakeAnthropicClient (markerFallback) 의 markerless 응답이 1턴 DONE finalize,
+// usage = { input_tokens: 10, output_tokens: 10 }. 호출당 input=10, output=10 누적.
+const PER_CALL_INPUT_TOKENS = 10;
+const PER_CALL_OUTPUT_TOKENS = 10;
+
+async function createAuthedClient(uid, email) {
+    try {
+        await admin.auth().deleteUser(uid);
+    } catch (_) { /* ignore */ }
+    await admin.auth().createUser({ uid, email, password: 'test-password-usage' });
+    const customToken = await admin.auth().createCustomToken(uid);
+    const response = await axios.post(
+        `${AUTH_EMULATOR_URL}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake-api-key`,
+        { token: customToken, returnSecureToken: true }
+    );
+    const idToken = response.data.idToken;
+    return axios.create({
+        baseURL: BASE_URL,
+        headers: { Authorization: `Bearer ${idToken}` },
+        validateStatus: () => true
+    });
+}
+
+async function pollJob(client, jobId, { timeoutMs = 5000, intervalMs = 100 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const res = await client.get(`/v1/ai/jobs/${jobId}`);
+        if (res.status === 200 && ['DONE', 'CONFIRM', 'FAILED'].includes(res.data.status)) {
+            return res.data;
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error(`pollJob timeout (${timeoutMs}ms) — jobId: ${jobId}`);
+}
+
+function todayUtcKey() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+async function deleteUsageDoc(uid, dateKey) {
+    const ref = admin.firestore().collection('aiUsage').doc(uid).collection('dailyUsage').doc(dateKey);
+    await ref.delete();
+}
+
+async function readUsageDoc(uid, dateKey) {
+    const snap = await admin.firestore().collection('aiUsage').doc(uid).collection('dailyUsage').doc(dateKey).get();
+    return snap.exists ? snap.data() : null;
+}
+
+async function postCommand(client, commandText = 'plain text') {
+    const res = await client.post(
+        '/v1/ai/command',
+        { command_text: commandText, timezone: 'Asia/Seoul' },
+        { headers: { device_id: 'e2e-device-usage' } }
+    );
+    assert.strictEqual(res.status, 202, `command 응답 202 — actual ${res.status} body ${JSON.stringify(res.data)}`);
+    return res.data.job_id;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+describe('aiUsage /v1/ai/usage', function () {
+
+    let usageClient;
+    let emptyClient;
+
+    before(async function () {
+        this.timeout(15000);
+        usageClient = await createAuthedClient(USAGE_USER_UID, USAGE_USER_EMAIL);
+        emptyClient = await createAuthedClient(EMPTY_USER_UID, EMPTY_USER_EMAIL);
+        // 본 시나리오 전용 user 의 오늘 doc 초기화 (이전 emulator run 잔여 제거)
+        await deleteUsageDoc(USAGE_USER_UID, todayUtcKey());
+        await deleteUsageDoc(EMPTY_USER_UID, todayUtcKey());
+    });
+
+    it('DONE 골든 command 1회 → Firestore aiUsage/{uid}/dailyUsage/{UTC-today} doc 에 input/output 토큰 누적', async function () {
+        this.timeout(10000);
+        const dateKey = todayUtcKey();
+
+        const jobId = await postCommand(usageClient);
+        const job = await pollJob(usageClient, jobId);
+        assert.strictEqual(job.status, 'DONE');
+
+        const doc = await readUsageDoc(USAGE_USER_UID, dateKey);
+        assert.ok(doc, `aiUsage doc 존재 (dateKey=${dateKey})`);
+        assert.strictEqual(doc.input_tokens, PER_CALL_INPUT_TOKENS);
+        assert.strictEqual(doc.output_tokens, PER_CALL_OUTPUT_TOKENS);
+        assert.ok(doc.updated_at, 'updated_at 채워짐');
+    });
+
+    it('같은 user 가 두 번째 command 발행 → 같은 dateKey doc 에 토큰 값이 합산됨 (atomic increment)', async function () {
+        this.timeout(10000);
+        const dateKey = todayUtcKey();
+
+        // 직전 케이스에서 이미 1회 누적된 상태 — 두 번째 command 후 doc 값이 2배여야 함.
+        const jobId = await postCommand(usageClient);
+        const job = await pollJob(usageClient, jobId);
+        assert.strictEqual(job.status, 'DONE');
+
+        const doc = await readUsageDoc(USAGE_USER_UID, dateKey);
+        assert.strictEqual(doc.input_tokens, PER_CALL_INPUT_TOKENS * 2);
+        assert.strictEqual(doc.output_tokens, PER_CALL_OUTPUT_TOKENS * 2);
+    });
+
+    it('GET /v1/ai/usage — 누적된 사용자가 조회 → 200 + 누적 token / today dateKey 응답', async function () {
+        const dateKey = todayUtcKey();
+        const res = await usageClient.get('/v1/ai/usage');
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(res.data.date, dateKey);
+        assert.strictEqual(res.data.input_tokens, PER_CALL_INPUT_TOKENS * 2);
+        assert.strictEqual(res.data.output_tokens, PER_CALL_OUTPUT_TOKENS * 2);
+        assert.ok(res.data.updated_at, 'updated_at 응답');
+    });
+
+    it('GET /v1/ai/usage — 사용량 doc 없는 user 조회 → 200 + 0/0/null 빈 응답 (균일 shape)', async function () {
+        const dateKey = todayUtcKey();
+        const res = await emptyClient.get('/v1/ai/usage');
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(res.data.date, dateKey);
+        assert.strictEqual(res.data.input_tokens, 0);
+        assert.strictEqual(res.data.output_tokens, 0);
+        assert.strictEqual(res.data.updated_at, null);
+    });
+});

--- a/functions/test/services/ai/agentLoopService.test.js
+++ b/functions/test/services/ai/agentLoopService.test.js
@@ -59,7 +59,7 @@ describe('AgentLoopService', () => {
             notification: { title: 'OK', body: '완료' }
         }));
 
-        const result = await service.run('할일 목록 보여줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 목록 보여줘', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'DONE');
         assert.strictEqual(result.text, '완료');
@@ -73,7 +73,7 @@ describe('AgentLoopService', () => {
         anthropic.enqueue(makeToolUseResponse('get_todos', {}));
         anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '할일 3개' }));
 
-        const result = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'DONE');
         assert.strictEqual(result.text, '할일 3개');
@@ -99,7 +99,7 @@ describe('AgentLoopService', () => {
 
         anthropic.enqueue(makeToolUseResponse('delete_todo', { todo_id: 't1' }));
 
-        const result = await service.run('할일 삭제해', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 삭제해', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'CONFIRM');
         assert.strictEqual(result.text, '확인이 필요한 작업이야');
@@ -126,7 +126,7 @@ describe('AgentLoopService', () => {
 
         anthropic.enqueue(makeToolUseResponse('delete_todo', { todo_id: 't1' }));
 
-        const result = await service.run('delete a todo', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('delete a todo', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'CONFIRM');
         assert.strictEqual(result.text, 'Confirmation required for this action');
@@ -146,7 +146,7 @@ describe('AgentLoopService', () => {
 
         anthropic.enqueue(makeToolUseResponse('delete_todo', { todo_id: 't1' }));
 
-        const result = await service.run('할일 삭제', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 삭제', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'CONFIRM');
         assert.strictEqual(result.text, '정말 삭제할 거야?');
@@ -164,7 +164,7 @@ describe('AgentLoopService', () => {
 
         anthropic.enqueue(makeToolUseResponse('future_tool', { some_arg: 'x' }));
 
-        const result = await service.run('미래 기능 실행해', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('미래 기능 실행해', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'CONFIRM');
         assert.strictEqual(result.notification.title, '확인 필요');
@@ -177,7 +177,7 @@ describe('AgentLoopService', () => {
             text: '요청 처리 불가'
         }));
 
-        const result = await service.run('할 수 없는 것', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할 수 없는 것', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'FAILED');
         assert.strictEqual(result.reason, '요청 처리 불가');
@@ -202,7 +202,7 @@ describe('AgentLoopService', () => {
             scopes: ['read:calendar']
         });
 
-        const result = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'FAILED');
         assert.strictEqual(result.reason, 'loop cap exceeded');
@@ -225,7 +225,7 @@ describe('AgentLoopService', () => {
             scopes: ['read:calendar']
         });
 
-        const result = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'FAILED');
         assert.strictEqual(result.reason, 'token cap exceeded');
@@ -244,7 +244,7 @@ describe('AgentLoopService', () => {
         anthropic.enqueue(makeToolUseResponse('get_todos', {}));
         anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '복구 후 완료' }));
 
-        const result = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'DONE');
         assert.strictEqual(result.text, '복구 후 완료');
@@ -327,7 +327,7 @@ describe('AgentLoopService', () => {
             usage: { input_tokens: 10, output_tokens: 10 }
         });
 
-        const result = await service.run('할일 삭제해', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 삭제해', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         assert.strictEqual(result.type, 'FAILED');
         assert.strictEqual(result.reason, 'multiple tool_uses in single turn');
@@ -383,7 +383,7 @@ describe('AgentLoopService', () => {
             scopes: ['read:calendar']
         });
 
-        const result = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+        const { result } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
 
         // over-count 였다면 100+10+200+10=320 > 250 → FAILED.
         // 올바른 계산: 200(last input) + 20(sum output) = 220 ≤ 250 → DONE.
@@ -455,6 +455,71 @@ describe('AgentLoopService', () => {
         assert.ok(capturedArgs !== null, 'build 가 호출됨');
         assert.ok(capturedArgs.now instanceof Date, 'now 는 Date 인스턴스');
         assert.strictEqual(capturedArgs.timezone, 'America/New_York');
+    });
+
+    // ─── usage 노출 (#156) ────────────────────────────────────────────────────
+
+    it('multi-turn DONE 시 반환 usage 는 outputTokens 합 + inputTokens 마지막 turn 값', async () => {
+        const { service, anthropic, registry } = makeService();
+        registry.registerExecute('get_todos', { items: [] });
+
+        // turn1: input=100, output=20 / turn2: input=180, output=30
+        // 기대값: inputTokens=180 (마지막), outputTokens=50 (합)
+        anthropic.enqueue(makeToolUseResponse('get_todos', {}, { input_tokens: 100, output_tokens: 20 }));
+        anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '완료' }, { input_tokens: 180, output_tokens: 30 }));
+
+        const { result, usage } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+
+        assert.strictEqual(result.type, 'DONE');
+        assert.deepStrictEqual(usage, { inputTokens: 180, outputTokens: 50 });
+    });
+
+    it('token cap 초과로 FAILED 종결되어도 usage 반환에 마지막 turn 의 토큰이 포함됨', async () => {
+        const registry = new StubToolRegistry();
+        const anthropic = new FakeAnthropicClient();
+        registry.registerExecute('get_todos', { items: [] });
+
+        anthropic.enqueue(makeToolUseResponse('get_todos', {}, { input_tokens: 200, output_tokens: 50 }));
+
+        const service = new AgentLoopService({
+            anthropic,
+            registryFactory: () => Promise.resolve(registry),
+            systemPromptBuilder: { build: () => 'stub-prompt' },
+            loopCap: 10,
+            tokenCap: 100,
+            scopes: ['read:calendar']
+        });
+
+        const { result, usage } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+
+        assert.strictEqual(result.type, 'FAILED');
+        assert.strictEqual(result.reason, 'token cap exceeded');
+        assert.deepStrictEqual(usage, { inputTokens: 200, outputTokens: 50 });
+    });
+
+    it('loop cap 초과로 FAILED 종결되어도 usage 반환에 모든 turn 누적이 포함됨', async () => {
+        const registry = new StubToolRegistry();
+        const anthropic = new FakeAnthropicClient();
+        registry.registerExecute('get_todos', { items: [] });
+
+        // loopCap=2, 두 turn 모두 non-finalize → loop cap exceeded
+        anthropic.enqueue(makeToolUseResponse('get_todos', {}, { input_tokens: 50, output_tokens: 10 }));
+        anthropic.enqueue(makeToolUseResponse('get_todos', {}, { input_tokens: 120, output_tokens: 15 }));
+
+        const service = new AgentLoopService({
+            anthropic,
+            registryFactory: () => Promise.resolve(registry),
+            systemPromptBuilder: { build: () => 'stub-prompt' },
+            loopCap: 2,
+            tokenCap: 50000,
+            scopes: ['read:calendar']
+        });
+
+        const { result, usage } = await service.run('할일 알려줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+
+        assert.strictEqual(result.type, 'FAILED');
+        assert.strictEqual(result.reason, 'loop cap exceeded');
+        assert.deepStrictEqual(usage, { inputTokens: 120, outputTokens: 25 });
     });
 
 });

--- a/functions/test/services/ai/aiUsageService.test.js
+++ b/functions/test/services/ai/aiUsageService.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const assert = require('assert');
+const AiUsageService = require('../../../services/ai/aiUsageService');
+const StubAiUsageRepository = require('../../doubles/stubAiUsageRepository');
+const AiUsage = require('../../../models/ai/AiUsage');
+
+describe('AiUsageService', () => {
+
+    let stubRepo;
+
+    function makeService({ now }) {
+        stubRepo = new StubAiUsageRepository();
+        const clock = () => new Date(now);
+        return new AiUsageService({ repository: stubRepo, clock });
+    }
+
+    // ------------------------------------------------------------------ //
+    // recordUsage
+    // ------------------------------------------------------------------ //
+
+    describe('recordUsage', () => {
+
+        it('inputTokens / outputTokens 가 양수이면 UTC 오늘 dateKey 의 doc 에 그대로 적재됨', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+
+            await service.recordUsage('user-1', { inputTokens: 100, outputTokens: 50 });
+
+            const stored = await stubRepo.load('user-1', '2026-05-22');
+            assert.strictEqual(stored.inputTokens, 100);
+            assert.strictEqual(stored.outputTokens, 50);
+        });
+
+        it('inputTokens / outputTokens 가 모두 0 이면 빈 doc 이 생성되지 않음', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+
+            await service.recordUsage('user-1', { inputTokens: 0, outputTokens: 0 });
+
+            const stored = await stubRepo.load('user-1', '2026-05-22');
+            assert.strictEqual(stored, null);
+        });
+
+        it('inputTokens / outputTokens 가 null / undefined 이면 빈 doc 이 생성되지 않음', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+
+            await service.recordUsage('user-1', { inputTokens: null, outputTokens: undefined });
+
+            const stored = await stubRepo.load('user-1', '2026-05-22');
+            assert.strictEqual(stored, null);
+        });
+
+        it('한 쪽만 0 이고 다른 쪽이 양수면 doc 에 그대로 적재 (no-op 조건은 둘 다 0/falsy 일 때만)', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+
+            await service.recordUsage('user-1', { inputTokens: 100, outputTokens: 0 });
+
+            const stored = await stubRepo.load('user-1', '2026-05-22');
+            assert.strictEqual(stored.inputTokens, 100);
+            assert.strictEqual(stored.outputTokens, 0);
+        });
+
+        it('같은 user / 같은 UTC 날짜에 두 번 record 하면 doc 에 토큰이 합산됨', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+
+            await service.recordUsage('user-1', { inputTokens: 100, outputTokens: 50 });
+            await service.recordUsage('user-1', { inputTokens: 30, outputTokens: 20 });
+
+            const stored = await stubRepo.load('user-1', '2026-05-22');
+            assert.strictEqual(stored.inputTokens, 130);
+            assert.strictEqual(stored.outputTokens, 70);
+        });
+
+        it('UTC 자정 경계 — KST 09:00 직전(UTC 어제) 과 직후(UTC 오늘) record 는 서로 다른 doc 에 저장됨', async () => {
+            // KST 09:00 = UTC 00:00. 그 직전 (UTC 어제 23:59:59) 과 직후 (UTC 오늘 00:00:01) 로 두 번 record.
+            stubRepo = new StubAiUsageRepository();
+            const before = new AiUsageService({ repository: stubRepo, clock: () => new Date('2026-05-22T23:59:59.000Z') });
+            const after = new AiUsageService({ repository: stubRepo, clock: () => new Date('2026-05-23T00:00:01.000Z') });
+
+            await before.recordUsage('user-1', { inputTokens: 10, outputTokens: 5 });
+            await after.recordUsage('user-1', { inputTokens: 20, outputTokens: 10 });
+
+            const yesterday = await stubRepo.load('user-1', '2026-05-22');
+            const today = await stubRepo.load('user-1', '2026-05-23');
+
+            assert.strictEqual(yesterday.inputTokens, 10);
+            assert.strictEqual(yesterday.outputTokens, 5);
+            assert.strictEqual(today.inputTokens, 20);
+            assert.strictEqual(today.outputTokens, 10);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // getTodayUsage
+    // ------------------------------------------------------------------ //
+
+    describe('getTodayUsage', () => {
+
+        it('오늘 doc 이 존재하면 누적값을 그대로 반환', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+            await service.recordUsage('user-1', { inputTokens: 1234, outputTokens: 567 });
+
+            const usage = await service.getTodayUsage('user-1');
+
+            assert.ok(usage instanceof AiUsage);
+            assert.strictEqual(usage.dateKey, '2026-05-22');
+            assert.strictEqual(usage.inputTokens, 1234);
+            assert.strictEqual(usage.outputTokens, 567);
+        });
+
+        it('오늘 doc 이 없으면 0/0/null 빈 AiUsage 반환 (caller 의 null 분기 부재)', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+
+            const usage = await service.getTodayUsage('user-no-history');
+
+            assert.ok(usage instanceof AiUsage);
+            assert.strictEqual(usage.dateKey, '2026-05-22');
+            assert.strictEqual(usage.inputTokens, 0);
+            assert.strictEqual(usage.outputTokens, 0);
+            assert.strictEqual(usage.updatedAt, null);
+        });
+    });
+});

--- a/functions/test/triggers/ai/agentLoopTrigger.test.js
+++ b/functions/test/triggers/ai/agentLoopTrigger.test.js
@@ -60,14 +60,17 @@ function makeUserRepository(device) {
     };
 }
 
-function makeAgentLoopService(resultOverride) {
+function makeAgentLoopService(resultOverride, usageOverride) {
     return {
         lastRunArgs: null,
         allRunArgs: [],
         async run(commandText, opts) {
             this.lastRunArgs = { commandText, opts };
             this.allRunArgs.push({ commandText, opts });
-            return resultOverride ?? AiJobResult.done('stub done');
+            return {
+                result: resultOverride ?? AiJobResult.done('stub done'),
+                usage: usageOverride ?? { inputTokens: 0, outputTokens: 0 }
+            };
         }
     };
 }
@@ -94,8 +97,29 @@ function seededRepo(jobId = 'job-1', data = BASE_JOB_DATA) {
     return repo;
 }
 
-function makeHandler({ jobService, agentLoopService, userRepository, messaging, logger }) {
-    return new AgentLoopHandler({ jobService, agentLoopService, userRepository, messaging, logger });
+function makeAiUsageService() {
+    return {
+        allRecordCalls: [],
+        lastRecordCall: null,
+        shouldFailRecord: false,
+        async recordUsage(userId, tokens) {
+            if (this.shouldFailRecord) throw new Error('stub recordUsage failed');
+            const call = { userId, tokens };
+            this.allRecordCalls.push(call);
+            this.lastRecordCall = call;
+        }
+    };
+}
+
+function makeHandler({ jobService, agentLoopService, aiUsageService, userRepository, messaging, logger }) {
+    return new AgentLoopHandler({
+        jobService,
+        agentLoopService,
+        aiUsageService: aiUsageService ?? makeAiUsageService(),
+        userRepository,
+        messaging,
+        logger
+    });
 }
 
 // ── cases ─────────────────────────────────────────────────────────────────────
@@ -151,7 +175,7 @@ describe('AgentLoopHandler', () => {
         const jobService = new JobService(repo);
         let runCalled = 0;
         const agentLoopService = {
-            async run() { runCalled += 1; return AiJobResult.done('x'); }
+            async run() { runCalled += 1; return { result: AiJobResult.done('x'), usage: { inputTokens: 0, outputTokens: 0 } }; }
         };
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -357,5 +381,107 @@ describe('AgentLoopHandler', () => {
 
         assert.strictEqual(messaging.sendCalled, 0, 'FCM 미호출');
         assert.ok(warns.length > 0, 'race warn 로그');
+    });
+
+    // ─── usage record (#156) ──────────────────────────────────────────────────
+
+    it('DONE 결과로 종결되면 aiUsageService.recordUsage 가 job.userId 와 usage 토큰으로 호출됨', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(
+            AiJobResult.done('stub done'),
+            { inputTokens: 1200, outputTokens: 340 }
+        );
+        const aiUsageService = makeAiUsageService();
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, aiUsageService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(aiUsageService.allRecordCalls.length, 1);
+        assert.deepStrictEqual(aiUsageService.lastRecordCall, {
+            userId: BASE_JOB_DATA.userId,
+            tokens: { inputTokens: 1200, outputTokens: 340 }
+        });
+    });
+
+    it('CONFIRM 결과로 종결되어도 동일하게 usage record 호출', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(
+            AiJobResult.confirm('stub confirm', { stub: true }),
+            { inputTokens: 500, outputTokens: 60 }
+        );
+        const aiUsageService = makeAiUsageService();
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, aiUsageService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.deepStrictEqual(aiUsageService.lastRecordCall, {
+            userId: BASE_JOB_DATA.userId,
+            tokens: { inputTokens: 500, outputTokens: 60 }
+        });
+    });
+
+    it('FAILED 결과 (finalize 또는 cap 초과) 종결 시에도 usage record 호출', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(
+            AiJobResult.failed('stub failed'),
+            { inputTokens: 800, outputTokens: 200 }
+        );
+        const aiUsageService = makeAiUsageService();
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, aiUsageService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.deepStrictEqual(aiUsageService.lastRecordCall, {
+            userId: BASE_JOB_DATA.userId,
+            tokens: { inputTokens: 800, outputTokens: 200 }
+        });
+    });
+
+    it('agentLoopService.run 이 throw 한 경로에서는 usage record 호출되지 않음 (partial usage 손실)', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const throwingLoop = {
+            async run(_commandText, _opts) { throw new Error('claude api timeout'); }
+        };
+        const aiUsageService = makeAiUsageService();
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService: throwingLoop, aiUsageService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(aiUsageService.allRecordCalls.length, 0);
+    });
+
+    it('aiUsageService.recordUsage 가 throw 해도 후속 FCM 발송은 정상 진행', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(
+            AiJobResult.done('stub done'),
+            { inputTokens: 100, outputTokens: 30 }
+        );
+        const aiUsageService = makeAiUsageService();
+        aiUsageService.shouldFailRecord = true;
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, aiUsageService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 1, 'record 실패와 무관하게 FCM 발송');
     });
 });

--- a/functions/triggers/ai/agentLoopHandler.js
+++ b/functions/triggers/ai/agentLoopHandler.js
@@ -27,15 +27,17 @@ class AgentLoopHandler {
     /**
      * @param {{
      *   jobService: import('../../services/ai/jobService'),
-     *   agentLoopService: { run(commandText: string, opts: { userId: string }): Promise<object> },
+     *   agentLoopService: { run(commandText, opts): Promise<{ result: object, usage: { inputTokens: number, outputTokens: number } }> },
+     *   aiUsageService: { recordUsage(userId, tokens): Promise<void> },
      *   userRepository: { loadUserDevice(deviceId: string): Promise<object|null> },
      *   messaging: { send(message: object): Promise<any> },
      *   logger?: object
      * }} deps
      */
-    constructor({ jobService, agentLoopService, userRepository, messaging, logger }) {
+    constructor({ jobService, agentLoopService, aiUsageService, userRepository, messaging, logger }) {
         this.jobService = jobService;
         this.agentLoopService = agentLoopService;
+        this.aiUsageService = aiUsageService;
         this.userRepository = userRepository;
         this.messaging = messaging;
         this.log = logger ?? defaultLogger;
@@ -55,11 +57,20 @@ class AgentLoopHandler {
         // FAILED 결과로 종결시켜야 함. #154 의 실제 Agent Loop 이 Claude API /
         // MCP 호출 실패 시 throw 할 수 있음 — 본 stub 단계부터 인터페이스 잠금.
         let result;
+        let usage = null;
         try {
-            result = await this.agentLoopService.run(job.commandText, { userId: job.userId, timezone: job.timezone });
+            ({ result, usage } = await this.agentLoopService.run(job.commandText, { userId: job.userId, timezone: job.timezone }));
         } catch (err) {
             this.log.error('AI trigger — agentLoop 실패', { jobId, err });
             result = AiJobResult.failed('agent loop error');
+            // throw 경로는 usage 추출 불가 — 부분 사용 토큰이 있어도 손실 (acceptable loss).
+            // 정밀도 필요 시 service 가 throw 대신 partial usage 동봉한 error 객체로 전환 필요.
+        }
+
+        // 일별 사용량 record — completeWith / FCM 흐름과 독립. record 실패가 후속 단계를
+        // 막지 않도록 try/catch 로 격리. usage 가 0/0 이면 service 가 no-op.
+        if (usage) {
+            await this._recordUsage(job.userId, usage, jobId);
         }
 
         // completeWith false = 외부 process 가 이미 종결시킨 race. 우리가 만든 result 가
@@ -72,6 +83,14 @@ class AgentLoopHandler {
         }
 
         await this._sendFcm(job, result);
+    }
+
+    async _recordUsage(userId, usage, jobId) {
+        try {
+            await this.aiUsageService.recordUsage(userId, usage);
+        } catch (err) {
+            this.log.error('AI trigger — aiUsage record 실패', { jobId, err });
+        }
     }
 
     // _sendFcm — 보안 가드:

--- a/functions/triggers/ai/agentLoopTrigger.js
+++ b/functions/triggers/ai/agentLoopTrigger.js
@@ -21,6 +21,8 @@ const ToolRegistry = require('../../services/ai/toolRegistry');
 const AgentLoopService = require('../../services/ai/agentLoopService');
 const SystemPromptBuilder = require('../../services/ai/systemPrompt');
 const UserRepository = require('../../repositories/userRepository');
+const AiUsageRepository = require('../../repositories/ai/aiUsageRepository');
+const AiUsageService = require('../../services/ai/aiUsageService');
 
 // emulator 한정 분기 — production 에서는 require 자체 발생하지 않도록 lazy require
 let anthropic;
@@ -46,6 +48,7 @@ const agentLoopService = new AgentLoopService({
 const handler = new AgentLoopHandler({
     jobService: new JobService(new JobRepository()),
     agentLoopService,
+    aiUsageService: new AiUsageService({ repository: new AiUsageRepository() }),
     userRepository: new UserRepository(),
     messaging: getMessaging()
     // logger 생략 → AgentLoopHandler 내부에서 firebase-functions/logger 사용


### PR DESCRIPTION
Closes #156

## Summary

Agent Loop 매 실행에서 발생한 input/output 토큰 사용량을 Firestore `users/{uid}/aiUsage/{YYYY-MM-DD}` 에 일별 누적 기록하고, 본인 오늘 사용량을 조회하는 endpoint `GET /v1/ai/usage` 를 추가.

부모 이슈 #151 의 2단계 (안정화) 첫 step. **한도 체크 / 차단은 본 PR 스코프 외** — 별도 이슈 #157 에서 진행 (#166 (Free/Pro/Premium 한도 수치 결정) 의존).

## Architecture

신규 layer 3개:

- `models/ai/AiUsage.js` — 일별 사용량 데이터 클래스. `toJSON()` (snake_case) + `fromData(dateKey, snapshot)` + `empty(dateKey)`.
- `repositories/ai/aiUsageRepository.js` — `users/{userId}/aiUsage/{dateKey}` 의 `FieldValue.increment` 기반 atomic 누적 + load. `set({merge:true})` 조합으로 doc 미존재 시 0+inc 신규 생성, 동시 호출도 race 없이 합산.
- `services/ai/aiUsageService.js` — UTC dateKey 생성 + `recordUsage` (0/0 no-op) + `getTodayUsage` (null fallback 으로 빈 인스턴스 반환).

기존 layer 변경:

- `services/ai/agentLoopService.js` — `run()` 반환을 `AiJobResult` 단일 → `{ result, usage: { inputTokens, outputTokens } }` 로 확장. 모든 정상 return path 에 usage 동봉 (DONE/CONFIRM/FAILED via finalize, token cap, loop cap, no tool_use, multiple tool_uses). throw 경로는 그대로 propagate.
- `triggers/ai/agentLoopHandler.js` — `aiUsageService` 의존성 추가, `run` 정상 반환에서 추출한 usage 를 `recordUsage` 로 위임. record 실패가 completeWith / FCM 흐름을 막지 않도록 try/catch 격리.
- `controllers/ai/aiController.js` — `getUsage(req, res)` 메서드 추가. `req.auth.uid` 로 `getTodayUsage` 호출 후 `toJSON` 응답.
- `routes/ai/aiRoutes.js` — `GET /usage` 라우트 등록 + DI 와이어링.
- `triggers/ai/agentLoopTrigger.js` — composition root 에 `AiUsageRepository` / `AiUsageService` 인스턴스 주입.

## 주요 결정 사항

### Timezone — 서버 UTC 단일
일별 경계는 **server `new Date().toISOString().slice(0, 10)`** 한 기준만 사용. record / 조회 양쪽에서 timezone 파라미터 안 받음. 트레이드오프 (한국 자정 ≠ UTC 자정, KST 00–09 시 사용량이 "어제 doc" 으로 누적) 는 수용 — 서버 / 클라 일관성 우선.

### Anthropic input_tokens 합산 정책
Anthropic API 의 `input_tokens` 는 **매 호출마다 누적 prompt 전체**를 포함하므로 turn 별 단순 합산 시 double count. 따라서:
- `inputTokens` = 마지막 createMessage 호출의 `input_tokens` (= 전체 누적 prompt 토큰).
- `outputTokens` = 모든 turn 의 `output_tokens` 합.

기존 `agentLoopService` 의 token cap 검사 로직 (`agentLoopService.js#L99-100, L126-127`) 과 같은 의도. 노출만 추가.

### Throw 경로의 partial usage 손실
`AgentLoopService.run` 이 throw 한 경로에서는 handler 가 usage 를 추출할 수 없어 record 가 skip 됨. 이미 소모된 토큰이 있어도 손실 (acceptable loss). 정밀도 필요해지면 service 가 throw 대신 partial usage 동봉한 error 객체 정의 — 본 PR 스코프 외.

### 조회 API 단순화
`GET /v1/ai/usage` 는 query 없음. 항상 서버 UTC today 의 doc 반환. 과거 날짜 / 범위 조회는 클라 요구 들어올 때 별도 이슈.

### 빈 응답 균일 shape
사용량 doc 미존재 시 service 가 `AiUsage.empty(dateKey)` 로 fallback → caller / 클라가 null 분기 신경 쓰지 않게 `{date, input_tokens: 0, output_tokens: 0, updated_at: null}` 균일 응답.

## Test plan

- [x] 단위 테스트 (`npm test`) — 1021 PASS (회귀 0)
  - `AiUsageService` 단위 7 케이스 — record 양/0/null 경계 + UTC 자정 경계 + getToday null fallback
  - `AgentLoopService` 기존 17 케이스 보정 + usage 누적 / token cap / loop cap usage 동봉 3 케이스 추가
  - `AgentLoopHandler` 기존 14 케이스 + record 호출 검증 (DONE/CONFIRM/FAILED/throw/record-throw-격리) 5 케이스 추가
  - `AiController.getUsage` 2 케이스 — 누적 후 응답 / 빈 응답 균일 shape
- [x] E2E (`npm run test:e2e`) — 151 PASS, 신규 4 시나리오:
  - DONE 골든 → Firestore aiUsage doc 누적 (input=10, output=10)
  - 두 번째 command → 같은 doc 에 2배 합산 (FieldValue.increment atomic)
  - GET /v1/ai/usage → 200 + 누적 토큰 / today dateKey
  - 사용량 doc 없는 user GET → 200 + 0/0/null
- [x] 기존 `ai-frontapi.e2e.js` 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)