### PR TITLE
[#160] AgentLoopHandler — err raw dump 3곳 sanitize (Cloud Logging)

### DIFF
--- a/functions/test/triggers/ai/agentLoopTrigger.test.js
+++ b/functions/test/triggers/ai/agentLoopTrigger.test.js
@@ -537,4 +537,124 @@ describe('AgentLoopHandler', () => {
         assert.strictEqual(agentLoopService.allRunArgs.length, 1);
         assert.strictEqual(agentLoopService.allRunConfirmArgs.length, 0);
     });
+
+    // ─── 에러 로그 sanitize (#160) ─────────────────────────────────────────────
+    //
+    // Cloud Logging 에 err 객체를 raw dump 하면 SDK 에러 안의 stack / response headers /
+    // request body / 우발적 secret 이 함께 박힘. helper 가 { code, status, message } 만
+    // 추출하고 message 는 길이 캡 적용해야 함.
+
+    describe('에러 로그 sanitize (#160)', () => {
+
+        function makeFatErr() {
+            // Anthropic SDK 류 fat error: 추가 필드와 stack 포함
+            const err = new Error('upstream failed: api key abc-secret-12345 rejected');
+            err.code = 'unauthorized';
+            err.status = 401;
+            err.headers = { 'x-api-key': 'leaked-secret' };
+            err.response = { body: { detail: 'leaked' } };
+            err.request = { url: 'https://api.anthropic.com/v1/messages', body: { messages: ['leaked'] } };
+            return err;
+        }
+
+        function assertSanitized(loggedPayload, expected) {
+            assert.ok(loggedPayload.error, 'error key 존재');
+            assert.strictEqual('err' in loggedPayload, false, 'err key (raw) 가 더 이상 없음');
+            assert.deepStrictEqual(Object.keys(loggedPayload.error).sort(), ['code', 'message', 'status']);
+            assert.strictEqual(loggedPayload.error.code, expected.code);
+            assert.strictEqual(loggedPayload.error.status, expected.status);
+            assert.ok(loggedPayload.error.message.includes(expected.messageContains));
+        }
+
+        it('agentLoop throw 경로 — err 의 stack / headers / response / request 제외, code/status/message 만 로깅', async () => {
+            const repo = seededRepo();
+            const jobService = new JobService(repo);
+            const fatErr = makeFatErr();
+            const throwingLoop = { async run() { throw fatErr; } };
+            const messaging = makeMessaging();
+            const userRepo = makeUserRepository(BASE_DEVICE);
+            const { errors, logger } = captureLogger();
+
+            const handler = makeHandler({ jobService, agentLoopService: throwingLoop, userRepository: userRepo, messaging, logger });
+            await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+            const [msg, payload] = errors[0];
+            assert.ok(msg.includes('agentLoop 실패'));
+            assertSanitized(payload, { code: 'unauthorized', status: 401, messageContains: 'upstream failed' });
+        });
+
+        it('aiUsage record throw 경로 — 동일 sanitize 적용', async () => {
+            const repo = seededRepo();
+            const jobService = new JobService(repo);
+            const agentLoopService = makeAgentLoopService(
+                AiJobResult.done('stub done'),
+                { inputTokens: 100, outputTokens: 30 }
+            );
+            const aiUsageService = makeAiUsageService();
+            const fatErr = makeFatErr();
+            aiUsageService.recordUsage = async () => { throw fatErr; };
+            const messaging = makeMessaging();
+            const userRepo = makeUserRepository(BASE_DEVICE);
+            const { errors, logger } = captureLogger();
+
+            const handler = makeHandler({ jobService, agentLoopService, aiUsageService, userRepository: userRepo, messaging, logger });
+            await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+            const recordErr = errors.find(([m]) => m.includes('aiUsage record 실패'));
+            assert.ok(recordErr, 'aiUsage record 실패 로그 존재');
+            assertSanitized(recordErr[1], { code: 'unauthorized', status: 401, messageContains: 'upstream failed' });
+        });
+
+        it('FCM send throw 경로 — 동일 sanitize 적용', async () => {
+            const repo = seededRepo();
+            const jobService = new JobService(repo);
+            const agentLoopService = makeAgentLoopService();
+            const fatErr = makeFatErr();
+            const failMessaging = { async send() { throw fatErr; } };
+            const userRepo = makeUserRepository(BASE_DEVICE);
+            const { errors, logger } = captureLogger();
+
+            const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging: failMessaging, logger });
+            await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+            const fcmErr = errors.find(([m]) => m.includes('FCM 발송 실패'));
+            assert.ok(fcmErr, 'FCM 발송 실패 로그 존재');
+            assertSanitized(fcmErr[1], { code: 'unauthorized', status: 401, messageContains: 'upstream failed' });
+        });
+
+        it('매우 긴 message 는 길이 캡 적용 후 로깅', async () => {
+            const repo = seededRepo();
+            const jobService = new JobService(repo);
+            const hugeMsg = 'X'.repeat(2000);
+            const hugeErr = Object.assign(new Error(hugeMsg), { code: 'huge', status: 500 });
+            const throwingLoop = { async run() { throw hugeErr; } };
+            const messaging = makeMessaging();
+            const userRepo = makeUserRepository(BASE_DEVICE);
+            const { errors, logger } = captureLogger();
+
+            const handler = makeHandler({ jobService, agentLoopService: throwingLoop, userRepository: userRepo, messaging, logger });
+            await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+            const loggedMsg = errors[0][1].error.message;
+            assert.ok(loggedMsg.length < hugeMsg.length, '캡 적용으로 원본보다 짧음');
+            assert.ok(loggedMsg.length <= 600, '하드 cap 600자 이하');
+        });
+
+        it('non-Error 입력 (string throw) 도 안전 fallback', async () => {
+            const repo = seededRepo();
+            const jobService = new JobService(repo);
+            const throwingLoop = { async run() { throw 'plain string error'; } };
+            const messaging = makeMessaging();
+            const userRepo = makeUserRepository(BASE_DEVICE);
+            const { errors, logger } = captureLogger();
+
+            const handler = makeHandler({ jobService, agentLoopService: throwingLoop, userRepository: userRepo, messaging, logger });
+            await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+            const payload = errors[0][1];
+            assert.ok(payload.error.message.includes('plain string error'));
+            assert.strictEqual(payload.error.code, undefined);
+            assert.strictEqual(payload.error.status, undefined);
+        });
+    });
 });

