### PR TITLE
[#157] 무료 유저 일일 토큰 한도 사전 차단 + GET /usage daily_limit 노출

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,17 @@ routes/ → controllers/ → services/ → repositories/
 - **Services** (`services/`): Business logic. Services receive their dependencies injected; never instantiate repositories themselves.
 - **Repositories** (`repositories/`): Firestore read/write. Return domain model instances (e.g., `Todo.fromData(snapshot.id, snapshot.data())`). Firebase Admin SDK is initialized once in `index.js`.
 
+#### 정책/카테고리 값은 코드 상수 X — 구조화 데이터로 분리
+
+plan·tier·요금·한도·정책 같이 확장될 카테고리 값은 service 안 상수로 박지 말고 **`services/<도메인>/data/<name>.json`** 으로 분리한다. 이유:
+- 카테고리 추가 시 코드 변경 없이 데이터만 갱신 (향후 admin UI / Firestore / Remote Config 이전 trivial).
+- 다른 영역(사용량 조회 API, 결제 페이지, 운영 대시보드 등)에서 같은 정의를 재참조 가능 — 단일 source.
+- service 는 데이터 require 만 하고 그 값에 따른 로직만 가진다.
+
+예: AI plan 별 daily 토큰 한도를 `services/ai/data/aiPlans.json` 으로 두고 `aiUsageService.getDailyLimit(userId)` 가 plan 조회 → 한도 lookup (PR #?, issue #157). 추후 plan 추가는 JSON 갱신만으로.
+
+같은 패턴이 적합한 후보: 결제 tier, 권한 role, feature flag 의 정적 정의, 외부 webhook routing 매핑 등.
+
 ### API Versioning
 
 Routes are registered under `/v1/` and `/v2/` prefixes. A `setVersion` middleware sets `req.apiVersion` so services can branch on version where needed (e.g., tag delete behavior differs between v1 and v2).

--- a/docs/spec/aiFront.md
+++ b/docs/spec/aiFront.md
@@ -65,12 +65,13 @@
 | POST | `/v1/ai/command` | `{ command_text, timezone }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
 | POST | `/v1/ai/command/confirm` | `{ tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
 | GET | `/v1/ai/jobs/:id` | — | `Authorization` | `200 AiJob.toJSON()` |
-| GET | `/v1/ai/usage` | — | `Authorization` | `200 AiUsage.toJSON()` (오늘 사용량) |
+| GET | `/v1/ai/usage` | — | `Authorization` | `200 AiUsage.toJSON() + { daily_limit }` (오늘 사용량 + 일일 한도) |
 
 - 모두 Firebase Auth 필수 (`Authorization: Bearer <ID token>`).
 - `timezone` 은 IANA 형식 (`Asia/Seoul` 등). **1차 (command) 는 required, 2차 (confirm) 는 optional** — confirm path 는 systemPrompt 빌드를 안 거쳐 timezone 무관.
 - `Accept-Language` 헤더에서 `ko` / `en` 자동 결정 → `job.lang` 저장. 누락 / unsupported → `en` default. 표준 q-factor / region tag (`ko-KR`) 처리.
 - 누락 / invalid → 400.
+- `POST /v1/ai/command` 은 일일 토큰 한도 (`daily_limit`) 초과 시 controller 가 agent loop 진입 전 차단 → `202 { job_id }` 그대로 + Firestore 의 해당 job 은 즉시 `FAILED` (`errorCode: DailyLimitExceeded`). `/confirm` 은 한도 적용 X (#157).
 
 ## Firestore Collections
 
@@ -364,6 +365,7 @@ Content-Type: application/json
 |---|---|---|
 | `TokenCapExceeded` | 한 요청의 토큰 한도 초과 | "더 짧게 다시 요청해 주세요" 안내 |
 | `LoopCapExceeded` | Agent Loop 단계 한도 초과 | "더 단순한 요청" 안내 |
+| `DailyLimitExceeded` | 일일 토큰 한도 소진 (#157) — 본 케이스만 controller 가 agent loop 진입 전 차단해 즉시 FAILED | "내일 다시" 안내 + 한도 임박 시 사전 표시 (`GET /usage` 의 `daily_limit` 활용) |
 | `NoToolUse`, `MultipleToolUses`, `UnknownFinalize` | 내부 처리 오류 | "다시 시도해 주세요" generic |
 | `ConfirmExpired` | confirm token 5분 TTL 만료 | "다시 요청해 주세요" → 1차부터 재시작 |
 | `ConfirmArgsMismatch` | confirm token 의 args 가 변조됨 | "처음부터 다시" 안내 |
@@ -389,14 +391,17 @@ Content-Type: application/json
 
 ```json
 {
-  "date_key": "2026-05-27",
-  "input_tokens": 12500,
-  "output_tokens": 3200,
-  "last_updated_at": "..."
+  "date": "2026-05-30",
+  "input_tokens": 1250,
+  "output_tokens": 320,
+  "updated_at": "2026-05-30T10:00:00.000Z",
+  "daily_limit": 5000
 }
 ```
 
-`date_key` 는 **UTC 기준 YYYY-MM-DD** — 클라 timezone 과 별개 (서버 단일 정책으로 record / 조회 일관성 유지). doc 미존재 시 0/0/null 빈 응답.
+- `date` 는 **UTC 기준 YYYY-MM-DD** — 클라 timezone 과 별개 (서버 단일 정책으로 record / 조회 일관성 유지). doc 미존재 시 input/output `0`, `updated_at` `null`.
+- `daily_limit` 는 본 유저의 오늘 일일 토큰 한도 (input + output 합산 기준). #157 MVP 는 무료 단일 `5000`, 추후 #166 에서 plan 별 분기. 클라는 `(input_tokens + output_tokens) / daily_limit` 로 게이지 / 잔여 표시 가능.
+- 한도 소진 후 `POST /v1/ai/command` 호출 시 controller 가 agent loop 진입 전 차단 → 즉시 FAILED job 응답 (errorCode `DailyLimitExceeded`). `POST /v1/ai/command/confirm` 은 한도 적용 X (1차 confirm 흐름 보호 + tool 1회라 토큰 낮음).
 
 ### `GET /v1/ai/jobs/:id` — 단건 조회 (폴링 fallback)
 

--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -102,8 +102,12 @@ class AiController {
     }
 
     async getUsage(req, res) {
-        const usage = await this.aiUsageService.getTodayUsage(req.auth.uid);
-        res.status(200).send(usage.toJSON());
+        const userId = req.auth.uid;
+        const [usage, dailyLimit] = await Promise.all([
+            this.aiUsageService.getTodayUsage(userId),
+            this.aiUsageService.getDailyLimit(userId)
+        ]);
+        res.status(200).send({ ...usage.toJSON(), daily_limit: dailyLimit });
     }
 }
 

--- a/functions/models/ai/AiErrorCode.js
+++ b/functions/models/ai/AiErrorCode.js
@@ -24,6 +24,7 @@ const AiErrorCode = Object.freeze({
     AgentLoopThrow: 'AgentLoopThrow',
     UnknownFinalize: 'UnknownFinalize',
     AgentError: 'AgentError',
+    DailyLimitExceeded: 'DailyLimitExceeded',
 
     // lib `ToolError.code` 그대로 — `todocalendar-tools` 가 throw 시 e.code 값
     ConfirmExpired: 'ConfirmExpired',

--- a/functions/routes/ai/aiRoutes.js
+++ b/functions/routes/ai/aiRoutes.js
@@ -7,9 +7,9 @@ const AiUsageService = require('../../services/ai/aiUsageService');
 const AiController = require('../../controllers/ai/aiController');
 
 const jobRepository = new JobRepository();
-const jobService = new JobService(jobRepository);
 const aiUsageRepository = new AiUsageRepository();
 const aiUsageService = new AiUsageService({ repository: aiUsageRepository });
+const jobService = new JobService(jobRepository, aiUsageService);
 const controller = new AiController(jobService, aiUsageService);
 
 const router = express.Router();

--- a/functions/services/ai/agentLoopService.js
+++ b/functions/services/ai/agentLoopService.js
@@ -89,7 +89,8 @@ const MESSAGES = Object.freeze({
         agentError: '처리 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.',
         confirmExpired: '확인 시간이 만료됐어요. 다시 요청해 주세요.',
         confirmArgsMismatch: '확인 정보가 일치하지 않아요. 처음부터 다시 시도해 주세요.',
-        confirmDone: '요청하신 작업을 완료했어요.'
+        confirmDone: '요청하신 작업을 완료했어요.',
+        dailyLimitExceeded: '오늘 사용 가능한 한도를 모두 사용했어요. 내일 다시 시도해 주세요.'
     }),
     en: Object.freeze({
         internalError: 'Something went wrong. Please try again.',
@@ -99,7 +100,8 @@ const MESSAGES = Object.freeze({
         agentError: 'An error occurred. Please try again later.',
         confirmExpired: 'Confirmation expired. Please request again.',
         confirmArgsMismatch: "Confirmation details don't match. Please start over.",
-        confirmDone: 'Done'
+        confirmDone: 'Done',
+        dailyLimitExceeded: "You've reached today's usage limit. Please try again tomorrow."
     })
 });
 

--- a/functions/services/ai/aiUsageService.js
+++ b/functions/services/ai/aiUsageService.js
@@ -1,6 +1,13 @@
 'use strict';
 
 const AiUsage = require('../../models/ai/AiUsage');
+const aiPlans = require('./data/aiPlans.json');
+
+/**
+ * MVP — 모든 유저가 free plan. 추후 #166 에서 user → plan resolution 흐름 추가하면
+ * 이 상수 대신 user 의 plan id 를 조회한다.
+ */
+const DEFAULT_PLAN_ID = 'free';
 
 /**
  * 일별 토큰 사용량 record / 조회 정책.
@@ -46,6 +53,32 @@ class AiUsageService {
         const dateKey = this._todayUtcKey();
         const usage = await this.repository.load(userId, dateKey);
         return usage ?? AiUsage.empty(dateKey);
+    }
+
+    /**
+     * 본 user 의 오늘 일일 토큰 한도. plan 별 정의는 `data/aiPlans.json` 에서 조회.
+     * MVP 는 모두 free plan — 추후 #166 에서 user → plan resolution 추가.
+     *
+     * @param {string} _userId
+     * @returns {Promise<number>}
+     */
+    async getDailyLimit(_userId) {
+        return aiPlans[DEFAULT_PLAN_ID].dailyLimit;
+    }
+
+    /**
+     * 본 user 가 오늘 일일 한도를 소진했는지 (input+output 합산 ≥ limit).
+     * controller 가 새 명령 진입 시 사전 차단 판단에 사용.
+     *
+     * @param {string} userId
+     * @returns {Promise<boolean>}
+     */
+    async isOverDailyLimit(userId) {
+        const [usage, limit] = await Promise.all([
+            this.getTodayUsage(userId),
+            this.getDailyLimit(userId)
+        ]);
+        return (usage.inputTokens + usage.outputTokens) >= limit;
     }
 }
 

--- a/functions/services/ai/data/aiPlans.json
+++ b/functions/services/ai/data/aiPlans.json
@@ -1,0 +1,6 @@
+{
+  "free": {
+    "id": "free",
+    "dailyLimit": 5000
+  }
+}

--- a/functions/services/ai/jobService.js
+++ b/functions/services/ai/jobService.js
@@ -2,11 +2,25 @@
 
 const crypto = require('crypto');
 const AiJob = require('../../models/ai/AiJob');
+const AiJobResult = require('../../models/ai/AiJobResult');
+const AiErrorCode = require('../../models/ai/AiErrorCode');
+
+// #157 — 일일 한도 초과 시 user-facing reason. AgentLoopService 의
+// MESSAGES.dailyLimitExceeded 와 같은 워딩 (단일 출처가 아니라 양쪽 갱신 시 같이 갱신).
+const DAILY_LIMIT_REASON = Object.freeze({
+    ko: '오늘 사용 가능한 한도를 모두 사용했어요. 내일 다시 시도해 주세요.',
+    en: "You've reached today's usage limit. Please try again tomorrow."
+});
 
 class JobService {
 
-    constructor(jobRepository) {
+    /**
+     * @param {object} jobRepository
+     * @param {object} aiUsageService — 한도 체크 (`isOverDailyLimit`) 의존성.
+     */
+    constructor(jobRepository, aiUsageService) {
         this.jobRepository = jobRepository;
+        this.aiUsageService = aiUsageService;
     }
 
     /**
@@ -14,10 +28,18 @@ class JobService {
      * createdAt / updatedAt 은 jobRepository 가 serverTimestamp 로 채움 — 본 서비스는
      * 시간 필드를 만들지 않음. expireAt 만 24h 후 Date 로 caller 가 결정.
      *
+     * #157 — 진입 직후 일일 한도 초과 여부 확인. 초과 시 agent loop 진입 없이
+     * 즉시 FAILED-born job (private `_createDailyLimitExceededJob`) 으로 종결시키고
+     * 같은 jobId 반환. 호출처 (controller) 는 한도 로직에 무지하게 단일 호출.
+     *
      * @param {{ userId: string, deviceId: string, commandText: string, timezone: string, lang: 'ko'|'en' }} params
      * @returns {Promise<string>} jobId
      */
     async createJob({ userId, deviceId, commandText, timezone, lang }) {
+        if (await this.aiUsageService.isOverDailyLimit(userId)) {
+            return this._createDailyLimitExceededJob({ userId, deviceId, commandText, timezone, lang });
+        }
+
         const jobId = crypto.randomUUID();
         const expireAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
@@ -44,6 +66,8 @@ class JobService {
      * commandText 는 confirm path 에서 사용되지 않아 받지 않음 (#230 후속 정리).
      * lang 결정은 Accept-Language 헤더 → controller. 응답 메시지 워딩에 그것만 사용.
      *
+     * 일일 한도 적용 X (#157) — 1차 confirm 흐름 보호 + tool 1회라 토큰 낮음.
+     *
      * @param {{ userId, deviceId, timezone, lang, confirmPayload: { tool, args, confirmToken } }} params
      * @returns {Promise<string>} jobId
      */
@@ -60,6 +84,46 @@ class JobService {
             confirmPayload,
             status: AiJob.STATUS.PENDING,
             result: null,
+            expireAt
+        };
+
+        await this.jobRepository.put(jobId, data);
+        return jobId;
+    }
+
+    /**
+     * #157 — 일일 토큰 한도 초과로 인한 사전 차단용 atomic FAILED-born job 생성.
+     * createJob 내부 분기에서만 호출 (private).
+     *
+     * createJob → transitionToRunning → completeWith 3-step 은 Firestore onCreate trigger 와
+     * 의 race 에서 trigger 가 transitionToRunning 을 먼저 선점하면 agent loop 진입 →
+     * Anthropic 호출 비용 낭비. status=FAILED 로 born 시키면 trigger 의 transition CAS 가
+     * 즉시 false → silent return → agent loop 진입 차단 보장.
+     *
+     * errorCode 는 본 메서드가 박는 (`AiErrorCode.DailyLimitExceeded`) — 한도초과 용도
+     * 단일 출처. reason 도 lang 따라 본 메서드가 결정.
+     *
+     * @param {{ userId, deviceId, commandText, timezone, lang }} params
+     * @returns {Promise<string>} jobId
+     */
+    async _createDailyLimitExceededJob({ userId, deviceId, commandText, timezone, lang }) {
+        const jobId = crypto.randomUUID();
+        const expireAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+        const langKey = lang ?? 'en';
+        const reason = DAILY_LIMIT_REASON[langKey] ?? DAILY_LIMIT_REASON.en;
+        const result = AiJobResult.failed(reason, undefined, undefined, AiErrorCode.DailyLimitExceeded);
+
+        const data = {
+            userId,
+            deviceId,
+            commandText,
+            timezone,
+            lang: langKey,
+            mode: AiJob.MODE.COMMAND,
+            confirmPayload: null,
+            status: AiJob.STATUS.FAILED,
+            result,
             expireAt
         };
 

--- a/functions/swagger/swagger.yaml
+++ b/functions/swagger/swagger.yaml
@@ -3519,6 +3519,7 @@ components:
         - AgentLoopThrow
         - UnknownFinalize
         - AgentError
+        - DailyLimitExceeded
         - ConfirmExpired
         - ConfirmArgsMismatch
 
@@ -3616,17 +3617,24 @@ components:
 
     AiUsage:
       type: object
-      description: UTC 기준 dateKey 의 일별 토큰 사용량. doc 미존재 시 0/0/null.
+      description: UTC 기준 dateKey 의 일별 토큰 사용량 + 일일 한도. doc 미존재 시 input/output 0, updated_at null.
       properties:
-        date_key:
+        date:
           type: string
           description: UTC 기준 YYYY-MM-DD
-          example: "2026-05-28"
-        input_tokens: { type: integer, example: 12500 }
-        output_tokens: { type: integer, example: 3200 }
-        last_updated_at:
+          example: "2026-05-30"
+        input_tokens: { type: integer, example: 1250 }
+        output_tokens: { type: integer, example: 320 }
+        updated_at:
           type: string
           nullable: true
+        daily_limit:
+          type: integer
+          description: |
+            본 유저의 오늘 일일 토큰 한도 (input + output 합산 기준).
+            #157 MVP 는 무료 단일 5000, 추후 #166 에서 plan 별 분기.
+          example: 5000
+      required: [date, input_tokens, output_tokens, daily_limit]
 
     # ──────────────── OAuth 2.1 AS schemas ────────────────
     OAuthClientRegistrationRequest:

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -357,7 +357,7 @@ describe('AiController', () => {
 
     describe('getUsage', () => {
 
-        it('오늘 사용량 존재 — 200 + AiUsage.toJSON 응답', async () => {
+        it('오늘 사용량 존재 — 200 + AiUsage.toJSON + daily_limit 머지 응답', async () => {
             stubUsageService.seedUsage('user-1', {
                 inputTokens: 1234,
                 outputTokens: 567,
@@ -374,7 +374,8 @@ describe('AiController', () => {
                 date: '2026-05-22',
                 input_tokens: 1234,
                 output_tokens: 567,
-                updated_at: '2026-05-22T10:00:00.000Z'
+                updated_at: '2026-05-22T10:00:00.000Z',
+                daily_limit: 5000
             });
         });
 
@@ -390,6 +391,23 @@ describe('AiController', () => {
             assert.equal(res.body.output_tokens, 0);
             assert.equal(res.body.updated_at, null);
             assert.ok(typeof res.body.date === 'string', 'date 필드는 비어있지 않음');
+        });
+
+        it('응답에 daily_limit 노출', async () => {
+            stubUsageService.setDailyLimit(7777);
+            stubUsageService.seedUsage('user-1', {
+                inputTokens: 100, outputTokens: 50,
+                updatedAt: new Date('2026-05-22T10:00:00.000Z'), dateKey: '2026-05-22'
+            });
+            const req = { auth: { uid: 'user-1' } };
+            const res = makeRes();
+
+            await controller.getUsage(req, res);
+
+            assert.equal(res.statusCode, 200);
+            assert.equal(res.body.daily_limit, 7777);
+            assert.equal(res.body.input_tokens, 100);
+            assert.equal(res.body.output_tokens, 50);
         });
     });
 });

--- a/functions/test/doubles/stubAiUsageService.js
+++ b/functions/test/doubles/stubAiUsageService.js
@@ -13,6 +13,8 @@ class StubAiUsageService {
     constructor() {
         this._usageByUser = new Map();   // userId → AiUsage
         this._defaultDateKey = '2026-05-22';
+        this._dailyLimit = 5000;
+        this._overByUser = new Map();    // userId → boolean override; 미설정 시 false
 
         this.shouldFailGetTodayUsage = false;
         this.shouldFailRecordUsage = false;
@@ -20,6 +22,21 @@ class StubAiUsageService {
         // recorders
         this.allRecordCalls = [];
         this.lastRecordCall = null;
+        this.lastIsOverDailyLimitUserId = null;
+    }
+
+    /**
+     * 테스트 셋업용 — getDailyLimit 반환 값을 조정.
+     */
+    setDailyLimit(limit) {
+        this._dailyLimit = limit;
+    }
+
+    /**
+     * 테스트 셋업용 — isOverDailyLimit 반환 값을 user 별로 override.
+     */
+    setOverDailyLimit(userId, isOver) {
+        this._overByUser.set(userId, isOver);
     }
 
     /**
@@ -48,6 +65,15 @@ class StubAiUsageService {
             throw { message: 'stub getTodayUsage failed' };
         }
         return this._usageByUser.get(userId) ?? AiUsage.empty(this._defaultDateKey);
+    }
+
+    async getDailyLimit(_userId) {
+        return this._dailyLimit;
+    }
+
+    async isOverDailyLimit(userId) {
+        this.lastIsOverDailyLimitUserId = userId;
+        return this._overByUser.get(userId) ?? false;
     }
 }
 

--- a/functions/test/services/ai/aiUsageService.test.js
+++ b/functions/test/services/ai/aiUsageService.test.js
@@ -119,4 +119,47 @@ describe('AiUsageService', () => {
             assert.strictEqual(usage.updatedAt, null);
         });
     });
+
+    // ------------------------------------------------------------------ //
+    // getDailyLimit / isOverDailyLimit  (#157)
+    // ------------------------------------------------------------------ //
+
+    describe('getDailyLimit', () => {
+
+        it('무료 유저 단일 상수 반환', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+            const limit = await service.getDailyLimit('user-1');
+            assert.strictEqual(limit, 5000);
+        });
+    });
+
+    describe('isOverDailyLimit', () => {
+
+        it('사용량 없음 → false', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+            const over = await service.isOverDailyLimit('user-no-history');
+            assert.strictEqual(over, false);
+        });
+
+        it('input+output 합산이 한도 미만 → false', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+            await service.recordUsage('user-1', { inputTokens: 2000, outputTokens: 2999 });
+            const over = await service.isOverDailyLimit('user-1');
+            assert.strictEqual(over, false);
+        });
+
+        it('input+output 합산이 한도와 정확히 일치 → true (한도 소진 = 다음 호출 불가)', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+            await service.recordUsage('user-1', { inputTokens: 2500, outputTokens: 2500 });
+            const over = await service.isOverDailyLimit('user-1');
+            assert.strictEqual(over, true);
+        });
+
+        it('input+output 합산이 한도 초과 → true', async () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+            await service.recordUsage('user-1', { inputTokens: 5000, outputTokens: 1 });
+            const over = await service.isOverDailyLimit('user-1');
+            assert.strictEqual(over, true);
+        });
+    });
 });

--- a/functions/test/services/ai/jobService.test.js
+++ b/functions/test/services/ai/jobService.test.js
@@ -4,6 +4,7 @@
 const assert = require('assert');
 const JobService = require('../../../services/ai/jobService');
 const StubAiJobRepository = require('../../doubles/stubAiJobRepository');
+const StubAiUsageService = require('../../doubles/stubAiUsageService');
 const AiJob = require('../../../models/ai/AiJob');
 const AiJobResult = require('../../../models/ai/AiJobResult');
 
@@ -11,10 +12,12 @@ describe('JobService', () => {
 
     let service;
     let stubRepo;
+    let stubUsageService;
 
     beforeEach(() => {
         stubRepo = new StubAiJobRepository();
-        service = new JobService(stubRepo);
+        stubUsageService = new StubAiUsageService();
+        service = new JobService(stubRepo, stubUsageService);
     });
 
     // ------------------------------------------------------------------ //
@@ -140,6 +143,81 @@ describe('JobService', () => {
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
             });
             assert.strictEqual(stubRepo.lastPutPayload.data.lang, 'ko');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // createJob 의 일일 한도 사전 차단 분기  (#157)
+    // ------------------------------------------------------------------ //
+
+    describe('createJob — 일일 한도 사전 차단', () => {
+
+        it('한도 미달 — 기존 PENDING 흐름 (status=PENDING / result=null)', async () => {
+            // stubUsageService 기본값 = isOverDailyLimit false
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'Asia/Seoul', lang: 'ko'
+            });
+            assert.ok(typeof jobId === 'string');
+            const { data } = stubRepo.lastPutPayload;
+            assert.strictEqual(data.status, AiJob.STATUS.PENDING);
+            assert.strictEqual(data.result, null);
+        });
+
+        it('한도 초과 — status=FAILED / errorCode=DailyLimitExceeded 가 박혀 jobId 반환 (PENDING 거치지 않음)', async () => {
+            stubUsageService.setOverDailyLimit('u', true);
+
+            const before = Date.now();
+            const jobId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'Asia/Seoul', lang: 'ko'
+            });
+            const after = Date.now();
+
+            assert.ok(typeof jobId === 'string' && jobId.length > 0);
+
+            const { jobId: storedJobId, data } = stubRepo.lastPutPayload;
+            assert.strictEqual(storedJobId, jobId);
+            assert.strictEqual(Object.getPrototypeOf(data), Object.prototype);
+
+            assert.strictEqual(data.userId, 'u');
+            assert.strictEqual(data.deviceId, 'd');
+            assert.strictEqual(data.commandText, 'cmd');
+            assert.strictEqual(data.timezone, 'Asia/Seoul');
+            assert.strictEqual(data.lang, 'ko');
+            assert.strictEqual(data.mode, AiJob.MODE.COMMAND);
+            assert.strictEqual(data.confirmPayload, null);
+            assert.strictEqual(data.status, AiJob.STATUS.FAILED);
+
+            assert.strictEqual(data.result.type, 'FAILED');
+            assert.strictEqual(data.result.errorCode, 'DailyLimitExceeded');
+            assert.ok(typeof data.result.reason === 'string' && data.result.reason.length > 0);
+            // 한국어 워딩 (존댓말) 검증
+            assert.ok(data.result.reason.includes('한도'), `ko reason 에 '한도' 포함 (got: ${data.result.reason})`);
+
+            assert.ok(data.expireAt instanceof Date);
+            const expected24hLater = before + 24 * 60 * 60 * 1000;
+            const drift = data.expireAt.getTime() - expected24hLater;
+            assert.ok(drift >= 0 && drift <= (after - before) + 1000);
+        });
+
+        it('한도 초과 + lang 누락 → en reason', async () => {
+            stubUsageService.setOverDailyLimit('u', true);
+            await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: 'cmd', timezone: 'Asia/Seoul'
+            });
+            const { data } = stubRepo.lastPutPayload;
+            assert.strictEqual(data.lang, 'en');
+            assert.ok(data.result.reason.toLowerCase().includes('limit'), `en reason 에 'limit' 포함 (got: ${data.result.reason})`);
+        });
+
+        it('createConfirmJob 은 한도 적용 X — 한도 초과여도 PENDING / status=PENDING 그대로', async () => {
+            stubUsageService.setOverDailyLimit('u', true);
+            await service.createConfirmJob({
+                userId: 'u', deviceId: 'd', timezone: 'Asia/Seoul', lang: 'ko',
+                confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
+            });
+            const { data } = stubRepo.lastPutPayload;
+            assert.strictEqual(data.status, AiJob.STATUS.PENDING);
+            assert.strictEqual(data.result, null);
         });
     });
 

--- a/functions/test/triggers/ai/agentLoopTrigger.test.js
+++ b/functions/test/triggers/ai/agentLoopTrigger.test.js
@@ -140,7 +140,7 @@ describe('AgentLoopHandler', () => {
 
     it('정상 발화 — result.notification 없을 때 fallback DONE 카피로 FCM 발송', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.done('stub done')); // no notification
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -166,7 +166,7 @@ describe('AgentLoopHandler', () => {
 
     it('정상 발화 — result.notification 있으면 그 값으로 FCM 발송', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const customNotification = { title: '커스텀 제목', body: '커스텀 본문' };
         const agentLoopService = makeAgentLoopService(AiJobResult.done('stub done', customNotification));
         const messaging = makeMessaging();
@@ -184,7 +184,7 @@ describe('AgentLoopHandler', () => {
 
     it('같은 job 두 번째 발화 — transition CAS 실패로 agentLoop / FCM 모두 skip', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         let runCalled = 0;
         const agentLoopService = {
             async run() { runCalled += 1; return { result: AiJobResult.done('x'), usage: { inputTokens: 0, outputTokens: 0 } }; }
@@ -203,7 +203,7 @@ describe('AgentLoopHandler', () => {
 
     it('device 미존재 — completeWith 까지는 호출, FCM skip + warn 로그', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService();
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(null); // device 없음
@@ -220,7 +220,7 @@ describe('AgentLoopHandler', () => {
 
     it('device.userId 가 job.userId 와 다르면 (기기 재할당) FCM skip + warn 로그', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService();
         const messaging = makeMessaging();
         const mismatchDevice = { ...BASE_DEVICE, userId: 'other-user' };
@@ -238,7 +238,7 @@ describe('AgentLoopHandler', () => {
 
     it('result.type 이 CONFIRM 일 때 FCM 에 fallback CONFIRM 카피 사용', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.confirm('stub confirm', { stub: true })); // no notification
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -254,7 +254,7 @@ describe('AgentLoopHandler', () => {
 
     it('result.type 이 FAILED 일 때 FCM 에 fallback FAILED 카피 사용', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.failed('stub failed')); // no notification
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -270,7 +270,7 @@ describe('AgentLoopHandler', () => {
 
     it('result.notification 의 title 이 빈 문자열이면 hasNotification false → fallback 사용', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const partialNotification = { title: '', body: '본문은 있음' };
         const agentLoopService = makeAgentLoopService(AiJobResult.done('stub done', partialNotification));
         const messaging = makeMessaging();
@@ -286,7 +286,7 @@ describe('AgentLoopHandler', () => {
 
     it('FCM 발송 중 네트워크 오류로 throw 가 발생해도 핸들러는 정상 종료', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService();
         const failMessaging = {
             async send() { throw new Error('FCM network error'); }
@@ -302,7 +302,7 @@ describe('AgentLoopHandler', () => {
 
     it('agentLoopService.run 이 throw 하면 RUNNING 고착 대신 FAILED 로 종결 + FCM 발송', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const throwingLoop = {
             async run(_commandText, _opts) { throw new Error('claude api timeout'); }
         };
@@ -327,7 +327,7 @@ describe('AgentLoopHandler', () => {
 
     it('DONE result.notification 이 없고 commandText 가 영어이면 영어 fallback 적용', async () => {
         const repo = seededRepo('job-1', EN_JOB_DATA);
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.done('stub done')); // no notification
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -344,7 +344,7 @@ describe('AgentLoopHandler', () => {
 
     it('CONFIRM result.notification 이 없고 commandText 가 영어이면 영어 fallback 적용', async () => {
         const repo = seededRepo('job-1', EN_JOB_DATA);
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.confirm('stub confirm', { stub: true }));
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -361,7 +361,7 @@ describe('AgentLoopHandler', () => {
 
     it('FAILED result.notification 이 없고 commandText 가 영어이면 영어 fallback 적용', async () => {
         const repo = seededRepo('job-1', EN_JOB_DATA);
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.failed('stub failed'));
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -399,7 +399,7 @@ describe('AgentLoopHandler', () => {
 
     it('DONE 결과로 종결되면 aiUsageService.recordUsage 가 job.userId 와 usage 토큰으로 호출됨', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(
             AiJobResult.done('stub done'),
             { inputTokens: 1200, outputTokens: 340 }
@@ -421,7 +421,7 @@ describe('AgentLoopHandler', () => {
 
     it('CONFIRM 결과로 종결되어도 동일하게 usage record 호출', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(
             AiJobResult.confirm('stub confirm', { stub: true }),
             { inputTokens: 500, outputTokens: 60 }
@@ -442,7 +442,7 @@ describe('AgentLoopHandler', () => {
 
     it('FAILED 결과 (finalize 또는 cap 초과) 종결 시에도 usage record 호출', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(
             AiJobResult.failed('stub failed'),
             { inputTokens: 800, outputTokens: 200 }
@@ -463,7 +463,7 @@ describe('AgentLoopHandler', () => {
 
     it('agentLoopService.run 이 throw 한 경로에서는 usage record 호출되지 않음 (partial usage 손실)', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const throwingLoop = {
             async run(_commandText, _opts) { throw new Error('claude api timeout'); }
         };
@@ -480,7 +480,7 @@ describe('AgentLoopHandler', () => {
 
     it('aiUsageService.recordUsage 가 throw 해도 후속 FCM 발송은 정상 진행', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(
             AiJobResult.done('stub done'),
             { inputTokens: 100, outputTokens: 30 }
@@ -507,7 +507,7 @@ describe('AgentLoopHandler', () => {
             confirmPayload
         };
         const repo = seededRepo('job-cf', confirmJobData);
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.done('done'));
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -527,7 +527,7 @@ describe('AgentLoopHandler', () => {
 
     it('mode=command (default) job → run 호출, runConfirm 호출 X — 기존 흐름 회귀 가드', async () => {
         const repo = seededRepo();
-        const jobService = new JobService(repo);
+        const jobService = new JobService(repo, makeAiUsageService());
         const agentLoopService = makeAgentLoopService(AiJobResult.done('done'));
         const messaging = makeMessaging();
         const userRepo = makeUserRepository(BASE_DEVICE);
@@ -570,7 +570,7 @@ describe('AgentLoopHandler', () => {
 
         it('agentLoop throw 경로 — err 의 stack / headers / response / request 제외, code/status/message 만 로깅', async () => {
             const repo = seededRepo();
-            const jobService = new JobService(repo);
+            const jobService = new JobService(repo, makeAiUsageService());
             const fatErr = makeFatErr();
             const throwingLoop = { async run() { throw fatErr; } };
             const messaging = makeMessaging();
@@ -587,7 +587,7 @@ describe('AgentLoopHandler', () => {
 
         it('aiUsage record throw 경로 — 동일 sanitize 적용', async () => {
             const repo = seededRepo();
-            const jobService = new JobService(repo);
+            const jobService = new JobService(repo, makeAiUsageService());
             const agentLoopService = makeAgentLoopService(
                 AiJobResult.done('stub done'),
                 { inputTokens: 100, outputTokens: 30 }
@@ -609,7 +609,7 @@ describe('AgentLoopHandler', () => {
 
         it('FCM send throw 경로 — 동일 sanitize 적용', async () => {
             const repo = seededRepo();
-            const jobService = new JobService(repo);
+            const jobService = new JobService(repo, makeAiUsageService());
             const agentLoopService = makeAgentLoopService();
             const fatErr = makeFatErr();
             const failMessaging = { async send() { throw fatErr; } };
@@ -626,7 +626,7 @@ describe('AgentLoopHandler', () => {
 
         it('매우 긴 message 는 길이 캡 적용 후 로깅', async () => {
             const repo = seededRepo();
-            const jobService = new JobService(repo);
+            const jobService = new JobService(repo, makeAiUsageService());
             const hugeMsg = 'X'.repeat(2000);
             const hugeErr = Object.assign(new Error(hugeMsg), { code: 'huge', status: 500 });
             const throwingLoop = { async run() { throw hugeErr; } };
@@ -644,7 +644,7 @@ describe('AgentLoopHandler', () => {
 
         it('non-Error 입력 (string throw) 도 안전 fallback', async () => {
             const repo = seededRepo();
-            const jobService = new JobService(repo);
+            const jobService = new JobService(repo, makeAiUsageService());
             const throwingLoop = { async run() { throw 'plain string error'; } };
             const messaging = makeMessaging();
             const userRepo = makeUserRepository(BASE_DEVICE);

--- a/functions/triggers/ai/agentLoopTrigger.js
+++ b/functions/triggers/ai/agentLoopTrigger.js
@@ -45,10 +45,15 @@ const agentLoopService = new AgentLoopService({
     scopes: ['read:calendar', 'write:calendar']
 });
 
+// aiUsageService 인스턴스 단일화 — JobService.createJob 의 한도 체크 의존성 (#157) 과
+// AgentLoopHandler 의 usage record 의존성을 같은 instance 로 공유해 composition root
+// 정합성 유지.
+const aiUsageService = new AiUsageService({ repository: new AiUsageRepository() });
+
 const handler = new AgentLoopHandler({
-    jobService: new JobService(new JobRepository()),
+    jobService: new JobService(new JobRepository(), aiUsageService),
     agentLoopService,
-    aiUsageService: new AiUsageService({ repository: new AiUsageRepository() }),
+    aiUsageService,
     userRepository: new UserRepository(),
     messaging: getMessaging()
     // logger 생략 → AgentLoopHandler 내부에서 firebase-functions/logger 사용


### PR DESCRIPTION
Closes #157.

## Summary

- `POST /v1/ai/command` 가 사용자의 오늘 토큰 사용량 (input+output 합산) 이 한도 (MVP free=5000) 를 넘은 경우 agent loop 진입 없이 즉시 FAILED job 으로 종결. Anthropic 호출 / trigger 가 도는 비용을 입구에서 차단.
- 분기 책임은 `JobService.createJob` 안에 응집 — controller 는 한도 로직에 무지하게 단순 createJob 호출. 다른 진입점(trigger / cron / CLI)이 같은 service 를 부르면 일관 적용.
- `GET /v1/ai/usage` 응답에 `daily_limit` 노출 — 클라가 % / 잔여 표시 / 한도 임박 사전 안내 가능.
- plan 별 한도값은 코드 상수가 아닌 `services/ai/data/aiPlans.json` 으로 분리. 추후 #166 plan (`general` / `lifetime` 등) 확장 시 데이터만 갱신.

## 변경 단위

1. **AiUsageService daily limit 조회 helper + aiPlans 데이터 분리** (`00e6927`) — `getDailyLimit` / `isOverDailyLimit`, `AiErrorCode.DailyLimitExceeded`, `MESSAGES.dailyLimitExceeded` (ko/en), `CLAUDE.md` Layer Structure 에 "정책/카테고리 값은 구조화 데이터로" 패턴 가이드.
2. **POST /v1/ai/command 사전 차단 + GET /v1/ai/usage daily_limit 노출** (`0a63f4f`) — `JobService.createJob` 안에 한도 분기 + private `_createDailyLimitExceededJob` (status=FAILED 박은 doc atomic put 으로 trigger race 회피), `AiController.getUsage` daily_limit 머지, swagger `AiUsage` schema 정정 (stale 필드명 + daily_limit) + `AiErrorCode` enum, `docs/spec/aiFront` 한도 정책 반영.

## 책임 응집 메모

- 한도 체크는 진입점(controller) 이 아닌 `JobService.createJob` 진입에 둠. 인프라(HTTP)와 도메인 로직 결합 회피 + 다른 진입점에서 중복 방지.
- `_createDailyLimitExceededJob` 는 private — `createJob` 한도 분기에서만 호출. errorCode / reason 워딩 단일 출처 보장 (caller 가 잘못된 errorCode 넘길 여지 X).
- confirm path (`POST /v1/ai/command/confirm`) 는 한도 적용 X. 1차 confirm 흐름 보호 + tool 1회라 토큰 낮음.

## 검증

- 단위 테스트 1124 passing.
- swagger.yaml js-yaml 파싱 OK.

## Test plan

- [ ] emulator: free 유저 한도 미달 → POST /v1/ai/command 정상 PENDING + agent loop 동작.
- [ ] emulator: `aiUsage/{uid}/dailyUsage/{today}` 를 한도 초과 값으로 시드 후 POST /v1/ai/command → 응답 202 + jobId, 해당 doc 즉시 FAILED + `errorCode='DailyLimitExceeded'` + lang 별 reason.
- [ ] emulator: 위 상황에서 trigger 로그 — transitionToRunning false 받고 agent loop 미진입 (Anthropic 호출 X).
- [ ] emulator: 한도 초과 상태에서 POST /v1/ai/command/confirm → 정상 PENDING 통과.
- [ ] emulator: GET /v1/ai/usage 응답에 `daily_limit: 5000` 노출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)