### PR TITLE
docs/spec/aiFront — 클라 통합 가이드 + confirm body command_text 제거

### DIFF
--- a/docs/spec/aiFront.md
+++ b/docs/spec/aiFront.md
@@ -183,7 +183,7 @@ sequenceDiagram
     Trig->>Hand: handle event
     Hand->>JobSvc: transitionToRunning jobId
     JobSvc->>FS: tx PENDING to RUNNING
-    Hand->>Agent: runConfirm with tool, args, confirmToken, userId, commandText
+    Hand->>Agent: runConfirm with tool, args, confirmToken, userId, lang
     Note over Agent: Claude API 호출 없음, systemPrompt 빌드 없음
     Agent->>Reg: execute tool, args plus confirmToken, auth
     Reg->>Lib: tool execute auth, args plus confirmToken
@@ -228,8 +228,6 @@ sequenceDiagram
     Usage-->>Ctrl: usage or empty dateKey
     Ctrl-->>App: 200 with dateKey, inputTokens, outputTokens, lastUpdatedAt
 ```
-
----
 
 ---
 
@@ -428,4 +426,4 @@ Content-Type: application/json
 - **token cap**: `lastInputTokens + sumOutputTokens > tokenCap (50000)` 즉시 FAILED.
   Anthropic 의 `input_tokens` 은 매 호출에 누적 prefix 전체를 보고하므로 sum 하지 않고
   마지막 값만 비교 (double count 방지).
-- **loop cap**: 한 job 당 최대 `loopCap (10)` turn. 초과 시 FAILED("loop cap exceeded").
+- **loop cap**: 한 job 당 최대 `loopCap (10)` turn. 초과 시 FAILED + `errorCode: 'LoopCapExceeded'`.

--- a/docs/spec/aiFront.md
+++ b/docs/spec/aiFront.md
@@ -60,20 +60,22 @@
 
 ## Endpoints
 
-| Method | Path | Body / Header | Response |
-|---|---|---|---|
-| POST | `/v1/ai/command` | `{command_text, timezone}` + header `device_id` | `202 {job_id}` |
-| POST | `/v1/ai/command/confirm` | `{command_text, timezone, tool, args, confirm_token}` + header `device_id` | `202 {job_id}` |
-| GET | `/v1/ai/jobs/:id` | — | `200 AiJob.toJSON()` |
-| GET | `/v1/ai/usage` | — | `200 AiUsage.toJSON()` (오늘 사용량) |
+| Method | Path | Body | Headers | Response |
+|---|---|---|---|---|
+| POST | `/v1/ai/command` | `{ command_text, timezone }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
+| POST | `/v1/ai/command/confirm` | `{ command_text, tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
+| GET | `/v1/ai/jobs/:id` | — | `Authorization` | `200 AiJob.toJSON()` |
+| GET | `/v1/ai/usage` | — | `Authorization` | `200 AiUsage.toJSON()` (오늘 사용량) |
 
-모두 Firebase Auth 필수 (`Authorization: Bearer <ID token>`). `timezone` 은 IANA 형식 (`Asia/Seoul` 등).
-누락 / invalid → 400.
+- 모두 Firebase Auth 필수 (`Authorization: Bearer <ID token>`).
+- `timezone` 은 IANA 형식 (`Asia/Seoul` 등). **1차 (command) 는 required, 2차 (confirm) 는 optional** — confirm path 는 systemPrompt 빌드를 안 거쳐 timezone 무관.
+- `Accept-Language` 헤더에서 `ko` / `en` 자동 결정 → `job.lang` 저장. 누락 / unsupported → `en` default. 표준 q-factor / region tag (`ko-KR`) 처리.
+- 누락 / invalid → 400.
 
 ## Firestore Collections
 
 - **`ai_jobs/{jobId}`** — 단일 job. status: `PENDING` → `RUNNING` → `{DONE | CONFIRM | FAILED}`.
-  필드: `userId`, `deviceId`, `commandText`, `timezone`, `mode` (`command|confirm`), `confirmPayload`,
+  필드: `userId`, `deviceId`, `commandText`, `timezone`, `lang` (`ko`|`en`), `mode` (`command`|`confirm`), `confirmPayload`,
   `status`, `result` (`AiJobResult` plain object), `createdAt`, `updatedAt`, `expireAt` (24h).
 - **`aiUsage/{userId}/dailyUsage/{YYYY-MM-DD}`** — UTC 기준 일별 토큰 누적.
   필드: `inputTokens`, `outputTokens`, `lastUpdatedAt`.
@@ -226,6 +228,179 @@ sequenceDiagram
     Usage-->>Ctrl: usage or empty dateKey
     Ctrl-->>App: 200 with dateKey, inputTokens, outputTokens, lastUpdatedAt
 ```
