### PR TITLE
[#233] openAPI foremost event 엔드포인트 추가 (/v2/open/foremost)

### DIFF
--- a/docs/spec/openapi.md
+++ b/docs/spec/openapi.md
@@ -108,7 +108,7 @@ router.post('/', WRITE, ...);
 
 ## Endpoint 목록
 
-base prefix `/v2/open` 아래 다섯 그룹. 마운트 순서상 `dones` 가 `todos` 보다 먼저
+base prefix `/v2/open` 아래 여섯 그룹. 마운트 순서상 `dones` 가 `todos` 보다 먼저
 등록되어, `/todos/dones/...` 가 `/todos/` prefix 매칭에 흡수되지 않도록 한다.
 
 ### `todos`
@@ -169,9 +169,23 @@ base prefix `/v2/open` 아래 다섯 그룹. 마운트 순서상 `dones` 가 `to
 | PUT | `/v2/open/event_details/done/:id` | write |
 | DELETE | `/v2/open/event_details/done/:id` | write |
 
+### `foremost`
+
+serviceAPI `/v1/foremost/event` 와 동등. 사용자당 단일 foremost event (todo 또는 schedule) 지정/조회/해제.
+
+| Method | Path | Scope |
+|---|---|---|
+| GET | `/v2/open/foremost/event` | read |
+| PUT | `/v2/open/foremost/event` | write |
+| DELETE | `/v2/open/foremost/event` | write |
+
+- `GET` — 현재 foremost event. 미지정 시 빈 객체 `{}`.
+- `PUT` — body `{ event_id, is_todo }` 로 지정/교체. `is_todo` 는 boolean (serviceAPI 의 string 관용 파싱 없음). 누락 시 400. 응답 201 + `ForemostEvent`.
+- `DELETE` — 해제. 응답 200 + `{ status: 'ok' }`.
+
 각 endpoint 의 요청 body / 응답 모델은 swagger 정의 (`functions/swagger.yaml`) 와 도메인 모델
-(`models/Todo`, `models/Schedule`, `models/EventTag`, `models/DoneTodo`, `models/EventDetail`) 을
-재사용한다. 인증/스코프 외 라우팅·검증·응답 형식은 도메인 layer 와 동일.
+(`models/Todo`, `models/Schedule`, `models/EventTag`, `models/DoneTodo`, `models/EventDetail`,
+`models/ForemostEvent`) 을 재사용한다. 인증/스코프 외 라우팅·검증·응답 형식은 도메인 layer 와 동일.
 
 ## 에러 응답 형식
 

--- a/functions/controllers/openapi/foremostOpenController.js
+++ b/functions/controllers/openapi/foremostOpenController.js
@@ -1,0 +1,51 @@
+
+const Errors = require('../../models/Errors');
+
+class ForemostOpenController {
+
+    constructor(foremostEventService) {
+        this.foremostEventService = foremostEventService;
+    }
+
+    async getForemostEvent(req, res) {
+        const userId = req.openUserId;
+        if (!userId) {
+            throw new Errors.BadRequest('user id is missing.');
+        }
+        try {
+            const event = await this.foremostEventService.getForemostEvent(userId);
+            res.status(200).send(event);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async updateForemostEvent(req, res) {
+        const userId = req.openUserId;
+        const { event_id, is_todo } = req.body ?? {};
+        if (!userId || !event_id || is_todo == null) {
+            throw new Errors.BadRequest('user id, event_id or is_todo is missing.');
+        }
+        try {
+            const event = await this.foremostEventService.updateForemostEvent(userId, { event_id, is_todo });
+            res.status(201).send(event);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async removeForemostEvent(req, res) {
+        const userId = req.openUserId;
+        if (!userId) {
+            throw new Errors.BadRequest('user id is missing.');
+        }
+        try {
+            await this.foremostEventService.removeForemostEvent(userId);
+            res.status(200).send({ status: 'ok' });
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+}
+
+module.exports = ForemostOpenController;

--- a/functions/index.js
+++ b/functions/index.js
@@ -43,6 +43,7 @@ const doneTodoOpenRouter = require('./routes/openapi/doneTodoOpenRoutes');
 const scheduleOpenRouter = require('./routes/openapi/scheduleOpenRoutes');
 const tagOpenRouter = require('./routes/openapi/tagOpenRoutes');
 const eventDetailOpenRouter = require('./routes/openapi/eventDetailOpenRoutes');
+const foremostOpenRouter = require('./routes/openapi/foremostOpenRoutes');
 const patAuth = require('./middlewares/openapi/patAuth');
 const signedUserAuth = require('./middlewares/openapi/signedUserAuth');
 
@@ -117,6 +118,7 @@ app.use('/v2/open/todos', openApiAuth, todoOpenRouter);
 app.use('/v2/open/schedules', openApiAuth, scheduleOpenRouter);
 app.use('/v2/open/tags', openApiAuth, tagOpenRouter);
 app.use('/v2/open/event_details', openApiAuth, eventDetailOpenRouter);
+app.use('/v2/open/foremost', openApiAuth, foremostOpenRouter);
 
 // OAuth 2.1 Authorization Server (#189) — RFC 8414 metadata + JWKS + endpoints
 // register/token 가 먼저 mount (path 우선순위). authorize/consent 는 /v1/oauth 아래 묶음.

--- a/functions/routes/openapi/foremostOpenRoutes.js
+++ b/functions/routes/openapi/foremostOpenRoutes.js
@@ -1,0 +1,35 @@
+
+const express = require('express');
+const router = express.Router();
+
+const ForemostOpenController = require('../../controllers/openapi/foremostOpenController');
+const ForemostEventService = require('../../services/foremostEventService');
+const ForemostEventIdRepository = require('../../repositories/foremostEventIdRepository');
+const TodoRepository = require('../../repositories/todoRepository');
+const ScheduleRepository = require('../../repositories/scheduleEventRepository');
+const requireScope = require('../../middlewares/openapi/requireScope');
+
+const controller = new ForemostOpenController(
+    new ForemostEventService(
+        new ForemostEventIdRepository(),
+        new TodoRepository(),
+        new ScheduleRepository()
+    )
+);
+
+const READ = requireScope(['read:calendar']);
+const WRITE = requireScope(['write:calendar']);
+
+router.get('/event', READ, async (req, res) => {
+    await controller.getForemostEvent(req, res);
+});
+
+router.put('/event', WRITE, async (req, res) => {
+    await controller.updateForemostEvent(req, res);
+});
+
+router.delete('/event', WRITE, async (req, res) => {
+    await controller.removeForemostEvent(req, res);
+});
+
+module.exports = router;

--- a/functions/swagger/swagger.yaml
+++ b/functions/swagger/swagger.yaml
@@ -51,6 +51,8 @@ tags:
     description: "openAPI done todos for external callers. Auth: PAT + signed user JWT + scope."
   - name: OpenAPI EventDetails
     description: "openAPI event details for external callers. Auth: PAT + signed user JWT + scope."
+  - name: OpenAPI Foremost
+    description: "openAPI foremost event for external callers. Auth: PAT + signed user JWT + scope."
 
 security:
   - BearerAuth: []
@@ -2213,6 +2215,68 @@ paths:
               schema:
                 $ref: '#/components/schemas/StatusOk'
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  # ──────────────── OpenAPI Foremost (/v2/open/foremost) ────────────────
+  /v2/open/foremost/event:
+    get:
+      tags: [OpenAPI Foremost]
+      summary: "[openAPI] Get foremost event"
+      description: "현재 foremost event. 미지정 시 빈 객체 {}."
+      security:
+        - OpenApiPat: []
+          OpenApiUserToken: []
+      responses:
+        '200':
+          description: Foremost event (또는 미지정 시 빈 객체)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForemostEvent'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    put:
+      tags: [OpenAPI Foremost]
+      summary: "[openAPI] Set foremost event"
+      security:
+        - OpenApiPat: []
+          OpenApiUserToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [event_id, is_todo]
+              properties:
+                event_id:
+                  type: string
+                is_todo:
+                  type: boolean
+      responses:
+        '201':
+          description: Foremost event set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForemostEvent'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    delete:
+      tags: [OpenAPI Foremost]
+      summary: "[openAPI] Remove foremost event"
+      security:
+        - OpenApiPat: []
+          OpenApiUserToken: []
+      responses:
+        '200':
+          description: Foremost event removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOk'
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
 

--- a/functions/test/controllers/openapi/foremostOpenController.test.js
+++ b/functions/test/controllers/openapi/foremostOpenController.test.js
@@ -1,0 +1,120 @@
+
+const assert = require('assert');
+const ForemostOpenController = require('../../../controllers/openapi/foremostOpenController');
+const Errors = require('../../../models/Errors');
+const StubServices = require('../../doubles/stubServices');
+const makeRes = StubServices.makeRes;
+
+
+describe('ForemostOpenController', () => {
+
+    let stubService;
+    let controller;
+
+    beforeEach(() => {
+        stubService = new StubServices.ForemostEvent();
+        controller = new ForemostOpenController(stubService);
+    });
+
+
+    describe('getForemostEvent', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null };
+            const res = makeRes();
+            await assert.rejects(controller.getForemostEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200', async () => {
+            const req = { openUserId: 'uid' };
+            const res = makeRes();
+            await controller.getForemostEvent(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, { event_id: 'evt1', is_todo: false, event: { uuid: 'evt1' } });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid' };
+            const res = makeRes();
+            await assert.rejects(controller.getForemostEvent(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('updateForemostEvent', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null, body: { event_id: 'evt1', is_todo: true } };
+            const res = makeRes();
+            await assert.rejects(controller.updateForemostEvent(req, res), Errors.BadRequest);
+        });
+
+        it('event_id가 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', body: { is_todo: true } };
+            const res = makeRes();
+            await assert.rejects(controller.updateForemostEvent(req, res), Errors.BadRequest);
+        });
+
+        it('is_todo가 null이면 BadRequest', async () => {
+            const req = { openUserId: 'uid', body: { event_id: 'evt1', is_todo: null } };
+            const res = makeRes();
+            await assert.rejects(controller.updateForemostEvent(req, res), Errors.BadRequest);
+        });
+
+        it('is_todo가 없으면 BadRequest', async () => {
+            const req = { openUserId: 'uid', body: { event_id: 'evt1' } };
+            const res = makeRes();
+            await assert.rejects(controller.updateForemostEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 201, is_todo boolean 그대로 service 전달', async () => {
+            const req = { openUserId: 'uid', body: { event_id: 'evt1', is_todo: false } };
+            const res = makeRes();
+            await controller.updateForemostEvent(req, res);
+            assert.equal(res.statusCode, 201);
+            assert.deepEqual(res.body, { event_id: 'evt1', is_todo: false, event: { uuid: 'evt1' } });
+            assert.deepEqual(stubService.lastUpdatePayload, { event_id: 'evt1', is_todo: false });
+        });
+
+        it('is_todo=true 도 boolean 그대로 전달', async () => {
+            const req = { openUserId: 'uid', body: { event_id: 'evt1', is_todo: true } };
+            const res = makeRes();
+            await controller.updateForemostEvent(req, res);
+            assert.equal(res.statusCode, 201);
+            assert.deepEqual(stubService.lastUpdatePayload, { event_id: 'evt1', is_todo: true });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid', body: { event_id: 'evt1', is_todo: true } };
+            const res = makeRes();
+            await assert.rejects(controller.updateForemostEvent(req, res), Errors.Application);
+        });
+    });
+
+
+    describe('removeForemostEvent', () => {
+
+        it('userId 없으면 BadRequest', async () => {
+            const req = { openUserId: null };
+            const res = makeRes();
+            await assert.rejects(controller.removeForemostEvent(req, res), Errors.BadRequest);
+        });
+
+        it('정상 → 200 {status:ok}', async () => {
+            const req = { openUserId: 'uid' };
+            const res = makeRes();
+            await controller.removeForemostEvent(req, res);
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(res.body, { status: 'ok' });
+        });
+
+        it('service 실패 → Application', async () => {
+            stubService.shouldFail = true;
+            const req = { openUserId: 'uid' };
+            const res = makeRes();
+            await assert.rejects(controller.removeForemostEvent(req, res), Errors.Application);
+        });
+    });
+});

--- a/functions/test/doubles/stubServices.js
+++ b/functions/test/doubles/stubServices.js
@@ -351,6 +351,7 @@ class StubForemostEventService {
     constructor() {
         this.shouldFail = false;
         this.foremostResult = { event_id: 'evt1', is_todo: false, event: { uuid: 'evt1' } };
+        this.lastUpdatePayload = null;
     }
 
     async getForemostEvent(userId) {
@@ -359,6 +360,7 @@ class StubForemostEventService {
     }
 
     async updateForemostEvent(userId, payload) {
+        this.lastUpdatePayload = payload;
         if (this.shouldFail) throw { message: 'service failed' };
         return this.foremostResult;
     }

--- a/functions/test/e2e/openapi/foremost.e2e.js
+++ b/functions/test/e2e/openapi/foremost.e2e.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const { TEST_USER_UID } = require('../seeds/commonData');
+const { signUserToken, openClient, defaultMcpPat } = require('../helpers/openClient');
+
+// foremost 사이클: todo 생성 → PUT 으로 foremost 지정 → GET 조회 → DELETE 해제.
+// scope: GET=read:calendar, PUT/DELETE=write:calendar.
+describe('openAPI /v2/open/foremost', function () {
+
+    let client;
+    let todoId;
+
+    before(async function () {
+        const userToken = signUserToken({
+            sub: TEST_USER_UID,
+            scope: ['read:calendar', 'write:calendar']
+        });
+        client = openClient({ pat: defaultMcpPat(), userToken });
+
+        const created = await client.post('/v2/open/todos/', {
+            name: 'openAPI E2E Foremost',
+            event_time: { time_type: 'at', timestamp: Math.floor(Date.now() / 1000) + 86400 }
+        });
+        assert.strictEqual(created.status, 201, `todo create failed: ${JSON.stringify(created.data)}`);
+        todoId = created.data.uuid;
+    });
+
+    it('GET /event — 미지정 시 빈 객체', async function () {
+        const res = await client.get('/v2/open/foremost/event');
+        assert.strictEqual(res.status, 200);
+        assert.deepStrictEqual(res.data, {});
+    });
+
+    it('PUT /event — foremost 지정 (201)', async function () {
+        const res = await client.put('/v2/open/foremost/event', { event_id: todoId, is_todo: true });
+        assert.strictEqual(res.status, 201);
+        assert.strictEqual(res.data.event_id, todoId);
+        assert.strictEqual(res.data.is_todo, true);
+    });
+
+    it('GET /event — 지정된 foremost 조회 (200)', async function () {
+        const res = await client.get('/v2/open/foremost/event');
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(res.data.event_id, todoId);
+    });
+
+    it('DELETE /event — 해제 (200)', async function () {
+        const res = await client.delete('/v2/open/foremost/event');
+        assert.strictEqual(res.status, 200);
+        assert.deepStrictEqual(res.data, { status: 'ok' });
+    });
+
+    it('PUT /event — write scope 없으면 403', async function () {
+        const readOnly = openClient({
+            pat: defaultMcpPat(),
+            userToken: signUserToken({ sub: TEST_USER_UID, scope: ['read:calendar'] })
+        });
+        const res = await readOnly.put('/v2/open/foremost/event', { event_id: todoId, is_todo: true });
+        assert.strictEqual(res.status, 403);
+    });
+});


### PR DESCRIPTION
## 문제

openAPI (`/v2/open/*`) 가 todos / schedules / tags / dones / event_details 만 노출하고 **foremost event 도메인이 빠져 있어** 외부 호출자(MCP / aiFrontAPI / OAuth client)가 read/write 불가했다.

## 접근

기존 serviceAPI `/v1/foremost/event` 와 동등한 GET/PUT/DELETE 를 openAPI 게이트웨이에 추가. 기존 `ForemostEventService` 를 그대로 재사용하는 thin adapter 패턴(다른 openAPI 도메인과 동일 — 별도 service layer 없음).

- **Controller** (`controllers/openapi/foremostOpenController.js`) — userId 를 `req.openUserId`(signedUserAuth 주입)에서 읽고, PUT body 의 `is_todo` 를 boolean 그대로 처리. serviceAPI 의 `JSON.parse(string)` 관용 파싱은 JSON 호출자 기준이라 제거.
- **Route + mount** — `routes/openapi/foremostOpenRoutes.js` composition root. `/v2/open/foremost` 를 `openApiAuth`(PAT + signedUserAuth + setVersion v2) 스택에 mount. scope: GET=`read:calendar`, PUT·DELETE=`write:calendar`.
- **테스트** — controller 단위 테스트 + E2E(PAT+JWT+scope 사이클, write scope 부족 시 403).
- **문서** — `docs/spec/openapi.md` foremost 섹션, `swagger.yaml` `OpenAPI Foremost` tag + 3 라우트.

## Endpoints

| Method | Path | Scope |
|---|---|---|
| GET | `/v2/open/foremost/event` | read:calendar |
| PUT | `/v2/open/foremost/event` | write:calendar |
| DELETE | `/v2/open/foremost/event` | write:calendar |

## 이슈 스펙과 다른 점 (의도적)

- `services/openapi/foremostOpenService.js` **생략** — 기존 openAPI 도메인 패턴(서비스 layer 없이 controller 가 기존 service 재사용)을 따름.
- 이슈 본문의 `rateLimit` 미들웨어는 현재 `openApiAuth` 스택에 존재하지 않아 제외.

## 검증

- `npm test` — 918 passing
- `npm run test:e2e` — 145 passing (foremost 사이클 + scope 403 포함)
- swagger YAML 파싱 검증 완료

## 알려진 한계

owner 검증 패턴이 v1/v2 와 동일(기존 service 재사용). 외부 호출자 환경 owner 검증은 #173 범위.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)