### PR TITLE
[#176] openAPI 시크릿 무중단 로테이션 — PRIMARY/SECONDARY 두 슬롯

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,13 @@ test/e2e/
 - 생성: `openssl rand -hex 32` (32바이트 이상 random hex 권장)
 
 **로테이션 / 변경**
-- 운영에서 PAT 또는 SIGNING_SECRET 을 바꾸면 호출자(MCP, aiFrontAPI) 도 동시에 갱신해야 함 — 무중단 교체가 필요하면 화이트리스트에 임시로 두 secret 을 모두 허용하는 단계가 필요(현 MVP 미지원, 단기 다운타임 감수).
+- **무중단 로테이션 지원 (#176)** — PAT, SIGNING_SECRET 둘 다 `_PRIMARY` / `_SECONDARY` 두 슬롯을 동시에 허용. 호출자(MCP, aiFrontAPI) 전환 시점을 분리할 수 있어 다운타임 없이 교체 가능. 기존 단일 env 이름(`OPENAPI_PAT_<SVC>`, `SIGNING_SECRET`) 은 PRIMARY 별칭으로 그대로 인식.
+- **로테이션 절차 (예: `OPENAPI_PAT_MCP`)**:
+  1. `OPENAPI_PAT_MCP_SECONDARY` 에 신 secret 등록 (구 secret 은 PRIMARY/legacy 그대로). 서버 재시작/redeploy 로 신 secret 검증 활성화.
+  2. 호출자(MCP) 가 신 secret 으로 전환 — 호출 측 배포 완료까지 대기.
+  3. `OPENAPI_PAT_MCP_PRIMARY` (또는 legacy `OPENAPI_PAT_MCP`) 에 신 secret 복사.
+  4. `OPENAPI_PAT_MCP_SECONDARY` 비움. 다시 단일 슬롯 운영으로 복귀.
+  `SIGNING_SECRET` 도 동일 절차 — 단 발급자(aiFrontAPI) 가 SECONDARY 로 서명을 전환하는 동안 구 PRIMARY 로 발급된 미만료 JWT 도 계속 통과.
 - `.env.test.example` dummy 값(`deadbeef...`/`cafebabe...`) 은 절대 운영 secret 으로 쓰지 말 것.
 
 #### OAuth 2.1 Authorization Server 시크릿 운영 정책 (`/v1/oauth/*`)

--- a/functions/middlewares/openapi/patAuth.js
+++ b/functions/middlewares/openapi/patAuth.js
@@ -3,8 +3,11 @@ const Errors = require('../../models/Errors');
 
 const KNOWN_SERVICES = ['mcp'];
 
-function envSecretFor(service) {
-    return process.env[`OPENAPI_PAT_${service.toUpperCase()}`];
+function envSecretsFor(service) {
+    const upper = service.toUpperCase();
+    const primary = process.env[`OPENAPI_PAT_${upper}_PRIMARY`] ?? process.env[`OPENAPI_PAT_${upper}`];
+    const secondary = process.env[`OPENAPI_PAT_${upper}_SECONDARY`];
+    return [primary, secondary].filter((s) => typeof s === 'string' && s.length > 0);
 }
 
 function safeEqual(a, b) {
@@ -33,12 +36,13 @@ function patAuth(req, res, next) {
         throw new Errors.Base(401, 'InvalidCredentials', 'Invalid credentials');
     }
 
-    const expected = envSecretFor(service);
-    if (!expected) {
+    const expectedSecrets = envSecretsFor(service);
+    if (expectedSecrets.length === 0) {
         throw new Errors.Base(500, 'ServerMisconfigured', 'PAT secret not configured');
     }
 
-    if (!safeEqual(secret, expected)) {
+    const matched = expectedSecrets.some((expected) => safeEqual(secret, expected));
+    if (!matched) {
         throw new Errors.Base(401, 'InvalidCredentials', 'Invalid credentials');
     }
 

--- a/functions/middlewares/openapi/signedUserAuth.js
+++ b/functions/middlewares/openapi/signedUserAuth.js
@@ -1,21 +1,33 @@
 const jwt = require('jsonwebtoken');
 const Errors = require('../../models/Errors');
 
+function signingSecrets() {
+    const primary = process.env.SIGNING_SECRET_PRIMARY ?? process.env.SIGNING_SECRET;
+    const secondary = process.env.SIGNING_SECRET_SECONDARY;
+    return [primary, secondary].filter((s) => typeof s === 'string' && s.length > 0);
+}
+
 function signedUserAuth(req, res, next) {
     const token = req.headers && req.headers['x-open-user-token'];
     if (typeof token !== 'string' || token.length === 0) {
         throw new Errors.Base(401, 'InvalidCredentials', 'Invalid token');
     }
 
-    const secret = process.env.SIGNING_SECRET;
-    if (!secret) {
+    const secrets = signingSecrets();
+    if (secrets.length === 0) {
         throw new Errors.Base(500, 'ServerMisconfigured', 'JWT signing secret not configured');
     }
 
     let payload;
-    try {
-        payload = jwt.verify(token, secret, { algorithms: ['HS256'] });
-    } catch (err) {
+    for (const secret of secrets) {
+        try {
+            payload = jwt.verify(token, secret, { algorithms: ['HS256'] });
+            break;
+        } catch (_err) {
+            // 다음 후보 시도
+        }
+    }
+    if (!payload) {
         throw new Errors.Base(401, 'InvalidCredentials', 'Invalid token');
     }
 

--- a/functions/secrets/.env.test.example
+++ b/functions/secrets/.env.test.example
@@ -16,9 +16,17 @@ HOLIDAY_API_KEY=dummy-not-a-real-google-api-key
 # MVP 는 mcp prefix 한 종류만 화이트리스트.
 OPENAPI_PAT_MCP=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 
+# 로테이션용 SECONDARY 슬롯 (#176). 평상시 비워 두고, 신 secret 으로 교체 시점에 일시 사용.
+# 절차: SECONDARY 에 신값 → 호출자 전환 → PRIMARY 에 신값 복사 → SECONDARY 비움.
+OPENAPI_PAT_MCP_SECONDARY=cafebabecafebabecafebabecafebabecafebabecafebabecafebabe11111111
+
 # openAPI 사용자 JWT 서명키 (HS256). aiFrontAPI 가 발급, openAPI 가 검증.
 # 32바이트 이상 random hex 권장 (운영에서는 반드시 별도 random 값으로 교체).
 SIGNING_SECRET=cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe
+
+# 로테이션용 SECONDARY 키 (#176). 발급자(aiFrontAPI) 가 SECONDARY 로 서명한 토큰도
+# jwt.verify 통과. 절차는 PAT 과 동일 (SECONDARY → 발급자 전환 → PRIMARY 복사 → 비움).
+SIGNING_SECRET_SECONDARY=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef22222222
 
 # ──────────────────────────────────────────────────────────────────────
 # OAuth 2.1 Authorization Server (#189) — 5개 env

--- a/functions/test/e2e/openapi/auth.e2e.js
+++ b/functions/test/e2e/openapi/auth.e2e.js
@@ -102,3 +102,35 @@ describe('openAPI auth/scope 실패', function () {
         });
     });
 });
+
+describe('openAPI 시크릿 로테이션 (#176) — SECONDARY 슬롯', function () {
+
+    it('PAT SECONDARY 만 매칭하는 토큰 → 200 통과', async function () {
+        const secondary = process.env.OPENAPI_PAT_MCP_SECONDARY;
+        assert.ok(secondary, 'OPENAPI_PAT_MCP_SECONDARY 가 .env.test 에 있어야 함');
+        const client = openClient({
+            pat: `mcp_${secondary}`,
+            userToken: signUserToken({
+                sub: TEST_USER_UID,
+                scope: ['read:calendar']
+            })
+        });
+        const res = await client.get('/v2/open/tags/');
+        assert.strictEqual(res.status, 200);
+    });
+
+    it('SIGNING SECONDARY 키로 서명한 JWT → 200 통과', async function () {
+        const secondary = process.env.SIGNING_SECRET_SECONDARY;
+        assert.ok(secondary, 'SIGNING_SECRET_SECONDARY 가 .env.test 에 있어야 함');
+        const client = openClient({
+            pat: defaultMcpPat(),
+            userToken: signUserToken({
+                sub: TEST_USER_UID,
+                scope: ['read:calendar'],
+                secret: secondary
+            })
+        });
+        const res = await client.get('/v2/open/tags/');
+        assert.strictEqual(res.status, 200);
+    });
+});

--- a/functions/test/middlewares/openapi/patAuth.test.js
+++ b/functions/test/middlewares/openapi/patAuth.test.js
@@ -14,11 +14,15 @@ describe('middlewares/openapi/patAuth', () => {
         req = { headers: {} };
         res = {};
         nextCalled = false;
+        delete process.env.OPENAPI_PAT_MCP_PRIMARY;
+        delete process.env.OPENAPI_PAT_MCP_SECONDARY;
         process.env.OPENAPI_PAT_MCP = SECRET;
     });
 
     afterEach(() => {
         delete process.env.OPENAPI_PAT_MCP;
+        delete process.env.OPENAPI_PAT_MCP_PRIMARY;
+        delete process.env.OPENAPI_PAT_MCP_SECONDARY;
     });
 
     const next = () => { nextCalled = true; };
@@ -75,5 +79,53 @@ describe('middlewares/openapi/patAuth', () => {
     it('시크릿 길이 다름 → 401', () => {
         req.headers.authorization = `Bearer mcp_short`;
         expectFail(401, 'InvalidCredentials');
+    });
+
+    it('PRIMARY 만 설정 — PRIMARY secret 일치 → next 호출', () => {
+        delete process.env.OPENAPI_PAT_MCP;
+        process.env.OPENAPI_PAT_MCP_PRIMARY = SECRET;
+        req.headers.authorization = `Bearer mcp_${SECRET}`;
+        patAuth(req, res, next);
+        assert.strictEqual(nextCalled, true);
+        assert.strictEqual(req.callerId, 'mcp');
+    });
+
+    it('SECONDARY 만 설정 — SECONDARY secret 일치 → next 호출 (로테이션 중간 단계)', () => {
+        delete process.env.OPENAPI_PAT_MCP;
+        const NEW = 'c'.repeat(32);
+        process.env.OPENAPI_PAT_MCP_SECONDARY = NEW;
+        req.headers.authorization = `Bearer mcp_${NEW}`;
+        patAuth(req, res, next);
+        assert.strictEqual(nextCalled, true);
+    });
+
+    it('PRIMARY + SECONDARY 동시 설정 — 둘 중 어느 쪽이든 일치하면 통과', () => {
+        delete process.env.OPENAPI_PAT_MCP;
+        const NEW = 'c'.repeat(32);
+        process.env.OPENAPI_PAT_MCP_PRIMARY = SECRET;
+        process.env.OPENAPI_PAT_MCP_SECONDARY = NEW;
+
+        req.headers.authorization = `Bearer mcp_${SECRET}`;
+        patAuth(req, res, () => { nextCalled = true; });
+        assert.strictEqual(nextCalled, true);
+
+        nextCalled = false;
+        req.headers.authorization = `Bearer mcp_${NEW}`;
+        patAuth(req, res, () => { nextCalled = true; });
+        assert.strictEqual(nextCalled, true);
+    });
+
+    it('PRIMARY + SECONDARY 둘 다 불일치 → 401', () => {
+        delete process.env.OPENAPI_PAT_MCP;
+        process.env.OPENAPI_PAT_MCP_PRIMARY = 'p'.repeat(32);
+        process.env.OPENAPI_PAT_MCP_SECONDARY = 's'.repeat(32);
+        req.headers.authorization = `Bearer mcp_${'x'.repeat(32)}`;
+        expectFail(401, 'InvalidCredentials');
+    });
+
+    it('PRIMARY/SECONDARY/legacy 셋 다 미설정 → 500 ServerMisconfigured', () => {
+        delete process.env.OPENAPI_PAT_MCP;
+        req.headers.authorization = `Bearer mcp_${SECRET}`;
+        expectFail(500, 'ServerMisconfigured');
     });
 });

--- a/functions/test/middlewares/openapi/signedUserAuth.test.js
+++ b/functions/test/middlewares/openapi/signedUserAuth.test.js
@@ -16,10 +16,14 @@ describe('middlewares/openapi/signedUserAuth', () => {
         res = {};
         nextCalled = false;
         process.env.SIGNING_SECRET = SECRET;
+        delete process.env.SIGNING_SECRET_PRIMARY;
+        delete process.env.SIGNING_SECRET_SECONDARY;
     });
 
     afterEach(() => {
         delete process.env.SIGNING_SECRET;
+        delete process.env.SIGNING_SECRET_PRIMARY;
+        delete process.env.SIGNING_SECRET_SECONDARY;
     });
 
     const next = () => { nextCalled = true; };
@@ -103,5 +107,71 @@ describe('middlewares/openapi/signedUserAuth', () => {
         signedUserAuth(req, res, next);
         assert.strictEqual(nextCalled, true);
         assert.strictEqual(req.openUserId, 'user-1');
+    });
+
+    describe('PRIMARY/SECONDARY 키 로테이션 지원', () => {
+        const PRIMARY_KEY = 'p'.repeat(32);
+        const SECONDARY_KEY = 's'.repeat(32);
+
+        it('PRIMARY 만 설정 → PRIMARY 로 서명된 토큰 통과', () => {
+            delete process.env.SIGNING_SECRET;
+            process.env.SIGNING_SECRET_PRIMARY = PRIMARY_KEY;
+            const token = jwt.sign({ sub: 'user-1', scope: ['read:calendar'] }, PRIMARY_KEY, { algorithm: 'HS256' });
+            req.headers['x-open-user-token'] = token;
+            signedUserAuth(req, res, next);
+            assert.strictEqual(nextCalled, true);
+            assert.strictEqual(req.openUserId, 'user-1');
+            assert.deepStrictEqual(req.openScope, ['read:calendar']);
+        });
+
+        it('SECONDARY 만 설정 → SECONDARY 로 서명된 토큰 통과', () => {
+            delete process.env.SIGNING_SECRET;
+            process.env.SIGNING_SECRET_SECONDARY = SECONDARY_KEY;
+            const token = jwt.sign({ sub: 'user-2', scope: ['write:calendar'] }, SECONDARY_KEY, { algorithm: 'HS256' });
+            req.headers['x-open-user-token'] = token;
+            signedUserAuth(req, res, next);
+            assert.strictEqual(nextCalled, true);
+            assert.strictEqual(req.openUserId, 'user-2');
+            assert.deepStrictEqual(req.openScope, ['write:calendar']);
+        });
+
+        it('PRIMARY + SECONDARY 둘 다 설정 → 어느 키로 서명된 토큰이든 통과', () => {
+            delete process.env.SIGNING_SECRET;
+            process.env.SIGNING_SECRET_PRIMARY = PRIMARY_KEY;
+            process.env.SIGNING_SECRET_SECONDARY = SECONDARY_KEY;
+
+            // PRIMARY 로 서명된 토큰
+            const tokenPrimary = jwt.sign({ sub: 'user-primary' }, PRIMARY_KEY, { algorithm: 'HS256' });
+            req.headers['x-open-user-token'] = tokenPrimary;
+            signedUserAuth(req, res, next);
+            assert.strictEqual(nextCalled, true);
+            assert.strictEqual(req.openUserId, 'user-primary');
+
+            // SECONDARY 로 서명된 토큰
+            nextCalled = false;
+            const tokenSecondary = jwt.sign({ sub: 'user-secondary' }, SECONDARY_KEY, { algorithm: 'HS256' });
+            req.headers['x-open-user-token'] = tokenSecondary;
+            signedUserAuth(req, res, next);
+            assert.strictEqual(nextCalled, true);
+            assert.strictEqual(req.openUserId, 'user-secondary');
+        });
+
+        it('PRIMARY + SECONDARY 설정되었으나 어느 키로도 검증 불가 → 401', () => {
+            delete process.env.SIGNING_SECRET;
+            process.env.SIGNING_SECRET_PRIMARY = PRIMARY_KEY;
+            process.env.SIGNING_SECRET_SECONDARY = SECONDARY_KEY;
+            const wrongKey = 'w'.repeat(32);
+            const token = jwt.sign({ sub: 'user-3' }, wrongKey, { algorithm: 'HS256' });
+            req.headers['x-open-user-token'] = token;
+            expectFail(401, 'InvalidCredentials');
+        });
+
+        it('PRIMARY/SECONDARY/SIGNING_SECRET 셋 다 미설정 → 500 ServerMisconfigured', () => {
+            delete process.env.SIGNING_SECRET;
+            delete process.env.SIGNING_SECRET_PRIMARY;
+            delete process.env.SIGNING_SECRET_SECONDARY;
+            req.headers['x-open-user-token'] = 'any.token.string';
+            expectFail(500, 'ServerMisconfigured');
+        });
     });
 });


### PR DESCRIPTION
Closes #176.

## 문제

openAPI 의 두 시크릿 — `OPENAPI_PAT_<SVC>`, `SIGNING_SECRET` — 은 운영 중 갱신하려면 호출자(MCP 서비스, aiFrontAPI) 와 서버 양쪽을 **동시에** 바꿔야 했음. 화이트리스트가 한 번에 단일 secret 만 등록 가능해 무중단 교체 경로 없음 → 단기 다운타임 감수. CLAUDE.md "openAPI 시크릿 운영 정책" 에 명시된 미해결 갭.

## 접근

설계 플랜: `docs/superpowers/plans/2026-05-24-openapi-secret-rotation.md` (로컬 노트).

두 미들웨어에 **PRIMARY/SECONDARY 두 슬롯** 을 동시에 허용. 기존 단일 env 이름(`OPENAPI_PAT_<SVC>`, `SIGNING_SECRET`) 은 PRIMARY 별칭으로 그대로 인식해 운영 .env 무수정 배포 가능. 이슈 본문이 제시한 후보 A 채택.

세 커밋으로 vertical slice 분리:

1. **`patAuth` dual-slot** (b7a8831) — `envSecretsFor(service)` 가 `OPENAPI_PAT_<UPPER>_PRIMARY` / `_SECONDARY` / legacy 를 모아 배열 반환. `Array.some(safeEqual)` 매칭 — 둘 중 하나라도 `timingSafeEqual` 통과면 OK. `safeEqual` 의 constant-time 속성은 그대로 유지.

2. **`signedUserAuth` dual-key** (19c1405) — `signingSecrets()` 가 `SIGNING_SECRET_PRIMARY` / `_SECONDARY` / legacy 를 모아 배열 반환. `for ... try jwt.verify ... break` 로 순차 시도, 첫 성공에서 멈춤. HS256 키 교체 시 옛 키 발급 토큰들의 잔여 만료 기간 동안 동시 검증 가능.

3. **운영 노출 + e2e** (65d06d9) — `.env.test.example` 에 SECONDARY dummy 추가, `CLAUDE.md` "로테이션 / 변경" 문단을 4단계 무중단 절차로 갱신("현 MVP 미지원" 표기 제거), e2e 2개 시나리오 (PAT SECONDARY-only / SIGNING SECONDARY-only 매칭 → 200) 로 wiring 검증.

## 로테이션 절차 (CLAUDE.md 갱신 반영)

1. `<KEY>_SECONDARY` 에 신 secret 등록 (구 secret 은 PRIMARY/legacy 그대로). 서버 재시작/redeploy 로 신 secret 검증 활성화.
2. 호출자가 신 secret 으로 전환 — 호출 측 배포 완료까지 대기.
3. `<KEY>_PRIMARY` (또는 legacy `<KEY>`) 에 신 secret 복사.
4. `<KEY>_SECONDARY` 비움. 단일 슬롯 운영으로 복귀.

`SIGNING_SECRET` 도 동일 절차 — 발급자(aiFrontAPI) 가 SECONDARY 로 서명 전환하는 동안 구 PRIMARY 로 발급된 미만료 JWT 도 계속 통과.

## 검증

- **단위테스트 +10** (1038 → 1048): patAuth 5 (PRIMARY-only / SECONDARY-only / 양쪽 어느 쪽이든 매치 / 양쪽 불일치 401 / 셋 다 미설정 500) + signedUserAuth 5 (동일 패턴, jwt.verify 기반).
- **하위호환 회귀 게이트** — 기존 patAuth 8 + signedUserAuth 8 테스트는 legacy 단일 env 호환 검증으로 그대로 통과.
- **E2E +2**: PAT SECONDARY 만 매칭하는 토큰 → 200, SIGNING SECONDARY 로 서명한 JWT → 200. (포트 충돌 등으로 이번 PR 에선 e2e 직접 실행 못 함 — 머지 전 사용자 별도 확인 권장.)

## 운영 — 머지 후

- production `.env` 무수정으로도 동작 (기존 단일 env 가 PRIMARY 별칭). 실제 로테이션 시작 시점에 `<KEY>_SECONDARY` 추가.
- `.env.test.example` dummy hex 패턴 (`...11111111` / `...22222222` 접미사) 은 PRIMARY 와 시각적으로 구별되게 의도. 운영 secret 으로 재사용 절대 금지.

## 수용 기준 (이슈 #176)

- [x] PAT 두 슬롯(primary/secondary) 동시 허용
- [x] SIGNING_SECRET 두 슬롯(primary/secondary) 동시 허용 (jwt.verify 를 양쪽 시도)
- [x] CLAUDE.md Secrets 섹션의 "로테이션 / 변경" 문단 갱신 (현 MVP 미지원 표기 제거)
- [x] e2e 테스트로 secondary 만 매칭하는 경우도 통과 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)