+
+---
+
+---
+
+## 클라 통합 가이드
+
+클라(앱) 가 frontAPI 를 어떻게 호출하고 응답을 어떻게 처리해야 하는지.
+
+### 1차 호출 — 자연어 명령
+
+```http
+POST /v1/ai/command
+Authorization: Bearer <Firebase ID token>
+device_id: <FCM-registered device id>
+Accept-Language: ko-KR,ko;q=0.9,en;q=0.8
+Content-Type: application/json
+
+{
+  "command_text": "내일 오후 3시 회의 잡아줘",
+  "timezone": "Asia/Seoul"
+}
+```
+
+응답:
+```json
+{ "job_id": "8c2f1e9d-..." }
+```
+
+→ 클라는 `job_id` 를 받아 **결과를 비동기로 대기**. 두 채널:
+1. **Firestore listen** — `ai_jobs/{jobId}` doc 의 `status` / `result` 필드 watch (실시간, 추천).
+2. **FCM push** — handler 가 종결 후 발송. payload 의 `data.jobId` 로 doc 다시 fetch.
+3. **Polling fallback** — `GET /v1/ai/jobs/{jobId}` (백그라운드 진입 시).
+
+### Job 상태 흐름
+
+```
+PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
+                                       ├─▶ CONFIRM   (terminal)
+                                       └─▶ FAILED
+```
+
+`status` 가 terminal (`DONE` / `CONFIRM` / `FAILED`) 이면 `result` 필드에 `AiJobResult` 가 박혀 있다.
+
+### `AiJobResult` 응답 형태
+
+세 type 모두 공통: `type`, `mutations` (항상 array, 빈 array 가능), 옵션 `notification`.
+
+**DONE** — 정상 완료:
+```json
+{
+  "type": "DONE",
+  "text": "내일 오후 3시에 회의 일정 등록했어요.",
+  "notification": { "title": "...", "body": "..." },
+  "mutations": [{ "dataType": "schedule", "op": "created" }]
+}
+```
+
+**CONFIRM** — 사용자 확인 필요 (`delete_todo` / `delete_schedule`):
+```json
+{
+  "type": "CONFIRM",
+  "text": "정말 삭제하시겠어요?",
+  "action": {
+    "tool": "delete_schedule",
+    "args": { "schedule_id": "abc" },
+    "confirmToken": "<HMAC token>"
+  },
+  "notification": { "title": "일정 삭제 확인", "body": "..." },
+  "mutations": [...]
+}
+```
+
+**FAILED** — 실패:
+```json
+{
+  "type": "FAILED",
+  "reason": "확인 시간이 만료됐어요. 다시 요청해 주세요.",
+  "errorCode": "ConfirmExpired",
+  "mutations": [...]
+}
+```
+
+### 클라 처리 패턴
+
+| `type` | 클라가 할 일 |
+|---|---|
+| `DONE` | `text` 사용자에게 표시 (toast / chat 등). **`mutations` 보고 영향받은 도메인 list/cache invalidate**. |
+| `CONFIRM` | `text` 로 confirm UI 표시. **사용자가 승인하면 `action` 통째로 2차 호출 body 에 박아 `POST /v1/ai/command/confirm`** 호출. 거부 시 그냥 폐기. 1차 응답에 `mutations` 가 박혀 있을 수 있음 (이전 turn 의 변경) → list reload. |
+| `FAILED` | `reason` 사용자에게 표시. **`errorCode` 보고 분류 / 다른 UX 분기**. `mutations` 도 박혀 있을 수 있음 (부분 mutation) → reload. |
+
+### 2차 호출 — CONFIRM 확인 후
+
+1차 응답의 `action` 을 그대로 박는다. `command_text` 와 `Accept-Language` 는 1차에서 쓴 값 재사용 권장.
+
+```http
+POST /v1/ai/command/confirm
+Authorization: Bearer <Firebase ID token>
+device_id: <device id>
+Accept-Language: ko-KR
+Content-Type: application/json
+
+{
+  "command_text": "회의 삭제해줘",
+  "tool": "delete_schedule",
+  "args": { "schedule_id": "abc" },
+  "confirm_token": "<1차 응답의 action.confirmToken>"
+}
+```
+
+`timezone` 은 박지 않아도 됨 (optional). 응답은 1차와 동일하게 `{ job_id }` — 새 jobId 발급되어 1차 jobId 와 독립. 같은 흐름으로 `ai_jobs/{newJobId}` 결과 대기.
+
+### `mutations` 처리
+
+도메인 별 reload 결정에 사용. `dataType` × `op` 매핑:
+
+| `dataType` | 영향받는 컬렉션 |
+|---|---|
+| `todo` | todos 리스트 |
+| `done` | 완료된 todos (dones) 리스트 |
+| `schedule` | schedules 리스트 |
+| `tag` | event_tags 리스트 |
+| `event_detail` | 해당 event 의 detail 캐시 |
+
+**복합 매핑 주의**: `complete_todo` → `[{todo, updated}, {done, created}]`, `revert_done_todo` → `[{done, deleted}, {todo, created}]`. 두 dataType 동시 영향 — 둘 다 reload.
+
+빈 array 이면 read-only command (e.g., "오늘 할일 보여줘") 또는 finalize 만 호출 — reload 불필요.
+
+### `errorCode` 분류 (`AiErrorCode`)
+
+`FAILED` 응답의 `errorCode` 로 분기. enum 값 (PascalCase) — `models/ai/AiErrorCode.js` 와 일치.
+
+| `errorCode` | 의미 | 권장 UX |
+|---|---|---|
+| `TokenCapExceeded` | 한 요청의 토큰 한도 초과 | "더 짧게 다시 요청해 주세요" 안내 |
+| `LoopCapExceeded` | Agent Loop 단계 한도 초과 | "더 단순한 요청" 안내 |
+| `NoToolUse`, `MultipleToolUses`, `UnknownFinalize` | 내부 처리 오류 | "다시 시도해 주세요" generic |
+| `ConfirmExpired` | confirm token 5분 TTL 만료 | "다시 요청해 주세요" → 1차부터 재시작 |
+| `ConfirmArgsMismatch` | confirm token 의 args 가 변조됨 | "처음부터 다시" 안내 |
+| `UnexpectedConfirmRequired` | 2차에서 다시 confirm 요구 (비정상) | "다시 시도해 주세요" |
+| `AgentLoopThrow`, `AgentError` | 외부 SDK / 알 수 없는 throw | "잠시 후 다시" 안내 |
+
+`reason` 필드는 이미 `Accept-Language` 따라 워싱된 사용자 메시지 — 그대로 표시해도 됨. `errorCode` 는 클라가 다른 UX 분기 (재시도 / 처음부터 / 안내 톤) 결정에 사용.
+
+### FCM payload
+
+```json
+{
+  "notification": { "title": "...", "body": "..." },
+  "data": { "jobId": "...", "status": "DONE" }
+}
+```
+
+- `notification.{title,body}` — 1차 응답의 `result.notification` (있으면) 또는 lang 별 fallback.
+- `data.status` — `DONE` / `CONFIRM` / `FAILED` 중 하나. 클라가 tap 시 → `ai_jobs/{jobId}` doc 으로 결과 fetch.
+- 페이로드에 민감 정보 없음 — text / args / token 등 일체 미포함.
+
+### `GET /v1/ai/usage` — 오늘 사용량 조회
+
+```json
+{
+  "date_key": "2026-05-27",
+  "input_tokens": 12500,
+  "output_tokens": 3200,
+  "last_updated_at": "..."
+}
+```
+
+`date_key` 는 **UTC 기준 YYYY-MM-DD** — 클라 timezone 과 별개 (서버 단일 정책으로 record / 조회 일관성 유지). doc 미존재 시 0/0/null 빈 응답.
+
+### `GET /v1/ai/jobs/:id` — 단건 조회 (폴링 fallback)
+
+본인 job 만 조회 가능 (`job.userId !== req.auth.uid` → 403). 응답은 `AiJob.toJSON()`.
 
 ---
 

