### PR TITLE
[#161] openAPI rate limit — per-user/per-PAT 분당 한도 + VIP override

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -46,6 +46,11 @@ const tagOpenRouter = require('./routes/openapi/tagOpenRoutes');
 const eventDetailOpenRouter = require('./routes/openapi/eventDetailOpenRoutes');
 const patAuth = require('./middlewares/openapi/patAuth');
 const signedUserAuth = require('./middlewares/openapi/signedUserAuth');
+const OpenRateLimitRepository = require('./repositories/openRateLimitRepository');
+const OpenRateLimitConfigRepository = require('./repositories/openRateLimitConfigRepository');
+const OpenRateLimitConfigProvider = require('./services/openRateLimitConfigProvider');
+const OpenRateLimitService = require('./services/openRateLimitService');
+const openRateLimit = require('./middlewares/openapi/rateLimit');
 
 const oauthWellKnownRouter = require('./routes/oauth/wellKnownRoutes');
 const oauthRegisterRouter = require('./routes/oauth/registerRoutes');
@@ -117,7 +122,18 @@ app.use('/v1/ai', authValidator, setVersion('v1'), aiRouter);
 
 // openAPI (/v2/open/*) — PAT (서비스 식별) + signed user JWT (사용자 식별) + scope 인가
 // dones 가 todos 보다 먼저 mount: '/v2/open/todos/dones/...' 가 '/v2/open/todos' 의 prefix 매칭으로 흡수되지 않게.
-const openApiAuth = [patAuth, signedUserAuth, setVersion('v2')];
+const openRateLimitConfigProvider = new OpenRateLimitConfigProvider({
+    repository: new OpenRateLimitConfigRepository(),
+    ttlMs: parseInt(process.env.RATE_LIMIT_CONFIG_CACHE_TTL_SEC ?? '60', 10) * 1000
+});
+const openRateLimitService = new OpenRateLimitService({
+    repository: new OpenRateLimitRepository(),
+    configProvider: openRateLimitConfigProvider,
+    userPerMin: parseInt(process.env.RATE_LIMIT_USER_PER_MIN ?? '120', 10),
+    patPerMin: parseInt(process.env.RATE_LIMIT_PAT_PER_MIN ?? '600', 10),
+    unlimitedPats: (process.env.RATE_LIMIT_PAT_UNLIMITED ?? 'mcp').split(',').map((s) => s.trim()).filter(Boolean)
+});
+const openApiAuth = [patAuth, signedUserAuth, openRateLimit(openRateLimitService), setVersion('v2')];
 app.use('/v2/open/todos/dones', openApiAuth, doneTodoOpenRouter);
 app.use('/v2/open/todos', openApiAuth, todoOpenRouter);
 app.use('/v2/open/schedules', openApiAuth, scheduleOpenRouter);

--- a/functions/middlewares/openapi/rateLimit.js
+++ b/functions/middlewares/openapi/rateLimit.js
@@ -1,0 +1,21 @@
+const Errors = require('../../models/Errors');
+const logger = require('firebase-functions/logger');
+
+function rateLimit(service) {
+    return async function rateLimitMiddleware(req, res, next) {
+        let result;
+        try {
+            result = await service.check({ userId: req.openUserId, patId: req.callerId });
+        } catch (err) {
+            logger.error('openapi rate limit check failed, failing open', err);
+            return next();
+        }
+        if (!result.allowed) {
+            res.set('Retry-After', String(result.retryAfterSec));
+            throw new Errors.Base(429, 'RateLimitExceeded', 'Rate limit exceeded');
+        }
+        next();
+    };
+}
+
+module.exports = rateLimit;

--- a/functions/repositories/openRateLimitConfigRepository.js
+++ b/functions/repositories/openRateLimitConfigRepository.js
@@ -1,0 +1,21 @@
+const { getFirestore } = require('firebase-admin/firestore');
+
+const db = getFirestore();
+const configRef = db.collection('open_rate_limits').doc('config');
+
+class OpenRateLimitConfigRepository {
+
+    async load() {
+        const snap = await configRef.get();
+        if (!snap.exists) {
+            return { userUnlimited: [], userOverrides: {} };
+        }
+        const data = snap.data();
+        return {
+            userUnlimited: Array.isArray(data.userUnlimited) ? data.userUnlimited : [],
+            userOverrides: (data.userOverrides && typeof data.userOverrides === 'object') ? data.userOverrides : {}
+        };
+    }
+}
+
+module.exports = OpenRateLimitConfigRepository;

--- a/functions/repositories/openRateLimitRepository.js
+++ b/functions/repositories/openRateLimitRepository.js
@@ -1,0 +1,36 @@
+const { getFirestore } = require('firebase-admin/firestore');
+
+const db = getFirestore();
+const usageRef = db.collection('open_rate_limits').doc('usage');
+
+class OpenRateLimitRepository {
+
+    async incrementWithinWindow(dimension, entityId, windowSeconds, now = Date.now()) {
+        const windowMs = windowSeconds * 1000;
+        const windowStartMs = Math.floor(now / windowMs) * windowMs;
+        const expireAtMs = windowStartMs + windowMs;
+        const ref = usageRef.collection(dimension).doc(entityId);
+
+        try {
+            return await db.runTransaction(async (tx) => {
+                const snap = await tx.get(ref);
+                if (!snap.exists) {
+                    tx.set(ref, { windowStartMs, count: 1, expireAt: new Date(expireAtMs) });
+                    return 1;
+                }
+                const data = snap.data();
+                if (data.windowStartMs === windowStartMs) {
+                    const newCount = (data.count ?? 0) + 1;
+                    tx.update(ref, { count: newCount });
+                    return newCount;
+                }
+                tx.update(ref, { windowStartMs, count: 1, expireAt: new Date(expireAtMs) });
+                return 1;
+            });
+        } catch (error) {
+            throw { status: 500, message: error?.message || error };
+        }
+    }
+}
+
+module.exports = OpenRateLimitRepository;

--- a/functions/secrets/.env.test.example
+++ b/functions/secrets/.env.test.example
@@ -75,3 +75,15 @@ CONFIRM_SECRET=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 # emulator: functions emulator 가 띄우는 api(v1 gen) 함수의 HTTP path.
 # production: hosting custom domain (예: https://api.todo-calendar.com).
 OPENAPI_BASE_URL=http://127.0.0.1:5001/todocalendar-1707723626269/us-central1/api
+
+# ──────────────────────────────────────────────────────────────────────
+# openAPI rate limit (#161)
+# ──────────────────────────────────────────────────────────────────────
+# 에뮬레이터/e2e 에선 한도를 크게 깔아 사실상 비활성화 — 한도 env 는 프로세스 시작 시
+# 주입돼 런타임 변경 불가하므로, 낮게 깔면 같은 TEST_USER 로 도는 다른 openapi e2e 가
+# per-user 윈도우를 공유해 429 로 깨짐. production 코드 기본값은 user 120 / PAT 600.
+# VIP bypass/override 는 env 가 아니라 Firestore open_rate_limits/config doc 에서 읽음.
+RATE_LIMIT_USER_PER_MIN=100000
+RATE_LIMIT_PAT_PER_MIN=100000
+RATE_LIMIT_PAT_UNLIMITED=mcp
+RATE_LIMIT_CONFIG_CACHE_TTL_SEC=60

--- a/functions/services/openRateLimitConfigProvider.js
+++ b/functions/services/openRateLimitConfigProvider.js
@@ -1,0 +1,38 @@
+const logger = require('firebase-functions/logger');
+
+const DEFAULT_TTL_MS = 60000;
+
+class OpenRateLimitConfigProvider {
+
+    constructor({ repository, ttlMs = DEFAULT_TTL_MS, now = () => Date.now() }) {
+        this.repository = repository;
+        this.ttlMs = ttlMs;
+        this.now = now;
+        this.cache = null;
+        this.cachedAt = 0;
+    }
+
+    async get() {
+        const t = this.now();
+        if (this.cache && (t - this.cachedAt) < this.ttlMs) {
+            return this.cache;
+        }
+        try {
+            const raw = await this.repository.load();
+            this.cache = {
+                userUnlimited: new Set(raw.userUnlimited),
+                userOverrides: new Map(Object.entries(raw.userOverrides))
+            };
+            this.cachedAt = t;
+            return this.cache;
+        } catch (err) {
+            logger.error('openapi rate limit config load failed', err);
+            if (this.cache) {
+                return this.cache;
+            }
+            return { userUnlimited: new Set(), userOverrides: new Map() };
+        }
+    }
+}
+
+module.exports = OpenRateLimitConfigProvider;

--- a/functions/services/openRateLimitService.js
+++ b/functions/services/openRateLimitService.js
@@ -1,0 +1,40 @@
+const DEFAULT_WINDOW_SECONDS = 60;
+
+class OpenRateLimitService {
+
+    constructor({ repository, configProvider, userPerMin, patPerMin, unlimitedPats, windowSeconds = DEFAULT_WINDOW_SECONDS }) {
+        this.repository = repository;
+        this.configProvider = configProvider;
+        this.userPerMin = userPerMin;
+        this.patPerMin = patPerMin;
+        this.unlimitedPats = unlimitedPats ?? [];
+        this.windowSeconds = windowSeconds;
+    }
+
+    _retryAfterSec() {
+        return this.windowSeconds - Math.floor((Date.now() / 1000) % this.windowSeconds);
+    }
+
+    async check({ userId, patId }) {
+        const config = await this.configProvider.get();
+
+        if (!config.userUnlimited.has(userId)) {
+            const limit = config.userOverrides.get(userId) ?? this.userPerMin;
+            const userCount = await this.repository.incrementWithinWindow('users', userId, this.windowSeconds);
+            if (userCount > limit) {
+                return { allowed: false, retryAfterSec: this._retryAfterSec() };
+            }
+        }
+
+        if (!this.unlimitedPats.includes(patId)) {
+            const patCount = await this.repository.incrementWithinWindow('pats', patId, this.windowSeconds);
+            if (patCount > this.patPerMin) {
+                return { allowed: false, retryAfterSec: this._retryAfterSec() };
+            }
+        }
+
+        return { allowed: true };
+    }
+}
+
+module.exports = OpenRateLimitService;

--- a/functions/test/doubles/stubRepositories.js
+++ b/functions/test/doubles/stubRepositories.js
@@ -781,7 +781,7 @@ class StubUserRepository {
         }
         this.userDevices.set(device.deviceId, device)
     }
