### PR TITLE
[#158] CONFIRM 2차 호출 흐름 도입

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,11 +164,11 @@ test/e2e/
 못하게).
 
 **OPENAPI_PAT_MCP — PAT(Personal Access Token) secret**
-- 호출자(MCP 서비스)가 헤더에 넣는 토큰 형식: `Authorization: Bearer mcp_<secret>`
-- 환경변수에는 **prefix 없이 secret 만** 둔다. 예: `OPENAPI_PAT_MCP=abc123...` (X: `mcp_abc123...`)
-- 검증 로직(`middlewares/openapi/patAuth.js`): 인입 토큰을 `_` 로 split → secret 부분만
-  `crypto.timingSafeEqual` 비교. prefix 가 env 값에 섞이면 절대 일치하지 않음.
-- 생성: `openssl rand -hex 32` (32바이트 = 64 hex 문자) — 길이는 32 이상 권장
+- 호출자(MCP 서비스 또는 functions self-loopback)가 헤더에 넣는 토큰 형식: `Authorization: Bearer mcp_<secret>`
+- 환경변수에는 **prefix 포함 full token** 을 둔다. 예: `OPENAPI_PAT_MCP=mcp_abc123...`
+  - lib `todocalendar-tools` 의 `callOpenApi` 가 env 값을 그대로 Authorization 헤더에 박는 형식과 일관. Agent Loop → openAPI self-loopback 흐름(예: `delete_todo` 2차 confirm) 이 작동하려면 prefix 포함 필수.
+- 검증 로직(`middlewares/openapi/patAuth.js`): 인입 토큰을 `_` 로 split → service+secret 분리, env 값도 같은 형식이라 prefix 떼고 secret 부분만 `crypto.timingSafeEqual` 비교.
+- 생성: secret 부분만 `openssl rand -hex 32` (32바이트 = 64 hex 문자) → 앞에 `mcp_` 접두 → env 에 박는다.
 - 화이트리스트(`KNOWN_SERVICES`): MVP 는 `mcp` 한 종류만. 새 서비스 추가 시 코드 수정 필요.
 
 **SIGNING_SECRET — 사용자 JWT(HS256) 서명키**

--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -56,6 +56,52 @@ class AiController {
         res.status(200).send(job.toJSON());
     }
 