--- a/functions/triggers/ai/agentLoopHandler.js
+++ b/functions/triggers/ai/agentLoopHandler.js
@@ -5,6 +5,28 @@ const AiJob = require('../../models/ai/AiJob');
 const AiJobResult = require('../../models/ai/AiJobResult');
 const { detectLanguage } = require('../../services/ai/language');
 
+// Cloud Logging sanitize (#160). err 를 그대로 logger.error 2nd arg 에 박으면
+// Anthropic SDK / firebase-admin / Firestore 에러의 stack, response headers,
+// request body, 우발적 secret 이 함께 박힌다. code/status/message 만 추출하고
+// message 는 캡을 둬 response body echo 가 통째로 들어오는 경우 차단.
+const ERROR_MESSAGE_CAP = 600;
+function _summarizeError(err) {
+    if (err && typeof err === 'object') {
+        const message = typeof err.message === 'string' ? err.message : String(err);
+        return {
+            code: err.code,
+            status: err.status,
+            message: message.length > ERROR_MESSAGE_CAP ? message.slice(0, ERROR_MESSAGE_CAP) : message
+        };
+    }
+    const fallback = String(err);
+    return {
+        code: undefined,
+        status: undefined,
+        message: fallback.length > ERROR_MESSAGE_CAP ? fallback.slice(0, ERROR_MESSAGE_CAP) : fallback
+    };
+}
+
 // status 별 fallback notification — result.notification 이 비어 있을 때 사용.
 // Agent Loop 이 컨텍스트 기반 맞춤 메시지를 못 만들 때만 진입하는 path.
 // 언어는 job.commandText 의 한글 포함 여부로 결정 (services/ai/language detectLanguage).
@@ -64,7 +86,7 @@ class AgentLoopHandler {
         try {
             ({ result, usage } = await this._dispatchAgentLoop(job));
         } catch (err) {
-            this.log.error('AI trigger — agentLoop 실패', { jobId, err });
+            this.log.error('AI trigger — agentLoop 실패', { jobId, error: _summarizeError(err) });
             result = AiJobResult.failed('agent loop error');
             // throw 경로는 usage 추출 불가 — 부분 사용 토큰이 있어도 손실 (acceptable loss).
             // 정밀도 필요 시 service 가 throw 대신 partial usage 동봉한 error 객체로 전환 필요.
@@ -108,7 +130,7 @@ class AgentLoopHandler {
         try {
             await this.aiUsageService.recordUsage(userId, usage);
         } catch (err) {
-            this.log.error('AI trigger — aiUsage record 실패', { jobId, err });
+            this.log.error('AI trigger — aiUsage record 실패', { jobId, error: _summarizeError(err) });
         }
     }
 
@@ -149,7 +171,7 @@ class AgentLoopHandler {
                 data: { jobId: job.jobId, status: result.type }
             });
         } catch (err) {
-            this.log.error('AI trigger — FCM 발송 실패', { jobId: job.jobId, err });
+            this.log.error('AI trigger — FCM 발송 실패', { jobId: job.jobId, error: _summarizeError(err) });
         }
     }
 }


### PR DESCRIPTION
Closes #160 (parent #151 2단계).

## 문제

`functions/triggers/ai/agentLoopHandler.js` 의 catch 블록 3곳에서 `logger.error('...', { jobId, err })` 형태로 **err 객체를 Cloud Logging 에 raw dump**:

- L67 `agentLoop 실패` — Anthropic SDK / lib `todocalendar-tools` / Firestore 에러 (HIGH)
- L111 `aiUsage record 실패` — Firestore 에러 (LOW)
- L152 `FCM 발송 실패` — firebase-admin/messaging 에러, push token 일부 echo 가능 (MEDIUM)

err 안에 stack · response headers · request body · 우발적 secret 이 함께 박힐 surface 가 가변적. 외부 SDK 가 바뀌면 새 필드가 자동 노출.

## 변경

- `_summarizeError(err)` helper 추가 (handler 내부 private). `{ code, status, message }` 만 추출, message 600자 캡. non-Error 입력 (string throw) 도 안전 fallback.
- 3 곳 `logger.error` 인자: `{ jobId, err }` → `{ jobId, error: _summarizeError(err) }`. key 명 `err` → `error` 로 raw vs 요약 신호.

## scope 외 (follow-up 후보)

- `functions/index.js:172-174` 글로벌 error handler 의 `res.send(err)` — Cloud Logging 이 아니라 client 응답 노출면, 별 이슈.
- L123/127 의 `deviceId` / `userId` PII — 운영 디버깅 가치와 trade-off, 별도 결정.
- lib `todocalendar-tools` 에러 message 안에 secret echo 있는지 — mcp repo 짝 작업 후보.

## Test plan

- [x] `npm test` (1080 passing)
- [x] 3 throw 경로 sanitize 검증
- [x] huge message 캡 적용
- [x] non-Error 입력 fallback
- [x] `agentLoopHandler.js` 안에 `{ ..., err }` 패턴 없음 (grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)