-    
+
     async removeUserDevice(deviceId) {
         if(this.shouldFail) {
             throw { message: 'failed' };
@@ -791,6 +791,25 @@ class StubUserRepository {
 }
 
 // MARK: - openAPI rate limit
+
+class StubOpenRateLimitRepository {
+
+    constructor() {
+        this.shouldFail = false
+        this.calls = []
+        this.counts = {}
+        this.defaultCount = 1
+    }
+
+    async incrementWithinWindow(dimension, entityId, windowSeconds, now = Date.now()) {
+        this.calls.push({ dimension, entityId, windowSeconds, now })
+        if(this.shouldFail) {
+            throw { message: 'failed' }
+        }
+        const key = `${dimension}:${entityId}`
+        return this.counts[key] !== undefined ? this.counts[key] : this.defaultCount
+    }
+}
 
 class StubOpenRateLimitConfigRepository {
 
@@ -812,17 +831,18 @@ class StubOpenRateLimitConfigRepository {
 module.exports = {
     Account: StubAccountRepository,
     User: StubUserRepository,
-    Todo: StubTodoRepository, 
-    EventTime: StubEventTimeRangeRepository, 
-    DoneTodo: StubDoneTodoEventRepository, 
+    Todo: StubTodoRepository,
+    EventTime: StubEventTimeRangeRepository,
+    DoneTodo: StubDoneTodoEventRepository,
     ScheduleEvent: StubScheduleEventRepository,
     Foremost: StubForemostEventIdRepository,
-    EventTag: StubEventTagRepository, 
-    EventDetailData: StubEventDetailDataRepository, 
-    Migration: StubMigrationReposiotry, 
-    ApPSetting: StubAppSettingRepository, 
-    Holiday: StubHolidayRepository, 
+    EventTag: StubEventTagRepository,
+    EventDetailData: StubEventDetailDataRepository,
+    Migration: StubMigrationReposiotry,
+    ApPSetting: StubAppSettingRepository,
+    Holiday: StubHolidayRepository,
     ChangeLog: StubDataChangeLogRepository,
     SyncTimeStamp: StubSyncTimeStampRepository,
+    OpenRateLimit: StubOpenRateLimitRepository,
     OpenRateLimitConfig: StubOpenRateLimitConfigRepository
 };

--- a/functions/test/doubles/stubRepositories.js
+++ b/functions/test/doubles/stubRepositories.js
@@ -790,6 +790,25 @@ class StubUserRepository {
     }
 }
 
+// MARK: - openAPI rate limit
+
+class StubOpenRateLimitConfigRepository {
+
+    constructor() {
+        this.shouldFail = false
+        this.loadCalls = 0
+        this.loadResult = { userUnlimited: [], userOverrides: {} }
+    }
+
+    async load() {
+        this.loadCalls += 1
+        if(this.shouldFail) {
+            throw { message: 'failed' }
+        }
+        return this.loadResult
+    }
+}
+
 module.exports = {
     Account: StubAccountRepository,
     User: StubUserRepository,
@@ -804,5 +823,6 @@ module.exports = {
     ApPSetting: StubAppSettingRepository, 
     Holiday: StubHolidayRepository, 
     ChangeLog: StubDataChangeLogRepository,
-    SyncTimeStamp: StubSyncTimeStampRepository
+    SyncTimeStamp: StubSyncTimeStampRepository,
+    OpenRateLimitConfig: StubOpenRateLimitConfigRepository
 };

--- a/functions/test/middlewares/openapi/rateLimit.test.js
+++ b/functions/test/middlewares/openapi/rateLimit.test.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const rateLimit = require('../../../middlewares/openapi/rateLimit');
+const Errors = require('../../../models/Errors');
+
+describe('middlewares/openapi/rateLimit', () => {
+
+    let req;
+    let res;
+    let headers;
+    let nextCalled;
+
+    beforeEach(() => {
+        req = { openUserId: 'u1', callerId: 'mcp' };
+        headers = {};
+        res = { set: (k, v) => { headers[k] = v; } };
+        nextCalled = false;
+    });
+
+    const next = () => { nextCalled = true; };
+
+    it('allowed → next 호출, Retry-After 헤더 없음', async () => {
+        const service = { check: async () => ({ allowed: true }) };
+        await rateLimit(service)(req, res, next);
+        assert.strictEqual(nextCalled, true);
+        assert.strictEqual(headers['Retry-After'], undefined);
+    });
+
+    it('거부 → 429 throw + Retry-After 헤더, next 미호출', async () => {
+        const service = { check: async () => ({ allowed: false, retryAfterSec: 42 }) };
+        await assert.rejects(
+            () => rateLimit(service)(req, res, next),
+            (err) => {
+                assert.ok(err instanceof Errors.Base);
+                assert.strictEqual(err.status, 429);
+                assert.strictEqual(err.code, 'RateLimitExceeded');
+                return true;
+            }
+        );
+        assert.strictEqual(headers['Retry-After'], '42');
+        assert.strictEqual(nextCalled, false);
+    });
+
+    it('service throw → fail-open 으로 next 호출 (throw 없음)', async () => {
+        const service = { check: async () => { throw new Error('firestore down'); } };
+        await rateLimit(service)(req, res, next);
+        assert.strictEqual(nextCalled, true);
+    });
+});

--- a/functions/test/services/openRateLimitConfigProvider.test.js
+++ b/functions/test/services/openRateLimitConfigProvider.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const OpenRateLimitConfigProvider = require('../../services/openRateLimitConfigProvider');
+const StubRepositories = require('../doubles/stubRepositories');
+
+describe('services/openRateLimitConfigProvider', () => {
+
+    let repo;
+    let nowMs;
+
+    function makeProvider(ttlMs = 60000) {
+        return new OpenRateLimitConfigProvider({ repository: repo, ttlMs, now: () => nowMs });
+    }
+
+    beforeEach(() => {
+        repo = new StubRepositories.OpenRateLimitConfig();
+        repo.loadResult = { userUnlimited: ['a'], userOverrides: { b: 500 } };
+        nowMs = 1000;
+    });
+
+    it('첫 호출 → repo read + Set/Map 변환', async () => {
+        const config = await makeProvider().get();
+        assert.strictEqual(repo.loadCalls, 1);
+        assert.ok(config.userUnlimited.has('a'));
+        assert.strictEqual(config.userOverrides.get('b'), 500);
+    });
+
+    it('TTL 내 재호출 → repo 재호출 안 함 (캐시)', async () => {
+        const provider = makeProvider(60000);
+        await provider.get();
+        nowMs += 30000;
+        await provider.get();
+        assert.strictEqual(repo.loadCalls, 1);
+    });
+
+    it('TTL 경과 후 재호출 → repo 재호출', async () => {
+        const provider = makeProvider(60000);
+        await provider.get();
+        nowMs += 60001;
+        await provider.get();
+        assert.strictEqual(repo.loadCalls, 2);
+    });
+
+    it('repo throw + 직전 캐시 있음 → stale 캐시 반환, throw 안 함', async () => {
+        const provider = makeProvider(1000);
+        await provider.get();
+        nowMs += 2000;
+        repo.shouldFail = true;
+        const config = await provider.get();
+        assert.ok(config.userUnlimited.has('a'));
+    });
+
+    it('repo throw + 캐시 없음 → 빈 config 반환, throw 안 함', async () => {
+        repo.shouldFail = true;
+        const config = await makeProvider().get();
+        assert.strictEqual(config.userUnlimited.size, 0);
+        assert.strictEqual(config.userOverrides.size, 0);
+    });
+});

--- a/functions/test/services/openRateLimitService.test.js
+++ b/functions/test/services/openRateLimitService.test.js
@@ -1,0 +1,95 @@
+const assert = require('assert');
+const OpenRateLimitService = require('../../services/openRateLimitService');
+const StubRepositories = require('../doubles/stubRepositories');
+
+describe('services/openRateLimitService', () => {
+
+    let repo;
+
+    function fakeConfig({ unlimited = [], overrides = {} } = {}) {
+        return {
+            get: async () => ({
+                userUnlimited: new Set(unlimited),
+                userOverrides: new Map(Object.entries(overrides))
+            })
+        };
+    }
+
+    function makeService(overrides = {}) {
+        return new OpenRateLimitService({
+            repository: repo,
+            configProvider: fakeConfig(),
+            userPerMin: 120,
+            patPerMin: 600,
+            unlimitedPats: ['mcp'],
+            ...overrides
+        });
+    }
+
+    beforeEach(() => {
+        repo = new StubRepositories.OpenRateLimit();
+    });
+
+    it('user 한도 이내 + mcp PAT → 통과, pats 차원은 카운트하지 않음', async () => {
+        repo.counts['users:u1'] = 10;
+        const result = await makeService().check({ userId: 'u1', patId: 'mcp' });
+        assert.strictEqual(result.allowed, true);
+        const dims = repo.calls.map((c) => c.dimension);
+        assert.ok(dims.includes('users'));
+        assert.ok(!dims.includes('pats'));
+    });
+
+    it('user 한도 초과 → 거부 + retryAfterSec 1..60', async () => {
+        repo.counts['users:u1'] = 121;
+        const result = await makeService().check({ userId: 'u1', patId: 'mcp' });
+        assert.strictEqual(result.allowed, false);
+        assert.ok(result.retryAfterSec > 0 && result.retryAfterSec <= 60);
+    });
+
+    it('unlimited 아닌 PAT 가 한도 초과 → 거부', async () => {
+        repo.counts['users:u1'] = 1;
+        repo.counts['pats:other'] = 601;
+        const result = await makeService().check({ userId: 'u1', patId: 'other' });
+        assert.strictEqual(result.allowed, false);
+    });
+
+    it('unlimited 아닌 PAT + 양 차원 한도 이내 → 통과, 두 차원 모두 카운트', async () => {
+        repo.counts['users:u1'] = 5;
+        repo.counts['pats:other'] = 5;
+        const result = await makeService().check({ userId: 'u1', patId: 'other' });
+        assert.strictEqual(result.allowed, true);
+        const dims = repo.calls.map((c) => c.dimension);
+        assert.ok(dims.includes('users'));
+        assert.ok(dims.includes('pats'));
+    });
+
+    it('user 한도 초과 시 pats 차원은 카운트하지 않음', async () => {
+        repo.counts['users:u1'] = 121;
+        await makeService().check({ userId: 'u1', patId: 'other' });
+        const dims = repo.calls.map((c) => c.dimension);
+        assert.ok(!dims.includes('pats'));
+    });
+
+    it('VIP bypass(userUnlimited) → user 카운트 스킵, 한도 무관 통과', async () => {
+        repo.counts['users:vip'] = 999999;
+        const service = makeService({ configProvider: fakeConfig({ unlimited: ['vip'] }) });
+        const result = await service.check({ userId: 'vip', patId: 'mcp' });
+        assert.strictEqual(result.allowed, true);
+        const dims = repo.calls.map((c) => c.dimension);
+        assert.ok(!dims.includes('users'));
+    });
+
+    it('VIP override 한도 적용 → 기본 한도 초과여도 override 이내면 통과', async () => {
+        repo.counts['users:vip'] = 200;
+        const service = makeService({ configProvider: fakeConfig({ overrides: { vip: 500 } }) });
+        const result = await service.check({ userId: 'vip', patId: 'mcp' });
+        assert.strictEqual(result.allowed, true);
+    });
+
+    it('VIP override 한도 초과 → 거부', async () => {
+        repo.counts['users:vip'] = 501;
+        const service = makeService({ configProvider: fakeConfig({ overrides: { vip: 500 } }) });
+        const result = await service.check({ userId: 'vip', patId: 'mcp' });
+        assert.strictEqual(result.allowed, false);
+    });
+});


### PR DESCRIPTION
Closes #161 (parent #151 3단계 — 외부 공개).

## 문제

`/v2/open/*` 게이트웨이는 외부 서비스(현재 MCP 단일)에 노출되는 API 게이트웨이지만, 호출량 제한이 없어 단일 user 가 독식하거나 한 서비스가 백엔드를 도배해도 막을 장치가 없음. 외부 공개 전 차원별 분당 한도(429 + Retry-After) 가 필요. 다만 운영 중에 특정 VIP user 만 한도를 풀어주거나 조정할 수 있어야 함 (redeploy 없이).

## 접근

설계 스펙: `docs/superpowers/specs/2026-05-22-openapi-rate-limit-design.md` (로컬 노트).

기존 OAuth register rate limit(`repositories/oauth/rateLimitRepository.js` + `middlewares/oauth/ipRateLimit.js`) 가 이미 같은 문제(Firestore fixed-window)를 풀고 있어, 그 패턴을 그대로 따르되 차원이 둘(user / PAT) 이고 VIP override 가 붙는 형태로 확장.

세 커밋으로 vertical slice 분리:

1. **VIP config 파이프라인** — 운영 중 `open_rate_limits/config` doc 만 고치면 VIP 가 반영되도록 인메모리 TTL(60s) 캐시. config load 실패 시 stale/빈 config 반환해 never-throws (config 장애가 rate limit 전체를 끄지 않게).
2. **결정 파이프라인** — `open_rate_limits/usage/{users|pats}/{id}` doc 1개로 fixed-window roll-in-place 카운트. service 가 차원 판별(unlimited PAT skip, VIP bypass/override 적용) → 미들웨어가 store 오류는 fail-open, 한도 초과만 429 + Retry-After.
3. **composition root 조립 + 에뮬레이터 env** — 한도값과 unlimited PAT 목록은 env 로 주입 (`RATE_LIMIT_USER_PER_MIN` 120 / `RATE_LIMIT_PAT_PER_MIN` 600 / `RATE_LIMIT_PAT_UNLIMITED` mcp / `RATE_LIMIT_CONFIG_CACHE_TTL_SEC` 60). 미들웨어는 `signedUserAuth` 뒤에 꽂아 `req.callerId` + `req.openUserId` 둘 다 확보된 뒤 카운트.

## 단위테스트 16종 (1004 → 1020)

- `OpenRateLimitConfigProvider` 5종 — 첫 read, TTL hit/miss, 장애 시 stale/빈 fallback.
- `OpenRateLimitService` 8종 — 통과/거부, VIP bypass/override, unlimited PAT skip, user 거부 시 PAT 안 부르기.
- `rateLimit` 미들웨어 3종 — 통과 next, 거부 429+Retry-After, store 오류 fail-open.

production Firestore repository 2개는 기존 `repositories/oauth/rateLimitRepository.js` 와 같은 thin I/O wrapper 라 단위테스트 없음 (선례 따름).

## E2E 정책

OAuth register rate limit 과 동일하게, `.env.test` 한도를 100000 으로 깔아 **에뮬레이터에선 사실상 비활성화**. 한도 env 가 프로세스 시작 시 주입돼 런타임 변경 불가라, 낮게 깔면 같은 TEST_USER 로 도는 다른 openapi e2e 가 per-user 윈도우를 공유해 429 로 깨짐. 회귀는 단위테스트로만 검증 — 이번 PR 에선 포트 충돌로 e2e 미실행, 머지 전 사용자가 별도 확인 권장.

## 운영 — 머지 후 후속

- **Firestore TTL 정책** 을 `open_rate_limits/usage/*/*` doc 의 `expireAt` 필드에 설정 (Firebase 콘솔, 코드 아님). 미설정해도 doc 누적은 엔티티당 1개라 기능엔 무해, 비용도 미미.
- **production `.env`** 에 한도 env 4개 추가 (없으면 코드 기본값 적용 — user 120 / PAT 600 / unlimited mcp / TTL 60s).
- VIP 관리: `open_rate_limits/config` doc 의 `userUnlimited: ['uid', ...]` 또는 `userOverrides: { uid: 분당한도 }` 직접 수정. TTL 내(최대 60s) 모든 인스턴스에 반영.

## 남은 과제 (별도 이슈)

- 감사 로그(#161 형제) — 누가 429 맞았는지 별도 로깅.
- sliding window / 가중 보간 — 미들웨어 인터페이스 유지하면 추후 교체 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)