+    async postCommandConfirm(req, res) {
+        const deviceId = req.header('device_id');
+        if (!deviceId) {
+            throw new Errors.BadRequest('device_id header is required');
+        }
+
+        const rawCommandText = req.body.command_text;
+        if (!rawCommandText || !rawCommandText.trim()) {
+            throw new Errors.BadRequest('command_text is required');
+        }
+        const commandText = rawCommandText.trim();
+
+        const timezone = req.body.timezone;
+        if (!timezone) {
+            throw new Errors.BadRequest('timezone is required');
+        }
+        if (!isValidTimezone(timezone)) {
+            throw new Errors.BadRequest('timezone is invalid (must be a valid IANA timezone name)');
+        }
+
+        const tool = req.body.tool;
+        if (!tool || typeof tool !== 'string') {
+            throw new Errors.BadRequest('tool is required');
+        }
+
+        const args = req.body.args;
+        if (!args || typeof args !== 'object' || Array.isArray(args)) {
+            throw new Errors.BadRequest('args is required (object)');
+        }
+
+        const confirmToken = req.body.confirm_token;
+        if (!confirmToken || typeof confirmToken !== 'string') {
+            throw new Errors.BadRequest('confirm_token is required');
+        }
+
+        const userId = req.auth.uid;
+        const jobId = await this.jobService.createConfirmJob({
+            userId,
+            deviceId,
+            commandText,
+            timezone,
+            confirmPayload: { tool, args, confirmToken }
+        });
+        res.status(202).send({ job_id: jobId });
+    }
+
     async getUsage(req, res) {
         const usage = await this.aiUsageService.getTodayUsage(req.auth.uid);
         res.status(200).send(usage.toJSON());

--- a/functions/middlewares/openapi/patAuth.js
+++ b/functions/middlewares/openapi/patAuth.js
@@ -3,11 +3,18 @@ const Errors = require('../../models/Errors');
 
 const KNOWN_SERVICES = ['mcp'];
 
+// env 의 OPENAPI_PAT_<SERVICE>(_PRIMARY|_SECONDARY) 는 '<service>_<secret>' full token 형식
+// (lib `todocalendar-tools` 의 callOpenApi 가 Authorization 헤더에 그대로 박는 형식과 일관).
+// 두 슬롯(#176: 무중단 로테이션)을 모두 보되, prefix 누락 슬롯은 즉시 폐기. 일치 비교는
+// secret 부분만 수행하므로 호출자에 secret 만 추려서 반환.
 function envSecretsFor(service) {
     const upper = service.toUpperCase();
+    const prefix = `${service}_`;
     const primary = process.env[`OPENAPI_PAT_${upper}_PRIMARY`] ?? process.env[`OPENAPI_PAT_${upper}`];
     const secondary = process.env[`OPENAPI_PAT_${upper}_SECONDARY`];
-    return [primary, secondary].filter((s) => typeof s === 'string' && s.length > 0);
+    return [primary, secondary]
+        .filter((s) => typeof s === 'string' && s.startsWith(prefix) && s.length > prefix.length)
+        .map((s) => s.slice(prefix.length));
 }
 
 function safeEqual(a, b) {

--- a/functions/models/ai/AiJob.js
+++ b/functions/models/ai/AiJob.js
@@ -3,12 +3,14 @@
 const { toISOString } = require('./_timestamp');
 
 class AiJob {
-    constructor({ jobId, userId, deviceId, commandText, timezone, status, result, createdAt, updatedAt, expireAt }) {
+    constructor({ jobId, userId, deviceId, commandText, timezone, mode, confirmPayload, status, result, createdAt, updatedAt, expireAt }) {
         this.jobId = jobId;
         this.userId = userId;
         this.deviceId = deviceId;
         this.commandText = commandText;
         this.timezone = timezone;
+        this.mode = mode ?? AiJob.MODE.COMMAND;
+        this.confirmPayload = confirmPayload ?? null;
         this.status = status;
         this.result = result ?? null;
         this.createdAt = createdAt;
@@ -17,12 +19,15 @@ class AiJob {
     }
 
     static fromData(jobId, data) {
+        // mode / confirmPayload 는 #158 에서 추가됨. 그 이전 doc 은 mode 'command' 로 backward-compatible.
         return new AiJob({
             jobId,
             userId: data.userId,
             deviceId: data.deviceId,
             commandText: data.commandText,
             timezone: data.timezone,
+            mode: data.mode ?? AiJob.MODE.COMMAND,
+            confirmPayload: data.confirmPayload ?? null,
             status: data.status,
             result: data.result ?? null,
             createdAt: toISOString(data.createdAt),
@@ -38,6 +43,8 @@ class AiJob {
             device_id: this.deviceId,
             command_text: this.commandText,
             timezone: this.timezone,
+            mode: this.mode,
+            confirm_payload: this.confirmPayload,
             status: this.status,
             result: this.result,
             created_at: this.createdAt,
@@ -67,6 +74,13 @@ AiJob.STATUS = Object.freeze({
     DONE: 'DONE',
     CONFIRM: 'CONFIRM',
     FAILED: 'FAILED'
+});
+
+// 'command': 자연어 명령 (1차) — Agent Loop run() 진입
+// 'confirm': confirm 2차 호출 — Agent Loop runConfirm() 진입, lib tool 1회 실행
+AiJob.MODE = Object.freeze({
+    COMMAND: 'command',
+    CONFIRM: 'confirm'
 });
 
 module.exports = AiJob;

--- a/functions/routes/ai/aiRoutes.js
+++ b/functions/routes/ai/aiRoutes.js
@@ -14,6 +14,7 @@ const controller = new AiController(jobService, aiUsageService);
 
 const router = express.Router();
 router.post('/command', (req, res) => controller.postCommand(req, res));
+router.post('/command/confirm', (req, res) => controller.postCommandConfirm(req, res));
 router.get('/jobs/:id', (req, res) => controller.getJob(req, res));
 router.get('/usage', (req, res) => controller.getUsage(req, res));
 

--- a/functions/secrets/.env.test.example
+++ b/functions/secrets/.env.test.example
@@ -11,10 +11,11 @@
 HOLIDAY_API_KEY=dummy-not-a-real-google-api-key
 
 # openAPI PAT 시크릿 (mcp 서비스용).
-# 호출 시 헤더에 들어가는 토큰은 `Bearer mcp_<이 값>` — env 에는 prefix 'mcp_' 없이 secret 부분만 둔다.
-# 검증 로직: middlewares/openapi/patAuth.js (token 을 '_' 로 split 후 secret 부분만 비교).
+# 호출 시 헤더에 들어가는 토큰은 `Bearer mcp_<secret>` — env 에 prefix 'mcp_' 포함한 full 형식 그대로 둔다.
+# 검증 로직: middlewares/openapi/patAuth.js (token 을 '_' 로 split → service+secret 분리, env 도 동일 형식이라 secret 만 비교).
+# lib(todocalendar-tools) callOpenApi 가 env 값을 그대로 Authorization 헤더에 박으므로 prefix 포함 필수.
 # MVP 는 mcp prefix 한 종류만 화이트리스트.
-OPENAPI_PAT_MCP=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+OPENAPI_PAT_MCP=mcp_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 
 # 로테이션용 SECONDARY 슬롯 (#176). 평상시 비워 두고, 신 secret 으로 교체 시점에 일시 사용.
 # 절차: SECONDARY 에 신값 → 호출자 전환 → PRIMARY 에 신값 복사 → SECONDARY 비움.

--- a/functions/services/ai/agentLoopService.js
+++ b/functions/services/ai/agentLoopService.js
@@ -55,6 +55,12 @@ function getConfirmTitle(toolName, lang) {
     return CONFIRM_TITLES_BY_TOOL[toolName]?.[lang] ?? CONFIRM_DEFAULTS[lang].title;
 }
 
+// runConfirm 의 DONE 응답 text — language 별 한 줄. notification 은 handler fallback 에 맡김.
+const CONFIRM_DONE_TEXTS = {
+    ko: '요청한 작업을 완료했어',
+    en: 'Done'
+};
+
 class AgentLoopService {
 
     /**
@@ -187,6 +193,36 @@ class AgentLoopService {
         }
 
         return { result: AiJobResult.failed('loop cap exceeded'), usage: usage() };
+    }
+
+    /**
+     * CONFIRM 2차 호출 흐름.
+     *
+     * Claude API / systemPrompt 호출 없이 lib tool 1회만 실행.
+     * confirmToken 검증·실 mutation 은 lib (`ensureConfirmToken` → openAPI DELETE 등) 가 수행.
+     * 검증 실패는 lib 가 `ToolError(Confirm*)` 로 throw → 본 메서드가 FAILED 로 매핑.
+     * usage 는 항상 0/0 (Claude 호출 없음) — handler 의 record 분기 일관성 유지용.
+     *
+     * @param {{ tool: string, args: object, confirmToken: string }} payload
+     * @param {{ userId: string, timezone?: string, commandText?: string }} context  commandText 는 language 검출 전용
+     * @returns {Promise<{ result: object, usage: { inputTokens: number, outputTokens: number } }>}
+     */
+    async runConfirm({ tool, args, confirmToken }, { userId, commandText }) {
+        const auth = { userId, scopes: this.scopes };
+        const lang = detectLanguage(commandText || '');
+        const usage = { inputTokens: 0, outputTokens: 0 };
+        const registry = await this._registryFactory();
+
+        try {
+            const result = await registry.execute(tool, { ...args, confirmToken }, auth);
+            if (registry.isConfirmRequired(result)) {
+                return { result: AiJobResult.failed('unexpected confirm_required on confirm-mode'), usage };
+            }
+            return { result: AiJobResult.done(CONFIRM_DONE_TEXTS[lang]), usage };
+        } catch (e) {
+            const reason = (e && e.code) ? e.code : 'agent error';
+            return { result: AiJobResult.failed(reason), usage };
+        }
     }
 }
 

--- a/functions/services/ai/fakes/anthropicClient.js
+++ b/functions/services/ai/fakes/anthropicClient.js
@@ -31,8 +31,11 @@ function resolveMarkerResponse(messages) {
         ? content
         : (Array.isArray(content) ? (content.find(b => b.type === 'text')?.text ?? '') : '');
 
-    if (text.includes('[stub:CONFIRM]')) {
-        return makeToolUseResponse('delete_todo', { todo_id: 'stub-todo-id' });
+    // [stub:CONFIRM] → 'stub-todo-id' (기본). [stub:CONFIRM:<id>] → 그 id (e2e #158 2차 흐름 검증용).
+    const confirmMatch = text.match(/\[stub:CONFIRM(?::([^\]]+))?\]/);
+    if (confirmMatch) {
+        const todoId = confirmMatch[1] || 'stub-todo-id';
+        return makeToolUseResponse('delete_todo', { todo_id: todoId });
     }
     if (text.includes('[stub:FAILED]')) {
         return makeToolUseResponse('finalize', {

--- a/functions/services/ai/jobService.js
+++ b/functions/services/ai/jobService.js
@@ -26,6 +26,34 @@ class JobService {
             deviceId,
             commandText,
             timezone,
+            mode: AiJob.MODE.COMMAND,
+            confirmPayload: null,
+            status: AiJob.STATUS.PENDING,
+            result: null,
+            expireAt
+        };
+
+        await this.jobRepository.put(jobId, data);
+        return jobId;
+    }
+
+    /**
+     * CONFIRM 2차 호출용 job 발행. 새 jobId 발급 — 1차 jobId 와 독립.
+     *
+     * @param {{ userId, deviceId, commandText, timezone, confirmPayload: { tool, args, confirmToken } }} params
+     * @returns {Promise<string>} jobId
+     */
+    async createConfirmJob({ userId, deviceId, commandText, timezone, confirmPayload }) {
+        const jobId = crypto.randomUUID();
+        const expireAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+        const data = {
+            userId,
+            deviceId,
+            commandText,
+            timezone,
+            mode: AiJob.MODE.CONFIRM,
+            confirmPayload,
             status: AiJob.STATUS.PENDING,
             result: null,
             expireAt

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -179,6 +179,90 @@ describe('AiController', () => {
     });
 
 
+    // MARK: - postCommandConfirm
+
+    describe('postCommandConfirm', () => {
+
+        function makeConfirmReq({
+            uid = 'user-1', deviceId = 'device-1',
+            commandText = '이거 삭제해', timezone = 'Asia/Seoul',
+            tool = 'delete_todo', args = { todo_id: 't1' }, confirmToken = 'tk'
+        } = {}) {
+            return {
+                auth: { uid },
+                header: (name) => name === 'device_id' ? deviceId : null,
+                body: {
+                    command_text: commandText, timezone,
+                    tool, args, confirm_token: confirmToken
+                }
+            };
+        }
+
+        it('정상 — 202 + job_id, createConfirmJob 인자에 confirmPayload 묶여 전달', async () => {
+            const req = makeConfirmReq();
+            const res = makeRes();
+
+            await controller.postCommandConfirm(req, res);
+
+            assert.equal(res.statusCode, 202);
+            assert.deepEqual(res.body, { job_id: 'job-123' });
+            assert.deepEqual(stubService.lastCreateConfirmJobArgs, {
+                userId: 'user-1',
+                deviceId: 'device-1',
+                commandText: '이거 삭제해',
+                timezone: 'Asia/Seoul',
+                confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
+            });
+        });
+
+        it('device_id 헤더 누락 → 400', async () => {
+            const req = makeConfirmReq({ deviceId: null });
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('command_text 누락 → 400', async () => {
+            const req = makeConfirmReq();
+            req.body.command_text = '';
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('timezone 누락 → 400', async () => {
+            const req = makeConfirmReq();
+            delete req.body.timezone;
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('timezone 이 invalid IANA → 400', async () => {
+            const req = makeConfirmReq({ timezone: 'Not/ATz' });
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('tool 누락 → 400', async () => {
+            const req = makeConfirmReq();
+            delete req.body.tool;
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('args 누락 → 400', async () => {
+            const req = makeConfirmReq();
+            delete req.body.args;
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('args 가 array → 400 (object 가 아님)', async () => {
+            const req = makeConfirmReq();
+            req.body.args = ['t1'];
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('confirm_token 누락 → 400', async () => {
+            const req = makeConfirmReq();
+            delete req.body.confirm_token;
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+    });
+
+
     // MARK: - getJob
 
     describe('getJob', () => {

--- a/functions/test/doubles/stubAiJobService.js
+++ b/functions/test/doubles/stubAiJobService.js
@@ -8,6 +8,7 @@ class StubAiJobService {
     constructor() {
         this.shouldFail = false;
         this.lastCreateJobArgs = null;
+        this.lastCreateConfirmJobArgs = null;
         this._jobs = {};
         this._nextJobId = 'job-123';
     }
@@ -19,6 +20,12 @@ class StubAiJobService {
     async createJob({ userId, deviceId, commandText, timezone }) {
         if (this.shouldFail) throw { message: 'service failed' };
         this.lastCreateJobArgs = { userId, deviceId, commandText, timezone };
+        return this._nextJobId;
+    }
+
+    async createConfirmJob({ userId, deviceId, commandText, timezone, confirmPayload }) {
+        if (this.shouldFail) throw { message: 'service failed' };
+        this.lastCreateConfirmJobArgs = { userId, deviceId, commandText, timezone, confirmPayload };
         return this._nextJobId;
     }
 

--- a/functions/test/e2e/ai-confirm.e2e.js
+++ b/functions/test/e2e/ai-confirm.e2e.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const assert = require('assert');
+
+const { authedClient } = require('./helpers/request');
+const { signUserToken, openClient, defaultMcpPat } = require('./helpers/openClient');
+const { TEST_USER_UID } = require('./seeds/commonData');
+
+// 1차 [stub:CONFIRM:<id>] → CONFIRM → 2차 confirm endpoint → DONE 흐름 검증.
+// FakeAnthropicClient markerFallback 이 [stub:CONFIRM:<id>] 를 delete_todo({todo_id:<id>})
+// tool_use 로 매핑하기 때문에 실제 openAPI todo 를 시드한 뒤 그 id 로 시나리오 진행.
+
+async function pollJob(client, jobId, { timeoutMs = 8000, intervalMs = 100 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const res = await client.get(`/v1/ai/jobs/${jobId}`);
+        if (res.status === 200 && ['DONE', 'CONFIRM', 'FAILED'].includes(res.data.status)) {
+            return res.data;
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error(`pollJob timeout (${timeoutMs}ms) — jobId: ${jobId}`);
+}
+
+describe('aiFrontAPI confirm 2차 호출', function () {
+
+    let client;
+    let openCli;
+
+    before(function () {
+        client = authedClient();
+        const userToken = signUserToken({
+            sub: TEST_USER_UID,
+            scope: ['read:calendar', 'write:calendar']
+        });
+        openCli = openClient({ pat: defaultMcpPat(), userToken });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    describe('POST /v1/ai/command/confirm — body validation', function () {
+
+        it('필수 body 누락 (tool) → 400', async function () {
+            const res = await client.post(
+                '/v1/ai/command/confirm',
+                {
+                    command_text: 'delete',
+                    timezone: 'Asia/Seoul',
+                    args: { todo_id: 't1' },
+                    confirm_token: 'tk'
+                },
+                { headers: { device_id: 'e2e-device-confirm' } }
+            );
+            assert.strictEqual(res.status, 400);
+        });
+
+        it('args 가 array → 400', async function () {
+            const res = await client.post(
+                '/v1/ai/command/confirm',
+                {
+                    command_text: 'delete',
+                    timezone: 'Asia/Seoul',
+                    tool: 'delete_todo',
+                    args: ['t1'],
+                    confirm_token: 'tk'
+                },
+                { headers: { device_id: 'e2e-device-confirm' } }
+            );
+            assert.strictEqual(res.status, 400);
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    describe('골든 흐름 — 1차 CONFIRM → 2차 DONE → 실제 삭제 확인', function () {
+
+        let createdTodoId;
+        let confirmAction;
+
+        it('todo 시드 (openAPI POST) → 1차 [stub:CONFIRM:<id>] → CONFIRM + result.action 추출', async function () {
+            this.timeout(15000);
+
+            // 1) todo 시드
+            const createRes = await openCli.post('/v2/open/todos/', {
+                name: 'AI confirm e2e todo',
+                event_time: { time_type: 'at', timestamp: Math.floor(Date.now() / 1000) + 3600 }
+            });
+            assert.strictEqual(createRes.status, 201);
+            createdTodoId = createRes.data.uuid;
+
+            // 2) 1차 command — FakeAnthropicClient 가 [stub:CONFIRM:<id>] 매칭해 delete_todo tool_use 반환
+            const cmdRes = await client.post(
+                '/v1/ai/command',
+                {
+                    command_text: `[stub:CONFIRM:${createdTodoId}] 이거 삭제해`,
+                    timezone: 'Asia/Seoul'
+                },
+                { headers: { device_id: 'e2e-device-confirm' } }
+            );
+            assert.strictEqual(cmdRes.status, 202);
+
+            const job1 = await pollJob(client, cmdRes.data.job_id);
+            assert.strictEqual(job1.status, 'CONFIRM');
+            assert.strictEqual(job1.result.type, 'CONFIRM');
+            assert.ok(job1.result.action, 'result.action 존재');
+            assert.strictEqual(job1.result.action.tool, 'delete_todo');
+            assert.deepStrictEqual(job1.result.action.args, { todo_id: createdTodoId });
+            assert.ok(job1.result.action.confirmToken, 'confirmToken 존재');
+
+            confirmAction = job1.result.action;
+        });
+
+        it('2차 confirm endpoint → DONE + 실제 todo 삭제 확인 (openAPI GET 404)', async function () {
+            this.timeout(15000);
+
+            const confirmRes = await client.post(
+                '/v1/ai/command/confirm',
+                {
+                    command_text: '이거 삭제해',
+                    timezone: 'Asia/Seoul',
+                    tool: confirmAction.tool,
+                    args: confirmAction.args,
+                    confirm_token: confirmAction.confirmToken
+                },
+                { headers: { device_id: 'e2e-device-confirm' } }
+            );
+            assert.strictEqual(confirmRes.status, 202);
+
+            const job2 = await pollJob(client, confirmRes.data.job_id);
+            assert.strictEqual(job2.status, 'DONE', `2차 호출 결과가 DONE 이어야 함 (actual: ${JSON.stringify(job2.result)})`);
+            assert.strictEqual(job2.result.type, 'DONE');
+
+            // 2차 job 의 mode 가 'confirm' 으로 응답에 노출됨
+            assert.strictEqual(job2.mode, 'confirm');
+
+            // 실 todo 가 삭제됐는지 — openAPI GET → 404
+            const checkRes = await openCli.get(`/v2/open/todos/${createdTodoId}`);
+            assert.strictEqual(checkRes.status, 404, 'todo 가 실제로 삭제됨');
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    describe('verify 실패 — 변조된 confirm_token → FAILED', function () {
+
+        it('전혀 다른 token 으로 2차 호출 → FAILED (lib verify 실패)', async function () {
+            this.timeout(15000);
+
+            const res = await client.post(
+                '/v1/ai/command/confirm',
+                {
+                    command_text: 'delete',
+                    timezone: 'Asia/Seoul',
+                    tool: 'delete_todo',
+                    args: { todo_id: 'never-existed' },
+                    confirm_token: 'invalid.token.value'
+                },
+                { headers: { device_id: 'e2e-device-confirm' } }
+            );
+            assert.strictEqual(res.status, 202);
+
+            const job = await pollJob(client, res.data.job_id);
+            assert.strictEqual(job.status, 'FAILED');
+            assert.strictEqual(job.result.type, 'FAILED');
+            assert.ok(job.result.reason, 'reason 노출');
+        });
+    });
+});

--- a/functions/test/e2e/helpers/openClient.js
+++ b/functions/test/e2e/helpers/openClient.js
@@ -32,14 +32,17 @@ function openClient({ pat, userToken, baseURL = BASE_URL_OPEN } = {}) {
     });
 }
 
-// .env.test 의 OPENAPI_PAT_MCP 값으로 정상 PAT 토큰 문자열 ('mcp_<secret>') 을 만든다.
-// 호출자에 prefix 붙이는 책임을 한 곳에 가둠.
+// .env.test 의 OPENAPI_PAT_MCP 값을 그대로 반환 (정책: 'mcp_<secret>' 형식으로 저장).
+// 잘못 셋업 (prefix 누락) 시 명시적 throw — operator 가 secrets 갱신해야 함.
 function defaultMcpPat() {
-    const secret = process.env.OPENAPI_PAT_MCP;
-    if (!secret) {
+    const raw = process.env.OPENAPI_PAT_MCP;
+    if (!raw) {
         throw new Error('OPENAPI_PAT_MCP not set; load secrets/.env.test');
     }
-    return `mcp_${secret}`;
+    if (!raw.startsWith('mcp_')) {
+        throw new Error('OPENAPI_PAT_MCP must start with "mcp_" (see CLAUDE.md openAPI 시크릿 운영 정책)');
+    }
+    return raw;
 }
 
 module.exports = {

--- a/functions/test/middlewares/openapi/patAuth.test.js
+++ b/functions/test/middlewares/openapi/patAuth.test.js
@@ -5,6 +5,7 @@ const Errors = require('../../../models/Errors');
 describe('middlewares/openapi/patAuth', () => {
 
     const SECRET = 'a'.repeat(32);
+    const FULL_PAT = `mcp_${SECRET}`;  // env 정책: prefix 포함 full token
 
     let req;
     let res;
@@ -16,7 +17,7 @@ describe('middlewares/openapi/patAuth', () => {
         nextCalled = false;
         delete process.env.OPENAPI_PAT_MCP_PRIMARY;
         delete process.env.OPENAPI_PAT_MCP_SECONDARY;
-        process.env.OPENAPI_PAT_MCP = SECRET;
+        process.env.OPENAPI_PAT_MCP = FULL_PAT;
     });
 
     afterEach(() => {
@@ -71,6 +72,12 @@ describe('middlewares/openapi/patAuth', () => {
         expectFail(500, 'ServerMisconfigured');
     });
 
+    it('환경변수 가 prefix 없이 저장됨 (잘못된 형식) → 500 ServerMisconfigured', () => {
+        process.env.OPENAPI_PAT_MCP = SECRET;  // 'mcp_' prefix 누락
+        req.headers.authorization = `Bearer mcp_${SECRET}`;
+        expectFail(500, 'ServerMisconfigured');
+    });
+
     it('시크릿 불일치 (같은 길이) → 401', () => {
         req.headers.authorization = `Bearer mcp_${'b'.repeat(32)}`;
         expectFail(401, 'InvalidCredentials');
@@ -83,7 +90,7 @@ describe('middlewares/openapi/patAuth', () => {
 
     it('PRIMARY 만 설정 — PRIMARY secret 일치 → next 호출', () => {
         delete process.env.OPENAPI_PAT_MCP;
-        process.env.OPENAPI_PAT_MCP_PRIMARY = SECRET;
+        process.env.OPENAPI_PAT_MCP_PRIMARY = FULL_PAT;
         req.headers.authorization = `Bearer mcp_${SECRET}`;
         patAuth(req, res, next);
         assert.strictEqual(nextCalled, true);
@@ -93,7 +100,7 @@ describe('middlewares/openapi/patAuth', () => {
     it('SECONDARY 만 설정 — SECONDARY secret 일치 → next 호출 (로테이션 중간 단계)', () => {
         delete process.env.OPENAPI_PAT_MCP;
         const NEW = 'c'.repeat(32);
-        process.env.OPENAPI_PAT_MCP_SECONDARY = NEW;
+        process.env.OPENAPI_PAT_MCP_SECONDARY = `mcp_${NEW}`;
         req.headers.authorization = `Bearer mcp_${NEW}`;
         patAuth(req, res, next);
         assert.strictEqual(nextCalled, true);
@@ -102,8 +109,8 @@ describe('middlewares/openapi/patAuth', () => {
     it('PRIMARY + SECONDARY 동시 설정 — 둘 중 어느 쪽이든 일치하면 통과', () => {
         delete process.env.OPENAPI_PAT_MCP;
         const NEW = 'c'.repeat(32);
-        process.env.OPENAPI_PAT_MCP_PRIMARY = SECRET;
-        process.env.OPENAPI_PAT_MCP_SECONDARY = NEW;
+        process.env.OPENAPI_PAT_MCP_PRIMARY = FULL_PAT;
+        process.env.OPENAPI_PAT_MCP_SECONDARY = `mcp_${NEW}`;
 
         req.headers.authorization = `Bearer mcp_${SECRET}`;
         patAuth(req, res, () => { nextCalled = true; });
@@ -117,8 +124,8 @@ describe('middlewares/openapi/patAuth', () => {
 
     it('PRIMARY + SECONDARY 둘 다 불일치 → 401', () => {
         delete process.env.OPENAPI_PAT_MCP;
-        process.env.OPENAPI_PAT_MCP_PRIMARY = 'p'.repeat(32);
-        process.env.OPENAPI_PAT_MCP_SECONDARY = 's'.repeat(32);
+        process.env.OPENAPI_PAT_MCP_PRIMARY = `mcp_${'p'.repeat(32)}`;
+        process.env.OPENAPI_PAT_MCP_SECONDARY = `mcp_${'s'.repeat(32)}`;
         req.headers.authorization = `Bearer mcp_${'x'.repeat(32)}`;
         expectFail(401, 'InvalidCredentials');
     });

--- a/functions/test/models/ai/AiJob.test.js
+++ b/functions/test/models/ai/AiJob.test.js
@@ -14,6 +14,13 @@ describe('AiJob', () => {
         });
     });
 
+    describe('MODE enum', () => {
+        it('command / confirm 두 상수가 존재함', () => {
+            assert.strictEqual(AiJob.MODE.COMMAND, 'command');
+            assert.strictEqual(AiJob.MODE.CONFIRM, 'confirm');
+        });
+    });
+
     describe('isTerminal', () => {
         it('DONE 은 terminal', () => {
             assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.DONE), true);
@@ -97,6 +104,30 @@ describe('AiJob', () => {
             assert.strictEqual(job.updatedAt, isoStr);
         });
 
+        it('mode 가 doc 에 없으면 command default — backward-compat (#158 이전 doc)', () => {
+            const now = new Date();
+            const job = AiJob.fromData('job-bc', {
+                userId: 'u', deviceId: 'd', commandText: 'cmd',
+                status: AiJob.STATUS.PENDING, result: null,
+                createdAt: now, updatedAt: now, expireAt: now
+            });
+            assert.strictEqual(job.mode, AiJob.MODE.COMMAND);
+            assert.strictEqual(job.confirmPayload, null);
+        });
+
+        it('mode=confirm + confirmPayload 가 있는 doc → 그대로 보존', () => {
+            const now = new Date();
+            const payload = { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' };
+            const job = AiJob.fromData('job-cf', {
+                userId: 'u', deviceId: 'd', commandText: 'cmd',
+                mode: 'confirm', confirmPayload: payload,
+                status: AiJob.STATUS.PENDING, result: null,
+                createdAt: now, updatedAt: now, expireAt: now
+            });
+            assert.strictEqual(job.mode, 'confirm');
+            assert.deepStrictEqual(job.confirmPayload, payload);
+        });
+
         it('result 가 있을 때 그대로 보존', () => {
             const result = { type: 'DONE', text: '완료됐어' };
             const now = new Date();
@@ -140,8 +171,18 @@ describe('AiJob', () => {
             assert.strictEqual(json.command_text, 'test command');
             assert.strictEqual(json.status, AiJob.STATUS.PENDING);
             assert.strictEqual(json.result, null);
+            assert.strictEqual(json.mode, AiJob.MODE.COMMAND);
+            assert.strictEqual(json.confirm_payload, null);
             assert.strictEqual(json.created_at, '2026-05-17T00:00:00.000Z');
             assert.strictEqual(json.updated_at, '2026-05-17T00:00:00.000Z');
+        });
+
+        it('confirm 모드 job — mode / confirm_payload 가 응답에 포함됨', () => {
+            const payload = { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' };
+            const job = makeJob({ mode: 'confirm', confirmPayload: payload });
+            const json = job.toJSON();
+            assert.strictEqual(json.mode, 'confirm');
+            assert.deepStrictEqual(json.confirm_payload, payload);
         });
 
         it('expire_at 은 응답에 포함되지 않음', () => {

--- a/functions/test/services/ai/agentLoopService.test.js
+++ b/functions/test/services/ai/agentLoopService.test.js
@@ -522,4 +522,108 @@ describe('AgentLoopService', () => {
         assert.deepStrictEqual(usage, { inputTokens: 120, outputTokens: 25 });
     });
 
+    // ─── runConfirm (CONFIRM 2차 호출) ─────────────────────────────────────────
+
+    describe('runConfirm', () => {
+
+        it('lib tool 정상 응답 → DONE, args 에 confirmToken merge 후 전달, usage 0/0', async () => {
+            const { service, registry } = makeService();
+            registry.registerExecute('delete_todo', { status: 'ok' });
+
+            const { result, usage } = await service.runConfirm(
+                { tool: 'delete_todo', args: { todo_id: 'todo-1' }, confirmToken: 'token-xyz' },
+                { userId: 'u1', timezone: 'Asia/Seoul', commandText: '이거 삭제해' }
+            );
+
+            assert.strictEqual(result.type, 'DONE');
+            assert.strictEqual(result.text, '요청한 작업을 완료했어');
+            assert.deepStrictEqual(usage, { inputTokens: 0, outputTokens: 0 });
+            assert.deepStrictEqual(registry.lastExecute.args, { todo_id: 'todo-1', confirmToken: 'token-xyz' });
+            assert.deepStrictEqual(registry.lastExecute.auth, { userId: 'u1', scopes: ['read:calendar', 'write:calendar'] });
+        });
+
+        it('영어 commandText → DONE text 영어 (language 분기)', async () => {
+            const { service, registry } = makeService();
+            registry.registerExecute('delete_todo', { status: 'ok' });
+
+            const { result } = await service.runConfirm(
+                { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' },
+                { userId: 'u1', timezone: 'UTC', commandText: 'delete this todo' }
+            );
+
+            assert.strictEqual(result.type, 'DONE');
+            assert.strictEqual(result.text, 'Done');
+        });
+
+        it('lib 가 ToolError(ConfirmExpired) throw → FAILED, reason=e.code', async () => {
+            const { service, registry } = makeService();
+            registry.registerExecute('delete_todo', () => {
+                const err = new Error('confirm token expired');
+                err.name = 'ToolError';
+                err.code = 'ConfirmExpired';
+                err.status = 410;
+                throw err;
+            });
+
+            const { result, usage } = await service.runConfirm(
+                { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' },
+                { userId: 'u1', timezone: 'Asia/Seoul', commandText: '삭제' }
+            );
+
+            assert.strictEqual(result.type, 'FAILED');
+            assert.strictEqual(result.reason, 'ConfirmExpired');
+            assert.deepStrictEqual(usage, { inputTokens: 0, outputTokens: 0 });
+        });
+
+        it('lib 가 ToolError(ConfirmArgsMismatch) throw → FAILED, reason=e.code (e.code 라우팅 검증)', async () => {
+            const { service, registry } = makeService();
+            registry.registerExecute('delete_schedule', () => {
+                const err = new Error('confirm token args mismatch');
+                err.code = 'ConfirmArgsMismatch';
+                err.status = 400;
+                throw err;
+            });
+
+            const { result } = await service.runConfirm(
+                { tool: 'delete_schedule', args: { schedule_id: 's1' }, confirmToken: 'tk' },
+                { userId: 'u1', timezone: 'Asia/Seoul', commandText: 'delete' }
+            );
+
+            assert.strictEqual(result.type, 'FAILED');
+            assert.strictEqual(result.reason, 'ConfirmArgsMismatch');
+        });
+
+        it('lib 가 confirm_required 다시 반환 (비정상) → FAILED', async () => {
+            const { service, registry } = makeService();
+            registry.registerExecute('delete_todo', {
+                status: 'confirm_required',
+                message: 'still requires confirmation',
+                confirmToken: 'new-token'
+            });
+
+            const { result } = await service.runConfirm(
+                { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' },
+                { userId: 'u1', timezone: 'Asia/Seoul', commandText: 'delete' }
+            );
+
+            assert.strictEqual(result.type, 'FAILED');
+            assert.strictEqual(result.reason, 'unexpected confirm_required on confirm-mode');
+        });
+
+        it('e.code 없는 generic Error throw → FAILED, reason="agent error"', async () => {
+            const { service, registry } = makeService();
+            registry.registerExecute('delete_todo', () => {
+                throw new Error('network down');
+            });
+
+            const { result } = await service.runConfirm(
+                { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' },
+                { userId: 'u1', timezone: 'Asia/Seoul', commandText: '삭제' }
+            );
+
+            assert.strictEqual(result.type, 'FAILED');
+            assert.strictEqual(result.reason, 'agent error');
+        });
+    });
+
 });

--- a/functions/test/services/ai/jobService.test.js
+++ b/functions/test/services/ai/jobService.test.js
@@ -71,6 +71,57 @@ describe('JobService', () => {
                 () => service.createJob({ userId: 'u', deviceId: 'd', commandText: 'cmd' })
             );
         });
+
+        it('createJob 은 mode=command + confirmPayload=null 로 plain object 를 박음', async () => {
+            await service.createJob({ userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'Asia/Seoul' });
+            const { data } = stubRepo.lastPutPayload;
+            assert.strictEqual(data.mode, AiJob.MODE.COMMAND);
+            assert.strictEqual(data.confirmPayload, null);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // createConfirmJob
+    // ------------------------------------------------------------------ //
+
+    describe('createConfirmJob', () => {
+
+        it('mode=confirm + confirmPayload 가 plain object 로 박히고 새 jobId 반환', async () => {
+            const before = Date.now();
+            const jobId = await service.createConfirmJob({
+                userId: 'u', deviceId: 'd', commandText: '삭제',
+                timezone: 'Asia/Seoul',
+                confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
+            });
+            const after = Date.now();
+
+            assert.ok(typeof jobId === 'string' && jobId.length > 0);
+
+            const { jobId: storedJobId, data } = stubRepo.lastPutPayload;
+            assert.strictEqual(storedJobId, jobId);
+            assert.strictEqual(Object.getPrototypeOf(data), Object.prototype);
+
+            assert.strictEqual(data.userId, 'u');
+            assert.strictEqual(data.deviceId, 'd');
+            assert.strictEqual(data.commandText, '삭제');
+            assert.strictEqual(data.timezone, 'Asia/Seoul');
+            assert.strictEqual(data.mode, AiJob.MODE.CONFIRM);
+            assert.deepStrictEqual(data.confirmPayload, { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' });
+            assert.strictEqual(data.status, AiJob.STATUS.PENDING);
+            assert.strictEqual(data.result, null);
+
+            assert.ok(data.expireAt instanceof Date);
+            const expected24hLater = before + 24 * 60 * 60 * 1000;
+            const drift = data.expireAt.getTime() - expected24hLater;
+            assert.ok(drift >= 0 && drift <= (after - before) + 1000);
+        });
+
+        it('두 번 호출하면 서로 다른 jobId 반환', async () => {
+            const payload = { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' };
+            const a = await service.createConfirmJob({ userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'UTC', confirmPayload: payload });
+            const b = await service.createConfirmJob({ userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'UTC', confirmPayload: payload });
+            assert.notStrictEqual(a, b);
+        });
     });
 
     // ------------------------------------------------------------------ //

--- a/functions/test/triggers/ai/agentLoopTrigger.test.js
+++ b/functions/test/triggers/ai/agentLoopTrigger.test.js
@@ -64,9 +64,19 @@ function makeAgentLoopService(resultOverride, usageOverride) {
     return {
         lastRunArgs: null,
         allRunArgs: [],
+        lastRunConfirmArgs: null,
+        allRunConfirmArgs: [],
         async run(commandText, opts) {
             this.lastRunArgs = { commandText, opts };
             this.allRunArgs.push({ commandText, opts });
+            return {
+                result: resultOverride ?? AiJobResult.done('stub done'),
+                usage: usageOverride ?? { inputTokens: 0, outputTokens: 0 }
+            };
+        },
+        async runConfirm(payload, opts) {
+            this.lastRunConfirmArgs = { payload, opts };
+            this.allRunConfirmArgs.push({ payload, opts });
             return {
                 result: resultOverride ?? AiJobResult.done('stub done'),
                 usage: usageOverride ?? { inputTokens: 0, outputTokens: 0 }
@@ -483,5 +493,48 @@ describe('AgentLoopHandler', () => {
         await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
 
         assert.strictEqual(messaging.sendCalled, 1, 'record 실패와 무관하게 FCM 발송');
+    });
+
+    // ─── mode 분기 (#158) ────────────────────────────────────────────────────
+
+    it('mode=confirm job → runConfirm 호출, run 호출 X, confirmPayload 그대로 전달', async () => {
+        const confirmPayload = { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' };
+        const confirmJobData = {
+            ...BASE_JOB_DATA,
+            mode: AiJob.MODE.CONFIRM,
+            confirmPayload
+        };
+        const repo = seededRepo('job-cf', confirmJobData);
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(AiJobResult.done('done'));
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-cf', confirmJobData));
+
+        assert.strictEqual(agentLoopService.allRunArgs.length, 0, 'run 호출 X');
+        assert.strictEqual(agentLoopService.allRunConfirmArgs.length, 1, 'runConfirm 1회');
+        assert.deepStrictEqual(agentLoopService.lastRunConfirmArgs, {
+            payload: confirmPayload,
+            opts: { userId: BASE_JOB_DATA.userId, timezone: BASE_JOB_DATA.timezone, commandText: BASE_JOB_DATA.commandText }
+        });
+        assert.strictEqual(messaging.sendCalled, 1, 'FCM 정상 발송');
+    });
+
+    it('mode=command (default) job → run 호출, runConfirm 호출 X — 기존 흐름 회귀 가드', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo);
+        const agentLoopService = makeAgentLoopService(AiJobResult.done('done'));
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(agentLoopService.allRunArgs.length, 1);
+        assert.strictEqual(agentLoopService.allRunConfirmArgs.length, 0);
     });
 });

--- a/functions/triggers/ai/agentLoopHandler.js
+++ b/functions/triggers/ai/agentLoopHandler.js
@@ -27,7 +27,10 @@ class AgentLoopHandler {
     /**
      * @param {{
      *   jobService: import('../../services/ai/jobService'),
-     *   agentLoopService: { run(commandText, opts): Promise<{ result: object, usage: { inputTokens: number, outputTokens: number } }> },
+     *   agentLoopService: {
+     *     run(commandText, opts): Promise<{ result: object, usage: { inputTokens: number, outputTokens: number } }>,
+     *     runConfirm(payload, opts): Promise<{ result: object, usage: { inputTokens: number, outputTokens: number } }>
+     *   },
      *   aiUsageService: { recordUsage(userId, tokens): Promise<void> },
      *   userRepository: { loadUserDevice(deviceId: string): Promise<object|null> },
      *   messaging: { send(message: object): Promise<any> },
@@ -59,7 +62,7 @@ class AgentLoopHandler {
         let result;
         let usage = null;
         try {
-            ({ result, usage } = await this.agentLoopService.run(job.commandText, { userId: job.userId, timezone: job.timezone }));
+            ({ result, usage } = await this._dispatchAgentLoop(job));
         } catch (err) {
             this.log.error('AI trigger — agentLoop 실패', { jobId, err });
             result = AiJobResult.failed('agent loop error');
@@ -83,6 +86,22 @@ class AgentLoopHandler {
         }
 
         await this._sendFcm(job, result);
+    }
+
+    // job.mode 에 따라 agentLoopService 의 run 또는 runConfirm 호출.
+    // 두 메서드 시그니처가 다르므로 dispatch 책임을 한 곳에 응집.
+    async _dispatchAgentLoop(job) {
+        if (job.mode === AiJob.MODE.CONFIRM) {
+            return this.agentLoopService.runConfirm(job.confirmPayload, {
+                userId: job.userId,
+                timezone: job.timezone,
+                commandText: job.commandText
+            });
+        }
+        return this.agentLoopService.run(job.commandText, {
+            userId: job.userId,
+            timezone: job.timezone
+        });
     }
 
     async _recordUsage(userId, usage, jobId) {


### PR DESCRIPTION
Closes #158

## 배경

`delete_todo` / `delete_schedule` 같은 위험 tool 의 2단계 confirm 흐름에서, 1차 `confirm_required` 응답까지는 #154 에서 머지됐지만 사용자 확인 후 들어오는 **2차 호출 entrypoint 가 없어 실제 삭제까지 가는 경로가 영영 막혀 있던** 상태를 마감.

HMAC sign/verify·5분 TTL·argsHash 는 lib `todocalendar-tools` 의 `signConfirmToken` / `verifyConfirmToken` (HS256 + `CONFIRM_SECRET`) 이 그대로 처리 — functions 측에 별도 HMAC 코드는 추가하지 않음.

## 변경

### 1. PAT env 정책 통일 (선행, 별도 commit)

작업 중 lib `callOpenApi` 의 self-loopback 호출이 `OPENAPI_PAT_MCP must start with "mcp_"` 로 throw 하는 결함을 발견. functions 측 `patAuth.js` 가 prefix 없는 env 를 기대하던 기존 정책과 lib 의 prefix 포함 기대가 충돌. confirm 2차 흐름 도입으로 처음 노출됐고, lib 호출 모든 흐름에 동일 영향이라 본 PR 에 함께 처리.

env 를 `mcp_<secret>` full token 형식으로 통일, `patAuth.envSecretFor` 가 prefix 떼고 secret 만 비교하게 한 줄 변경. `.env.test.example` / `CLAUDE.md` / `defaultMcpPat` helper / patAuth unit test 함께 갱신.

### 2. CONFIRM 2차 호출 흐름

- `POST /v1/ai/command/confirm` 신규 endpoint — body `{ command_text, tool, args, confirm_token, timezone }`
- `AgentLoopService.runConfirm` — systemPrompt / Claude 호출 없이 lib tool 1회 실행 후 종결. lib `ToolError(Confirm*)` 5종 reason 매핑.
- `JobService.createConfirmJob` — 새 jobId 발행, `AiJob.mode='confirm'` + `confirmPayload` 저장. 1차 jobId 와 독립.
- `AiJob` — `MODE.{COMMAND,CONFIRM}` enum + `mode` / `confirmPayload` 필드, fromData 가 누락 doc 은 'command' default 로 backward-compat.
- `AgentLoopHandler._dispatchAgentLoop` — `job.mode` 분기로 run vs runConfirm 호출. usage record / completeWith / FCM 흐름은 분기 X.
- `FakeAnthropicClient.markerFallback` — `[stub:CONFIRM:<todo_id>]` 동적 todo_id 매칭 (e2e 검증용).

## 테스트

- Unit 1063 통과
- e2e `aiFrontAPI confirm 2차 호출` 5/5 통과 — 골든 흐름은 openAPI 로 실 todo 시드 → 1차 `[stub:CONFIRM:<id>]` → CONFIRM 응답 → 2차 confirmToken echo → DONE → openAPI GET 404 (실 삭제 확인) 까지 완주

## 스코프 외

- HMAC 자체 (sign/verify/TTL/argsHash) — lib 처리
- 1차 jobId ↔ 2차 jobId 연관 reference — 미도입 (각 job 독립)
- PAT/SIGNING_SECRET 무중단 로테이션 (#176) — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)