### PR TITLE
[#232] AgentLoopService wall-clock budget 도입

### DIFF
--- a/functions/models/ai/AiErrorCode.js
+++ b/functions/models/ai/AiErrorCode.js
@@ -25,6 +25,7 @@ const AiErrorCode = Object.freeze({
     UnknownFinalize: 'UnknownFinalize',
     AgentError: 'AgentError',
     DailyLimitExceeded: 'DailyLimitExceeded',
+    Timeout: 'Timeout',
 
     // lib `ToolError.code` 그대로 — `todocalendar-tools` 가 throw 시 e.code 값
     ConfirmExpired: 'ConfirmExpired',

--- a/functions/services/ai/agentLoopService.js
+++ b/functions/services/ai/agentLoopService.js
@@ -90,7 +90,8 @@ const MESSAGES = Object.freeze({
         confirmExpired: '확인 시간이 만료됐어요. 다시 요청해 주세요.',
         confirmArgsMismatch: '확인 정보가 일치하지 않아요. 처음부터 다시 시도해 주세요.',
         confirmDone: '요청하신 작업을 완료했어요.',
-        dailyLimitExceeded: '오늘 사용 가능한 한도를 모두 사용했어요. 내일 다시 시도해 주세요.'
+        dailyLimitExceeded: '오늘 사용 가능한 한도를 모두 사용했어요. 내일 다시 시도해 주세요.',
+        timeout: '응답이 너무 오래 걸려 처리를 중단했어요. 잠시 후 다시 시도해 주세요.'
     }),
     en: Object.freeze({
         internalError: 'Something went wrong. Please try again.',
@@ -101,7 +102,8 @@ const MESSAGES = Object.freeze({
         confirmExpired: 'Confirmation expired. Please request again.',
         confirmArgsMismatch: "Confirmation details don't match. Please start over.",
         confirmDone: 'Done',
-        dailyLimitExceeded: "You've reached today's usage limit. Please try again tomorrow."
+        dailyLimitExceeded: "You've reached today's usage limit. Please try again tomorrow.",
+        timeout: 'The request took too long and was canceled. Please try again later.'
     })
 });
 
@@ -144,6 +146,14 @@ function _classifyTool(name) {
     return TOOL_MUTATIONS[name] ?? null;
 }
 
+// fetch 의 AbortError / DOMException name='AbortError' 를 잡는다.
+// SDK 내부의 isAbortError 도 같은 기준 (`@anthropic-ai/sdk/src/internal/errors.ts`).
+// `ac.abort()` 는 동기라 abort 경로에선 항상 `ac.signal.aborted === true` 가 함께
+// 잡힘. 호출처는 `_isAbortError(e) || ac.signal.aborted` OR 패턴으로 양쪽 보호.
+function _isAbortError(err) {
+    return !!err && (err.name === 'AbortError' || err.code === 'ABORT_ERR');
+}
+
 /**
  * (dataType, op) 키 기준 first-seen dedup tracker. 같은 조합 두 번째부터 무시.
  * Plain closure 한 곳 (run / runConfirm) 에만 쓰여 클래스 안 만듦.
@@ -173,16 +183,27 @@ class AgentLoopService {
      *   systemPromptBuilder: { build({ now: Date, timezone: string }): string },
      *   loopCap?: number,
      *   tokenCap?: number,
-     *   scopes?: string[]
+     *   scopes?: string[],
+     *   budgetMs?: number,
+     *   confirmBudgetMs?: number
      * }} options
+     *
+     * budgetMs / confirmBudgetMs — wall-clock watchdog (#232). loopCap / tokenCap 가
+     * 닿지 못하는 outlier (Anthropic rate limit 지연, slow response, lib HTTP stall)
+     * 가 Firebase Functions 9분 hard timeout 까지 끌고 가 process 강제 종료 → job
+     * status RUNNING 영구 고착되는 흐름을 차단. 기본값은 평균 latency × loopCap 여유:
+     *   - run: 60s (10 turn × 평균 5s + 여유)
+     *   - runConfirm: 30s (lib openAPI 단일 호출이라 충분)
      */
-    constructor({ anthropic, registryFactory, systemPromptBuilder, loopCap, tokenCap, scopes }) {
+    constructor({ anthropic, registryFactory, systemPromptBuilder, loopCap, tokenCap, scopes, budgetMs, confirmBudgetMs }) {
         this.anthropic = anthropic;
         this._registryFactory = registryFactory;
         this.systemPromptBuilder = systemPromptBuilder;
         this.loopCap = loopCap ?? 10;
         this.tokenCap = tokenCap ?? 50000;
         this.scopes = scopes ?? ['read:calendar', 'write:calendar'];
+        this.budgetMs = budgetMs ?? 60000;
+        this.confirmBudgetMs = confirmBudgetMs ?? 30000;
     }
 
     /**
@@ -260,56 +281,74 @@ class AgentLoopService {
             result.mutations = tracker.snapshot();
             return { result, usage: { inputTokens: tokens.input, outputTokens: tokens.output } };
         };
+        const timeoutResult = () => AiJobResult.failed(_msg(resolvedLang, 'timeout'), undefined, undefined, AiErrorCode.Timeout);
 
-        const systemBlocks = this._buildSystemBlocks(timezone, resolvedLang);
-        const registry = await this._registryFactory();
-        const tools = this._buildToolsWithCache(registry.anthropicTools);
+        const ac = new AbortController();
+        const budgetTimer = setTimeout(() => ac.abort(), this.budgetMs);
 
-        for (let iter = 0; iter < this.loopCap; iter++) {
-            _markLastMessageForCache(messages);
-            const resp = await this.anthropic.createMessage({
-                system: systemBlocks,
-                messages,
-                tools,
-                toolChoice: { type: 'any' },
-                maxTokens: 4096
-            });
+        try {
+            const systemBlocks = this._buildSystemBlocks(timezone, resolvedLang);
+            const registry = await this._registryFactory();
+            const tools = this._buildToolsWithCache(registry.anthropicTools);
 
-            tokens.input = resp.usage?.input_tokens || 0;
-            tokens.output += resp.usage?.output_tokens || 0;
-            if (tokens.input + tokens.output > this.tokenCap) {
-                return finish(AiJobResult.failed(_msg(resolvedLang, 'tokenCapExceeded'), undefined, undefined, AiErrorCode.TokenCapExceeded));
-            }
+            for (let iter = 0; iter < this.loopCap; iter++) {
+                if (ac.signal.aborted) return finish(timeoutResult());
 
-            messages.push({ role: 'assistant', content: resp.content });
-
-            const toolUses = resp.content.filter(c => c.type === 'tool_use');
-            if (toolUses.length === 0) return finish(AiJobResult.failed(_msg(resolvedLang, 'internalError'), undefined, undefined, AiErrorCode.NoToolUse));
-            if (toolUses.length > 1) return finish(AiJobResult.failed(_msg(resolvedLang, 'internalError'), undefined, undefined, AiErrorCode.MultipleToolUses));
-            const tu = toolUses[0];
-
-            if (registry.isFinalize(tu.name)) {
-                return finish(this._mapFinalizeToResult(tu.input, resolvedLang));
-            }
-
-            let toolResult;
-            try {
-                const libResult = await registry.execute(tu.name, tu.input, auth);
-                if (registry.isConfirmRequired(libResult)) {
-                    // confirm_required = 실 mutation 아직 발생 X (HMAC token 발급만)
-                    // → tracker 에 박지 않음. 이전 turn 들의 누적만 첨부.
-                    return finish(this._buildConfirmResult(tu, libResult, resolvedLang));
+                _markLastMessageForCache(messages);
+                let resp;
+                try {
+                    resp = await this.anthropic.createMessage({
+                        system: systemBlocks,
+                        messages,
+                        tools,
+                        toolChoice: { type: 'any' },
+                        maxTokens: 4096,
+                        signal: ac.signal
+                    });
+                } catch (e) {
+                    if (_isAbortError(e) || ac.signal.aborted) return finish(timeoutResult());
+                    throw e;
                 }
-                // 성공 시점에만 mutation 기록 (throw 경로는 박지 않음).
-                tracker.add(tu.name);
-                toolResult = this._toolResultBlock(tu.id, libResult, false);
-            } catch (e) {
-                toolResult = this._toolResultBlock(tu.id, { code: e.code, status: e.status, message: e.message }, true);
-            }
-            messages.push({ role: 'user', content: [toolResult] });
-        }
 
-        return finish(AiJobResult.failed(_msg(resolvedLang, 'loopCapExceeded'), undefined, undefined, AiErrorCode.LoopCapExceeded));
+                tokens.input = resp.usage?.input_tokens || 0;
+                tokens.output += resp.usage?.output_tokens || 0;
+                if (tokens.input + tokens.output > this.tokenCap) {
+                    return finish(AiJobResult.failed(_msg(resolvedLang, 'tokenCapExceeded'), undefined, undefined, AiErrorCode.TokenCapExceeded));
+                }
+
+                messages.push({ role: 'assistant', content: resp.content });
+
+                const toolUses = resp.content.filter(c => c.type === 'tool_use');
+                if (toolUses.length === 0) return finish(AiJobResult.failed(_msg(resolvedLang, 'internalError'), undefined, undefined, AiErrorCode.NoToolUse));
+                if (toolUses.length > 1) return finish(AiJobResult.failed(_msg(resolvedLang, 'internalError'), undefined, undefined, AiErrorCode.MultipleToolUses));
+                const tu = toolUses[0];
+
+                if (registry.isFinalize(tu.name)) {
+                    return finish(this._mapFinalizeToResult(tu.input, resolvedLang));
+                }
+
+                let toolResult;
+                try {
+                    const libResult = await registry.execute(tu.name, tu.input, auth);
+                    if (registry.isConfirmRequired(libResult)) {
+                        // confirm_required = 실 mutation 아직 발생 X (HMAC token 발급만)
+                        // → tracker 에 박지 않음. 이전 turn 들의 누적만 첨부.
+                        return finish(this._buildConfirmResult(tu, libResult, resolvedLang));
+                    }
+                    // 성공 시점에만 mutation 기록 (throw 경로는 박지 않음).
+                    tracker.add(tu.name);
+                    toolResult = this._toolResultBlock(tu.id, libResult, false);
+                } catch (e) {
+                    if (_isAbortError(e) || ac.signal.aborted) return finish(timeoutResult());
+                    toolResult = this._toolResultBlock(tu.id, { code: e.code, status: e.status, message: e.message }, true);
+                }
+                messages.push({ role: 'user', content: [toolResult] });
+            }
+
+            return finish(AiJobResult.failed(_msg(resolvedLang, 'loopCapExceeded'), undefined, undefined, AiErrorCode.LoopCapExceeded));
+        } finally {
+            clearTimeout(budgetTimer);
+        }
     }
 
     /**
@@ -335,20 +374,42 @@ class AgentLoopService {
             return { result, usage };
         };
 
+        // wall-clock budget (#232). lib `todocalendar-tools` execute 는 (auth, args)
+        // 시그니처라 AbortSignal 미지원 — Promise.race 로 wall-clock 만 강제. abort
+        // 후에도 underlying HTTP 는 계속 돌아 background 에 실 mutation 이 일어날
+        // 가능성 있음 (별 이슈에서 lib 측 signal 지원 추가). 우리 process 는 FAILED
+        // Timeout 으로 즉시 종결해 job status RUNNING 고착만은 방지.
+        let budgetTimer;
+        const timeoutPromise = new Promise((resolve) => {
+            budgetTimer = setTimeout(() => resolve({ __timeout: true }), this.confirmBudgetMs);
+        });
+
         try {
-            const result = await registry.execute(tool, { ...args, confirmToken }, auth);
-            if (registry.isConfirmRequired(result)) {
+            const result = await Promise.race([
+                registry.execute(tool, { ...args, confirmToken }, auth)
+                    .then((r) => ({ ok: r }), (err) => ({ err })),
+                timeoutPromise
+            ]);
+
+            if (result.__timeout) {
+                return finish(AiJobResult.failed(_msg(resolvedLang, 'timeout'), undefined, undefined, AiErrorCode.Timeout));
+            }
+            if (result.err) {
+                const e = result.err;
+                const key = ERROR_CODE_TO_KEY[e?.code] ?? 'agentError';
+                const errorCode = e?.code ?? AiErrorCode.AgentError;
+                return finish(AiJobResult.failed(_msg(resolvedLang, key), undefined, undefined, errorCode));
+            }
+            const libResult = result.ok;
+            if (registry.isConfirmRequired(libResult)) {
                 // confirm 2차에서 다시 confirm_required 는 비정상 — mutation 발생 X
                 return finish(AiJobResult.failed(_msg(resolvedLang, 'confirmRetry'), undefined, undefined, AiErrorCode.UnexpectedConfirmRequired));
             }
             // 성공 시점에만 mutation 기록
             tracker.add(tool);
             return finish(AiJobResult.done(_msg(resolvedLang, 'confirmDone')));
-        } catch (e) {
-            // e.code 가 알려진 lib ToolError 면 그 값 그대로 errorCode, 아니면 generic AgentError.
-            const key = ERROR_CODE_TO_KEY[e?.code] ?? 'agentError';
-            const errorCode = e?.code ?? AiErrorCode.AgentError;
-            return finish(AiJobResult.failed(_msg(resolvedLang, key), undefined, undefined, errorCode));
+        } finally {
+            clearTimeout(budgetTimer);
         }
     }
 }

--- a/functions/services/ai/anthropicClient.js
+++ b/functions/services/ai/anthropicClient.js
@@ -9,15 +9,18 @@ class AnthropicClient {
         this.model = model || 'claude-haiku-4-5-20251001';
     }
 
-    async createMessage({ system, messages, tools, toolChoice, maxTokens }) {
-        return this.client.messages.create({
-            model: this.model,
-            max_tokens: maxTokens,
-            system,
-            messages,
-            tools,
-            tool_choice: toolChoice
-        });
+    async createMessage({ system, messages, tools, toolChoice, maxTokens, signal }) {
+        return this.client.messages.create(
+            {
+                model: this.model,
+                max_tokens: maxTokens,
+                system,
+                messages,
+                tools,
+                tool_choice: toolChoice
+            },
+            signal ? { signal } : undefined
+        );
     }
 }
 

--- a/functions/services/ai/fakes/anthropicClient.js
+++ b/functions/services/ai/fakes/anthropicClient.js
@@ -59,11 +59,14 @@ class FakeAnthropicClient {
      *   when the queue is empty. Used in E2E (emulator) where test process ≠
      *   function process and enqueue is not possible. Default: false (throw on empty queue).
      */
-    constructor({ markerFallback = false } = {}) {
+    constructor({ markerFallback = false, responseDelayMs = 0 } = {}) {
         this._markerFallback = markerFallback;
+        this._responseDelayMs = responseDelayMs;
         this._queue = [];
         this.lastCreateMessageArgs = null;
         this.allCreateMessageArgs = [];
+        this.lastSignal = null;
+        this.allSignals = [];
     }
 
     enqueue(responseObj) {
@@ -71,9 +74,31 @@ class FakeAnthropicClient {
     }
 
     async createMessage(args) {
-        const snapshot = structuredClone(args);
+        const { signal, ...rest } = args;
+        const snapshot = structuredClone(rest);
         this.lastCreateMessageArgs = snapshot;
         this.allCreateMessageArgs.push(snapshot);
+        this.lastSignal = signal ?? null;
+        this.allSignals.push(signal ?? null);
+
+        if (this._responseDelayMs > 0) {
+            await new Promise((resolve, reject) => {
+                const timer = setTimeout(resolve, this._responseDelayMs);
+                if (signal) {
+                    const onAbort = () => {
+                        clearTimeout(timer);
+                        const err = new Error('Request was aborted.');
+                        err.name = 'AbortError';
+                        reject(err);
+                    };
+                    if (signal.aborted) {
+                        onAbort();
+                        return;
+                    }
+                    signal.addEventListener('abort', onAbort, { once: true });
+                }
+            });
+        }
 
         if (this._queue.length > 0) {
             return this._queue.shift();
@@ -82,7 +107,7 @@ class FakeAnthropicClient {
         if (this._markerFallback) {
             // Fallback for E2E: emulator function process cannot share state with test process,
             // so use command-text markers to produce deterministic fixture responses.
-            return resolveMarkerResponse(args.messages ?? []);
+            return resolveMarkerResponse(rest.messages ?? []);
         }
 
         throw new Error('stub queue empty');

--- a/functions/test/services/ai/agentLoopService.test.js
+++ b/functions/test/services/ai/agentLoopService.test.js
@@ -32,6 +32,8 @@ function makeService(overrides = {}) {
     const loopCap = overrides.loopCap ?? 10;
     const tokenCap = overrides.tokenCap ?? 50000;
     const scopes = overrides.scopes ?? ['read:calendar', 'write:calendar'];
+    const budgetMs = overrides.budgetMs;
+    const confirmBudgetMs = overrides.confirmBudgetMs;
 
     return {
         service: new AgentLoopService({
@@ -40,7 +42,9 @@ function makeService(overrides = {}) {
             systemPromptBuilder,
             loopCap,
             tokenCap,
-            scopes
+            scopes,
+            budgetMs,
+            confirmBudgetMs
         }),
         anthropic,
         registry
@@ -906,6 +910,132 @@ describe('AgentLoopService', () => {
             // generic Error (e.code 없음) → user-facing reason 은 agentError 워딩, errorCode 는 AGENT_ERROR fallback
             assert.strictEqual(result.reason, '처리 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
             assert.strictEqual(result.errorCode, 'AgentError');
+        });
+    });
+
+    // ─── wall-clock budget (#232) ───────────────────────────────────────────────
+    //
+    // loopCap / tokenCap 가 잡지 못하는 outlier (Anthropic rate limit 지연, slow
+    // response, lib HTTP stall) 를 setTimeout watchdog + AbortController 로 차단.
+    // Firebase Functions 9분 hard timeout 전에 자체 종결 → job RUNNING 영구 고착 방지.
+
+    describe('budget timer / AbortController (#232)', () => {
+
+        // 활성 timer 카운터 — leak 검증용. setTimeout/clearTimeout 을 patch 해
+        // 살아있는 handle 개수를 추적. afterEach 로 원상복구.
+        let activeTimers;
+        let originalSetTimeout;
+        let originalClearTimeout;
+
+        beforeEach(() => {
+            activeTimers = new Set();
+            originalSetTimeout = global.setTimeout;
+            originalClearTimeout = global.clearTimeout;
+            global.setTimeout = (fn, ms, ...rest) => {
+                const id = originalSetTimeout((...args) => {
+                    activeTimers.delete(id);
+                    fn(...args);
+                }, ms, ...rest);
+                activeTimers.add(id);
+                return id;
+            };
+            global.clearTimeout = (id) => {
+                activeTimers.delete(id);
+                return originalClearTimeout(id);
+            };
+        });
+
+        afterEach(() => {
+            global.setTimeout = originalSetTimeout;
+            global.clearTimeout = originalClearTimeout;
+        });
+
+        it('budget 안 정상 종료 → 기존 동작 회귀 없음 + timer leak 없음', async () => {
+            const { service, anthropic } = makeService({ budgetMs: 5000 });
+            anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '완료' }));
+
+            const { result } = await service.run('cmd', { userId: 'u1', timezone: 'Asia/Seoul' });
+
+            assert.strictEqual(result.type, 'DONE');
+            assert.strictEqual(activeTimers.size, 0, 'finally clearTimeout 으로 watchdog timer 가 정리되어 있어야 함');
+        });
+
+        it('createMessage 호출에 AbortSignal 이 전달됨', async () => {
+            const { service, anthropic } = makeService({ budgetMs: 5000 });
+            anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '완료' }));
+
+            await service.run('cmd', { userId: 'u1', timezone: 'Asia/Seoul' });
+
+            assert.ok(anthropic.lastSignal, 'createMessage 의 signal 인자가 forward 되어야 함');
+            assert.strictEqual(typeof anthropic.lastSignal.aborted, 'boolean');
+        });
+
+        it('budget 초과 — Anthropic 호출이 abort 되면 FAILED + errorCode=Timeout', async () => {
+            // responseDelayMs=200 인데 budgetMs=20 → abort 가 먼저
+            const anthropic = new FakeAnthropicClient({ responseDelayMs: 200 });
+            const { service } = makeService({ anthropic, budgetMs: 20 });
+            // queue 에 응답 enqueue 해두지만 delay 안에 abort 발생 → 응답 꺼내기 전에 abort
+            anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '완료' }));
+
+            const { result } = await service.run('cmd', { userId: 'u1', timezone: 'Asia/Seoul', lang: 'ko' });
+
+            assert.strictEqual(result.type, 'FAILED');
+            assert.strictEqual(result.errorCode, 'Timeout');
+            assert.strictEqual(result.reason, '응답이 너무 오래 걸려 처리를 중단했어요. 잠시 후 다시 시도해 주세요.');
+            assert.strictEqual(activeTimers.size, 0, 'abort path 도 finally clearTimeout 으로 정리');
+        });
+
+        it('budget 초과 (en) — en timeout 워딩', async () => {
+            const anthropic = new FakeAnthropicClient({ responseDelayMs: 200 });
+            const { service } = makeService({ anthropic, budgetMs: 20 });
+            anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: 'ok' }));
+
+            const { result } = await service.run('cmd', { userId: 'u1', timezone: 'Asia/Seoul', lang: 'en' });
+
+            assert.strictEqual(result.errorCode, 'Timeout');
+            assert.strictEqual(result.reason, 'The request took too long and was canceled. Please try again later.');
+        });
+
+        it('throw 가 abort 와 무관하면 그대로 propagate (기존 동작 유지)', async () => {
+            // queue 비어있을 때 fake 가 throw → abort 와 무관 → catch 에서 re-throw
+            const { service } = makeService({ budgetMs: 5000 });
+
+            await assert.rejects(
+                () => service.run('cmd', { userId: 'u1', timezone: 'Asia/Seoul' }),
+                /stub queue empty/
+            );
+            assert.strictEqual(activeTimers.size, 0, 'throw path 도 finally clearTimeout 으로 정리');
+        });
+
+        it('runConfirm — budget 초과 시 FAILED + errorCode=Timeout, mutations 빈 array', async () => {
+            const { service, registry } = makeService({ confirmBudgetMs: 20 });
+            // execute 가 영원히 hang
+            registry.registerExecute('delete_todo', () => new Promise(() => {}));
+
+            const { result, usage } = await service.runConfirm(
+                { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' },
+                { userId: 'u1', lang: 'ko' }
+            );
+
+            assert.strictEqual(result.type, 'FAILED');
+            assert.strictEqual(result.errorCode, 'Timeout');
+            assert.strictEqual(result.reason, '응답이 너무 오래 걸려 처리를 중단했어요. 잠시 후 다시 시도해 주세요.');
+            assert.deepStrictEqual(result.mutations, []);
+            assert.deepStrictEqual(usage, { inputTokens: 0, outputTokens: 0 });
+            assert.strictEqual(activeTimers.size, 0, 'budget timer 정리됨');
+        });
+
+        it('runConfirm — budget 안 정상 종료 시 timer leak 없음', async () => {
+            const { service, registry } = makeService({ confirmBudgetMs: 5000 });
+            registry.registerExecute('delete_todo', { ok: true });
+
+            const { result } = await service.runConfirm(
+                { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' },
+                { userId: 'u1', lang: 'ko' }
+            );
+
+            assert.strictEqual(result.type, 'DONE');
+            assert.strictEqual(activeTimers.size, 0);
         });
     });
 

--- a/functions/triggers/ai/agentLoopTrigger.js
+++ b/functions/triggers/ai/agentLoopTrigger.js
@@ -42,7 +42,11 @@ const agentLoopService = new AgentLoopService({
     systemPromptBuilder: new SystemPromptBuilder(),
     loopCap: 10,
     tokenCap: 50000,
-    scopes: ['read:calendar', 'write:calendar']
+    scopes: ['read:calendar', 'write:calendar'],
+    // wall-clock budget (#232). Firebase Functions timeoutSeconds=540 (9분 hard limit)
+    // 가까이 끌려가 process 강제 종료 → job RUNNING 고착되는 흐름 차단.
+    budgetMs: 60000,
+    confirmBudgetMs: 30000
 });
 
 // aiUsageService 인스턴스 단일화 — JobService.createJob 의 한도 체크 의존성 (#157) 과


### PR DESCRIPTION
Closes #232

## 문제

기존 보호 장치 — `loopCap` (10 turn), `tokenCap` (50000), Functions `timeoutSeconds: 540` (9분 hard) — 만으로는 outlier 시나리오 (Anthropic rate limit 지연, slow response, 긴 tool result echo, lib HTTP stall) 가 9분 boundary 가까이 끌려가 Firebase 가 process 강제 종료 → `job.status = RUNNING` 영구 고착되는 흐름을 막을 수 없음. transition CAS 가 다음 trigger 막고 onCreate 라 재발화 X.

명시적 wall-clock budget 없음 → 사용자 체감 latency / 비용 측면에서도 너무 긴 호출을 끊을 메커니즘 부재.

## 접근

`setTimeout` watchdog + `AbortController` 패턴. Firebase 9분 hard limit 전에 자체 종결.

- `AgentLoopService` constructor 에 `budgetMs` (기본 60s) / `confirmBudgetMs` (기본 30s)
- `run`: AbortController + setTimeout 등록, turn 진입 직전 `ac.signal.aborted` 체크, Anthropic `createMessage` 호출에 `signal` 전달 (SDK v0.96 RequestOptions.signal), abort 감지 시 FAILED + `errorCode='Timeout'`, finally `clearTimeout` 으로 timer leak 방지
- `runConfirm`: lib `todocalendar-tools` 의 `execute` 가 `(auth, args)` 시그니처라 AbortSignal 미지원 — Promise.race 로 wall-clock 만 강제. abort 이후 background HTTP 가 계속 도는 한계는 인라인 주석 (별 이슈에서 lib 측 signal 지원 추가 검토). 우리 process 는 즉시 Timeout 으로 종결해 job RUNNING 고착만은 방지

## 변경

- `models/ai/AiErrorCode.js` — `Timeout` enum 값 추가
- `services/ai/agentLoopService.js` — budget 옵션 + watchdog 로직, `MESSAGES.{ko,en}.timeout` 워딩 (ko 존댓말)
- `services/ai/anthropicClient.js` — `createMessage({ signal, ... })` 시그니처, SDK 두번째 인자 RequestOptions.signal 로 forward
- `services/ai/fakes/anthropicClient.js` — `responseDelayMs` 옵션 + `lastSignal`/`allSignals` 캡처, delay 안 abort 시 AbortError throw
- `triggers/ai/agentLoopTrigger.js` — composition root 에 `budgetMs: 60000` / `confirmBudgetMs: 30000` 명시 주입 (정책 한 눈에)
- `test/services/ai/agentLoopService.test.js` — budget 정상 / Timeout 매핑 / AbortSignal 전파 / timer leak 없음 / runConfirm budget 7케이스. `setTimeout`/`clearTimeout` monkey patch 로 활성 timer 카운트

## 검증

- [x] 단위 테스트 통과 (1144 passing)
- [x] 새 budget 케이스 7개 단독 통과
- [x] 기존 `loopCap` / `tokenCap` / `#157 dailyLimit` 가드와 충돌 없음 (기존 회귀 테스트 그대로 통과)
- [ ] E2E (emulator) — 의도적 slow response 시뮬 (수동 검증 필요)

## scope 외 (별 이슈)

- Firebase Functions `timeoutSeconds: 540` 자체 변경
- lib `todocalendar-tools` 에 AbortSignal 지원 추가 (현재 runConfirm 은 race 만 적용 — abort 후 background HTTP 가 mutation 일으키면 client 엔 Timeout 보이지만 실제 변경은 발생 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)