--- a/docs/spec/aiFront.md
+++ b/docs/spec/aiFront.md
@@ -63,7 +63,7 @@
 | Method | Path | Body | Headers | Response |
 |---|---|---|---|---|
 | POST | `/v1/ai/command` | `{ command_text, timezone }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
-| POST | `/v1/ai/command/confirm` | `{ command_text, tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
+| POST | `/v1/ai/command/confirm` | `{ tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
 | GET | `/v1/ai/jobs/:id` | — | `Authorization` | `200 AiJob.toJSON()` |
 | GET | `/v1/ai/usage` | — | `Authorization` | `200 AiUsage.toJSON()` (오늘 사용량) |
 
@@ -173,8 +173,8 @@ sequenceDiagram
     participant Lib as todocalendar-tools
     participant OAPI as openAPI
     participant FCM as Messaging
-    App->>Ctrl: POST /v1/ai/command/confirm with command_text, timezone, tool, args, confirm_token
-    Ctrl->>Ctrl: validate tool and args object and confirm_token and timezone
+    App->>Ctrl: POST /v1/ai/command/confirm with tool, args, confirm_token, timezone optional
+    Ctrl->>Ctrl: validate tool and args object and confirm_token
     Ctrl->>JobSvc: createConfirmJob with userId and confirmPayload
     JobSvc->>FS: put jobId, status PENDING, mode confirm
     JobSvc-->>Ctrl: jobId
@@ -319,7 +319,7 @@ PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
 
 ### 2차 호출 — CONFIRM 확인 후
 
-1차 응답의 `action` 을 그대로 박는다. `command_text` 와 `Accept-Language` 는 1차에서 쓴 값 재사용 권장.
+1차 응답의 `action` 을 그대로 박는다. `Accept-Language` 는 1차에서 쓴 값 재사용 권장 (응답 워딩 일관).
 
 ```http
 POST /v1/ai/command/confirm
@@ -329,14 +329,16 @@ Accept-Language: ko-KR
 Content-Type: application/json
 
 {
-  "command_text": "회의 삭제해줘",
   "tool": "delete_schedule",
   "args": { "schedule_id": "abc" },
   "confirm_token": "<1차 응답의 action.confirmToken>"
 }
 ```
 
-`timezone` 은 박지 않아도 됨 (optional). 응답은 1차와 동일하게 `{ job_id }` — 새 jobId 발급되어 1차 jobId 와 독립. 같은 흐름으로 `ai_jobs/{newJobId}` 결과 대기.
+- `command_text` 는 confirm path 에서 안 씀 — body 에서 제외.
+- `timezone` 도 박지 않아도 됨 (optional).
+
+응답은 1차와 동일하게 `{ job_id }` — 새 jobId 발급되어 1차 jobId 와 독립. 같은 흐름으로 `ai_jobs/{newJobId}` 결과 대기.
 
 ### `mutations` 처리
 

--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -64,14 +64,11 @@ class AiController {
             throw new Errors.BadRequest('device_id header is required');
         }
 
-        const rawCommandText = req.body.command_text;
-        if (!rawCommandText || !rawCommandText.trim()) {
-            throw new Errors.BadRequest('command_text is required');
-        }
-        const commandText = rawCommandText.trim();
+        // confirm path body:
+        //  - command_text: 클라가 보내지 않음. lang 은 Accept-Language 로, 그 외 confirm path
+        //    가 commandText 를 쓰지 않으므로 body 에서 제외 (#230 후속 정리).
+        //  - timezone: optional — runConfirm 본체에서 사용 X. 박혀 오면 형식만 검증.
 
-        // confirm path 의 timezone 은 optional — runConfirm 본체에서 사용 X.
-        // 박혀 오면 형식만 검증해 job doc 에 저장.
         const timezone = req.body.timezone;
         if (timezone !== undefined && timezone !== null && !isValidTimezone(timezone)) {
             throw new Errors.BadRequest('timezone is invalid (must be a valid IANA timezone name)');
@@ -97,7 +94,6 @@ class AiController {
         const jobId = await this.jobService.createConfirmJob({
             userId,
             deviceId,
-            commandText,
             timezone: timezone ?? null,
             lang,
             confirmPayload: { tool, args, confirmToken }

--- a/functions/services/ai/jobService.js
+++ b/functions/services/ai/jobService.js
@@ -41,17 +41,19 @@ class JobService {
     /**
      * CONFIRM 2차 호출용 job 발행. 새 jobId 발급 — 1차 jobId 와 독립.
      *
-     * @param {{ userId, deviceId, commandText, timezone, lang, confirmPayload: { tool, args, confirmToken } }} params
+     * commandText 는 confirm path 에서 사용되지 않아 받지 않음 (#230 후속 정리).
+     * lang 결정은 Accept-Language 헤더 → controller. 응답 메시지 워딩에 그것만 사용.
+     *
+     * @param {{ userId, deviceId, timezone, lang, confirmPayload: { tool, args, confirmToken } }} params
      * @returns {Promise<string>} jobId
      */
-    async createConfirmJob({ userId, deviceId, commandText, timezone, lang, confirmPayload }) {
+    async createConfirmJob({ userId, deviceId, timezone, lang, confirmPayload }) {
         const jobId = crypto.randomUUID();
         const expireAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
         const data = {
             userId,
             deviceId,
-            commandText,
             timezone,
             lang: lang ?? 'en',
             mode: AiJob.MODE.CONFIRM,

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -208,7 +208,7 @@ describe('AiController', () => {
 
         function makeConfirmReq({
             uid = 'user-1', deviceId = 'device-1',
-            commandText = '이거 삭제해', timezone = 'Asia/Seoul',
+            timezone = 'Asia/Seoul',
             tool = 'delete_todo', args = { todo_id: 't1' }, confirmToken = 'tk',
             acceptLanguage = null
         } = {}) {
@@ -220,13 +220,13 @@ describe('AiController', () => {
                     return null;
                 },
                 body: {
-                    command_text: commandText, timezone,
+                    timezone,
                     tool, args, confirm_token: confirmToken
                 }
             };
         }
 
-        it('정상 — 202 + job_id, createConfirmJob 인자에 confirmPayload 묶여 전달', async () => {
+        it('정상 — 202 + job_id, createConfirmJob 인자에 confirmPayload 묶여 전달 (commandText 안 받음)', async () => {
             const req = makeConfirmReq();
             const res = makeRes();
 
@@ -237,7 +237,6 @@ describe('AiController', () => {
             assert.deepEqual(stubService.lastCreateConfirmJobArgs, {
                 userId: 'user-1',
                 deviceId: 'device-1',
-                commandText: '이거 삭제해',
                 timezone: 'Asia/Seoul',
                 lang: 'en',
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
@@ -256,10 +255,14 @@ describe('AiController', () => {
             await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
         });
 
-        it('command_text 누락 → 400', async () => {
+        it('command_text 박혀 와도 무시 — confirm body 에서 안 씀, lang 은 Accept-Language 로', async () => {
             const req = makeConfirmReq();
-            req.body.command_text = '';
-            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+            req.body.command_text = '클라가 잘못 박은 값';
+            const res = makeRes();
+            await controller.postCommandConfirm(req, res);
+            assert.equal(res.statusCode, 202);
+            // createConfirmJob 인자에 commandText 키 자체가 없어야 함
+            assert.strictEqual('commandText' in stubService.lastCreateConfirmJobArgs, false);
         });
 
         it('timezone 누락 — optional 이라 정상 통과 (createConfirmJob 에 timezone=null)', async () => {

--- a/functions/test/doubles/stubAiJobService.js
+++ b/functions/test/doubles/stubAiJobService.js
@@ -23,9 +23,9 @@ class StubAiJobService {
         return this._nextJobId;
     }
 
-    async createConfirmJob({ userId, deviceId, commandText, timezone, lang, confirmPayload }) {
+    async createConfirmJob({ userId, deviceId, timezone, lang, confirmPayload }) {
         if (this.shouldFail) throw { message: 'service failed' };
-        this.lastCreateConfirmJobArgs = { userId, deviceId, commandText, timezone, lang, confirmPayload };
+        this.lastCreateConfirmJobArgs = { userId, deviceId, timezone, lang, confirmPayload };
         return this._nextJobId;
     }
 

--- a/functions/test/services/ai/jobService.test.js
+++ b/functions/test/services/ai/jobService.test.js
@@ -99,7 +99,7 @@ describe('JobService', () => {
         it('mode=confirm + confirmPayload 가 plain object 로 박히고 새 jobId 반환', async () => {
             const before = Date.now();
             const jobId = await service.createConfirmJob({
-                userId: 'u', deviceId: 'd', commandText: '삭제',
+                userId: 'u', deviceId: 'd',
                 timezone: 'Asia/Seoul',
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
             });
@@ -113,12 +113,13 @@ describe('JobService', () => {
 
             assert.strictEqual(data.userId, 'u');
             assert.strictEqual(data.deviceId, 'd');
-            assert.strictEqual(data.commandText, '삭제');
             assert.strictEqual(data.timezone, 'Asia/Seoul');
             assert.strictEqual(data.mode, AiJob.MODE.CONFIRM);
             assert.deepStrictEqual(data.confirmPayload, { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' });
             assert.strictEqual(data.status, AiJob.STATUS.PENDING);
             assert.strictEqual(data.result, null);
+            // confirm job 은 commandText 안 받음 (#230 후속 정리)
+            assert.strictEqual('commandText' in data, false);
 
             assert.ok(data.expireAt instanceof Date);
             const expected24hLater = before + 24 * 60 * 60 * 1000;
@@ -128,14 +129,14 @@ describe('JobService', () => {
 
         it('두 번 호출하면 서로 다른 jobId 반환', async () => {
             const payload = { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' };
-            const a = await service.createConfirmJob({ userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'UTC', confirmPayload: payload });
-            const b = await service.createConfirmJob({ userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'UTC', confirmPayload: payload });
+            const a = await service.createConfirmJob({ userId: 'u', deviceId: 'd', timezone: 'UTC', confirmPayload: payload });
+            const b = await service.createConfirmJob({ userId: 'u', deviceId: 'd', timezone: 'UTC', confirmPayload: payload });
             assert.notStrictEqual(a, b);
         });
 
         it('lang 인자 — confirm job 에 그대로 저장', async () => {
             await service.createConfirmJob({
-                userId: 'u', deviceId: 'd', commandText: '삭제', timezone: 'Asia/Seoul', lang: 'ko',
+                userId: 'u', deviceId: 'd', timezone: 'Asia/Seoul', lang: 'ko',
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
             });
             assert.strictEqual(stubRepo.lastPutPayload.data.lang, 'ko');


### PR DESCRIPTION
## 변경

### 1. `docs/spec/aiFront.md` — 클라 통합 가이드 섹션 신설
기존 spec 이 운영/구현 위주라 클라 통합 관점 부족 → 같은 문서 안 큰 섹션으로 응집.
- Endpoints 표 — `Accept-Language` 헤더 노출, confirm path `timezone` optional
- Firestore Collections — `ai_jobs` 의 `lang` 필드
- 1차 호출 request/response 예시, Job 상태 흐름
- `AiJobResult` 응답 형태 (DONE/CONFIRM/FAILED 각 JSON, `mutations` 포함)
- `type` 별 클라 처리 패턴 표
- 2차 confirm 호출 (action 통째 패스스루)
- `mutations` 처리 — dataType 별 영향 컬렉션, 복합 매핑 (`complete_todo` / `revert_done_todo`)
- `errorCode` 분류 표 — `AiErrorCode` 7건의 의미 / 권장 UX
- FCM payload, `GET /usage`, `GET /jobs/:id` 응답 예시

### 2. confirm body 의 `command_text` 제거 (#230 후속)
confirm path 에서 commandText 가 더 이상 쓰이지 않음 (lang 결정은 Accept-Language, runConfirm 본체 미사용).
- `AiController.postCommandConfirm` — command_text 파싱/가드 제거
- `JobService.createConfirmJob` — commandText 인자 제거, doc 에도 안 저장
- `StubAiJobService` 시그니처 동기화
- 테스트: confirm 정상 케이스 expected 에서 commandText 제외, "박혀 와도 무시" 가드 케이스로 갱신, confirm doc 에 commandText 키 없음 검증

### 3. stale 자국 정정
- 중복 `---` 가로선 정리
- CONFIRM 시퀀스의 `runConfirm` 메시지 매개변수 `commandText` → `lang`
- 가드 메모의 워싱 전 영어 reason → `errorCode: 'LoopCapExceeded'`

## Test plan
- [x] `npm test` 1114 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)