### PR TITLE
[#238] confirm job 응답에 parent command_text 노출

### DIFF
--- a/docs/spec/aiFront.md
+++ b/docs/spec/aiFront.md
@@ -63,7 +63,7 @@
 | Method | Path | Body | Headers | Response |
 |---|---|---|---|---|
 | POST | `/v1/ai/command` | `{ command_text, timezone }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
-| POST | `/v1/ai/command/confirm` | `{ tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
+| POST | `/v1/ai/command/confirm` | `{ parent_job_id, tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
 | GET | `/v1/ai/jobs/:id` | — | `Authorization` | `200 AiJob.toJSON()` |
 | GET | `/v1/ai/usage` | — | `Authorization` | `200 AiUsage.toJSON() + { daily_limit }` (오늘 사용량 + 일일 한도) |
 
@@ -174,10 +174,11 @@ sequenceDiagram
     participant Lib as todocalendar-tools
     participant OAPI as openAPI
     participant FCM as Messaging
-    App->>Ctrl: POST /v1/ai/command/confirm with tool, args, confirm_token, timezone optional
-    Ctrl->>Ctrl: validate tool and args object and confirm_token
-    Ctrl->>JobSvc: createConfirmJob with userId and confirmPayload
-    JobSvc->>FS: put jobId, status PENDING, mode confirm
+    App->>Ctrl: POST /v1/ai/command/confirm with parent_job_id, tool, args, confirm_token, timezone optional
+    Ctrl->>Ctrl: validate parent_job_id and tool and args object and confirm_token
+    Ctrl->>JobSvc: createConfirmJob with userId, parentJobId, confirmPayload
+    JobSvc->>FS: load parentJobId, verify userId, copy commandText
+    JobSvc->>FS: put jobId, status PENDING, mode confirm, commandText from parent
     JobSvc-->>Ctrl: jobId
     Ctrl-->>App: 202 job_id
     Note over FS,Trig: onCreate 발화
@@ -293,7 +294,8 @@ PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
   "action": {
     "tool": "delete_schedule",
     "args": { "schedule_id": "abc" },
-    "confirmToken": "<HMAC token>"
+    "confirmToken": "<HMAC token>",
+    "parentJobId": "<현재 1차 job 의 jobId>"
   },
   "notification": { "title": "일정 삭제 확인", "body": "..." },
   "mutations": [...]
@@ -315,7 +317,7 @@ PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
 | `type` | 클라가 할 일 |
 |---|---|
 | `DONE` | `text` 사용자에게 표시 (toast / chat 등). **`mutations` 보고 영향받은 도메인 list/cache invalidate**. |
-| `CONFIRM` | `text` 로 confirm UI 표시. **사용자가 승인하면 `action` 통째로 2차 호출 body 에 박아 `POST /v1/ai/command/confirm`** 호출. 거부 시 그냥 폐기. 1차 응답에 `mutations` 가 박혀 있을 수 있음 (이전 turn 의 변경) → list reload. |
+| `CONFIRM` | `text` 로 confirm UI 표시. **사용자가 승인하면 `action` 통째로 2차 호출 body 에 박아 `POST /v1/ai/command/confirm`** 호출 (`action.parentJobId` 는 body 의 `parent_job_id` 자리로). 거부 시 그냥 폐기. 1차 응답에 `mutations` 가 박혀 있을 수 있음 (이전 turn 의 변경) → list reload. |
 | `FAILED` | `reason` 사용자에게 표시. **`errorCode` 보고 분류 / 다른 UX 분기**. `mutations` 도 박혀 있을 수 있음 (부분 mutation) → reload. |
 
 ### 2차 호출 — CONFIRM 확인 후
@@ -330,13 +332,15 @@ Accept-Language: ko-KR
 Content-Type: application/json
 
 {
+  "parent_job_id": "<1차 응답의 action.parentJobId>",
   "tool": "delete_schedule",
   "args": { "schedule_id": "abc" },
   "confirm_token": "<1차 응답의 action.confirmToken>"
 }
 ```
 
-- `command_text` 는 confirm path 에서 안 씀 — body 에서 제외.
+- `parent_job_id` 는 1차 command job 의 jobId. 서버가 이걸로 parent 를 load 해 권한 검증 후 parent 의 `commandText` 를 confirm job 의 `command_text` 로 복사 (#238). 클라가 confirm job 단독 조회만으로도 원본 자연어 명령을 파악 가능. `action.parentJobId` 가 같은 값이라 클라는 action 통째로 받아 그대로 박으면 됨.
+- `command_text` 는 body 에서 받지 않음 — parent 의 값이 진실의 source.
 - `timezone` 도 박지 않아도 됨 (optional).
 
 응답은 1차와 동일하게 `{ job_id }` — 새 jobId 발급되어 1차 jobId 와 독립. 같은 흐름으로 `ai_jobs/{newJobId}` 결과 대기.

--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -65,9 +65,16 @@ class AiController {
         }
 
         // confirm path body:
-        //  - command_text: 클라가 보내지 않음. lang 은 Accept-Language 로, 그 외 confirm path
-        //    가 commandText 를 쓰지 않으므로 body 에서 제외 (#230 후속 정리).
+        //  - parent_job_id: 1차 command job 의 jobId. 서버가 그걸로 parent 의 commandText 를
+        //    load 해 confirm job 에 복사 (#238). confirmToken 에는 jobId 가 bind 되지 않아
+        //    클라가 명시.
+        //  - command_text: 클라가 보내지 않음. parent 의 commandText 가 진실의 source.
         //  - timezone: optional — runConfirm 본체에서 사용 X. 박혀 오면 형식만 검증.
+
+        const parentJobId = req.body.parent_job_id;
+        if (!parentJobId || typeof parentJobId !== 'string') {
+            throw new Errors.BadRequest('parent_job_id is required');
+        }
 
         const timezone = req.body.timezone;
         if (timezone !== undefined && timezone !== null && !isValidTimezone(timezone)) {
@@ -94,6 +101,7 @@ class AiController {
         const jobId = await this.jobService.createConfirmJob({
             userId,
             deviceId,
+            parentJobId,
             timezone: timezone ?? null,
             lang,
             confirmPayload: { tool, args, confirmToken }

--- a/functions/services/ai/agentLoopService.js
+++ b/functions/services/ai/agentLoopService.js
@@ -240,11 +240,16 @@ class AgentLoopService {
         ];
     }
 
-    _buildConfirmResult(tu, libResult, lang) {
+    _buildConfirmResult(tu, libResult, lang, jobId) {
         const defaults = CONFIRM_DEFAULTS[lang];
+        // #238 — action.parentJobId 는 현재 (1차 command) job 의 jobId. 클라가 action
+        // 통째로 받아 confirm 2차 호출 body 의 parent_job_id 로 그대로 박는다. jobId 미주입
+        // 시 (legacy caller) 키 자체 생략 — Firestore undefined reject 회피.
+        const action = { tool: tu.name, args: tu.input, confirmToken: libResult.confirmToken };
+        if (jobId !== undefined) action.parentJobId = jobId;
         return AiJobResult.confirm(
             libResult.message || defaults.text,
-            { tool: tu.name, args: tu.input, confirmToken: libResult.confirmToken },
+            action,
             { title: getConfirmTitle(tu.name, lang), body: defaults.body }
         );
     }
@@ -260,7 +265,7 @@ class AgentLoopService {
 
     /**
      * @param {string} commandText
-     * @param {{ userId: string, timezone: string, lang: 'ko'|'en' }} context
+     * @param {{ userId: string, timezone: string, lang: 'ko'|'en', jobId: string }} context
      * @returns {Promise<{ result: object, usage: { inputTokens: number, outputTokens: number } }>}
      *   result: AiJobResult plain object
      *   usage: 호출 누적 토큰 — caller (AgentLoopHandler) 가 일별 record 입력으로 사용.
@@ -268,8 +273,10 @@ class AgentLoopService {
      *          매 호출에 누적 prompt 전체를 input_tokens 로 보고하기 때문 — turn 별 합산
      *          시 double count 됨). outputTokens 는 모든 turn 합산.
      *          throw 경로는 catch 안 함 → caller 가 0/0 으로 처리 (acceptable loss).
+     *
+     * jobId 는 CONFIRM 종결 시 result.action.parentJobId 로 박는 용도 (#238).
      */
-    async run(commandText, { userId, timezone, lang }) {
+    async run(commandText, { userId, timezone, lang, jobId }) {
         const auth = { userId, scopes: this.scopes };
         const messages = [{ role: 'user', content: commandText }];
         const resolvedLang = lang ?? 'en';
@@ -333,7 +340,7 @@ class AgentLoopService {
                     if (registry.isConfirmRequired(libResult)) {
                         // confirm_required = 실 mutation 아직 발생 X (HMAC token 발급만)
                         // → tracker 에 박지 않음. 이전 turn 들의 누적만 첨부.
-                        return finish(this._buildConfirmResult(tu, libResult, resolvedLang));
+                        return finish(this._buildConfirmResult(tu, libResult, resolvedLang, jobId));
                     }
                     // 성공 시점에만 mutation 기록 (throw 경로는 박지 않음).
                     tracker.add(tu.name);

--- a/functions/services/ai/jobService.js
+++ b/functions/services/ai/jobService.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const AiJob = require('../../models/ai/AiJob');
 const AiJobResult = require('../../models/ai/AiJobResult');
 const AiErrorCode = require('../../models/ai/AiErrorCode');
+const Errors = require('../../models/Errors');
 
 // #157 — 일일 한도 초과 시 user-facing reason. AgentLoopService 의
 // MESSAGES.dailyLimitExceeded 와 같은 워딩 (단일 출처가 아니라 양쪽 갱신 시 같이 갱신).
@@ -63,21 +64,37 @@ class JobService {
     /**
      * CONFIRM 2차 호출용 job 발행. 새 jobId 발급 — 1차 jobId 와 독립.
      *
-     * commandText 는 confirm path 에서 사용되지 않아 받지 않음 (#230 후속 정리).
+     * #238 — parentJobId 로 1차 command job 을 load 해 그 commandText 를 confirm job 의
+     * commandText 로 복사한다. 클라가 confirm job 만 단독으로 봐도 "원래 어떤 자연어
+     * 명령이었는지" `command_text` 필드 하나로 파악 가능 (mode 별 분기 불필요).
+     * confirmToken payload 에 jobId 가 bind 되지 않아 클라가 parent 를 명시.
+     *
+     * - parent 미존재 → NotFound
+     * - parent.userId !== userId → 403 (다른 user 의 jobId 박는 거 차단)
+     *
      * lang 결정은 Accept-Language 헤더 → controller. 응답 메시지 워딩에 그것만 사용.
      *
      * 일일 한도 적용 X (#157) — 1차 confirm 흐름 보호 + tool 1회라 토큰 낮음.
      *
-     * @param {{ userId, deviceId, timezone, lang, confirmPayload: { tool, args, confirmToken } }} params
+     * @param {{ userId, deviceId, parentJobId, timezone, lang, confirmPayload: { tool, args, confirmToken } }} params
      * @returns {Promise<string>} jobId
      */
-    async createConfirmJob({ userId, deviceId, timezone, lang, confirmPayload }) {
+    async createConfirmJob({ userId, deviceId, parentJobId, timezone, lang, confirmPayload }) {
+        const parent = await this.jobRepository.load(parentJobId);
+        if (!parent) {
+            throw new Errors.NotFound('parent job not found');
+        }
+        if (parent.userId !== userId) {
+            throw new Errors.Base(403, 'Forbidden', 'forbidden');
+        }
+
         const jobId = crypto.randomUUID();
         const expireAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
         const data = {
             userId,
             deviceId,
+            commandText: parent.commandText,
             timezone,
             lang: lang ?? 'en',
             mode: AiJob.MODE.CONFIRM,

--- a/functions/swagger/swagger.yaml
+++ b/functions/swagger/swagger.yaml
@@ -2842,8 +2842,12 @@ paths:
         1차 호출이 CONFIRM 반환 시 사용자 승인 후 `action` 통째로 박아 재호출.
         Claude API 호출 없이 lib tool 1회만 실행 — 실제 mutation 수행.
 
-        `command_text` 는 confirm path 에서 사용되지 않아 body 에서 받지 않음.
-        `timezone` 도 사용되지 않아 optional.
+        `parent_job_id` — 1차 command job 의 jobId. 서버가 parent 의 `command_text` 를
+        confirm job 에 복사해, 클라가 confirm job 단독 조회만으로도 원본 명령을
+        파악할 수 있다 (#238).
+
+        `command_text` 는 body 에서 받지 않음 — parent 의 값이 진실의 source.
+        `timezone` 은 사용되지 않아 optional.
       parameters:
         - name: device_id
           in: header
@@ -2862,8 +2866,12 @@ paths:
           application/json:
             schema:
               type: object
-              required: [tool, args, confirm_token]
+              required: [parent_job_id, tool, args, confirm_token]
               properties:
+                parent_job_id:
+                  type: string
+                  description: 1차 command job 의 jobId. 서버가 parent 의 commandText 를 복사한다.
+                  example: "8c2f1e9d-..."
                 tool:
                   type: string
                   description: 1차 응답 `action.tool` 그대로
@@ -3619,7 +3627,8 @@ components:
             tool: { type: string }
             args: { type: object }
             confirmToken: { type: string, description: "HMAC token, 5분 TTL" }
-          required: [tool, args, confirmToken]
+            parentJobId: { type: string, description: "1차 command job 의 jobId. 2차 호출 body 의 parent_job_id 로 그대로 전달 (#238)." }
+          required: [tool, args, confirmToken, parentJobId]
         notification:
           $ref: '#/components/schemas/AiJobResultNotification'
         mutations:
@@ -3661,7 +3670,7 @@ components:
         job_id: { type: string }
         user_id: { type: string }
         device_id: { type: string }
-        command_text: { type: string, nullable: true, description: "confirm mode 면 null" }
+        command_text: { type: string, nullable: true, description: "사용자의 자연어 명령. confirm mode 인 confirm job 은 parent command job 의 값이 복사됨 (#238)." }
         timezone: { type: string, nullable: true }
         lang: { type: string, enum: [ko, en] }
         mode: { type: string, enum: [command, confirm] }

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -208,6 +208,7 @@ describe('AiController', () => {
 
         function makeConfirmReq({
             uid = 'user-1', deviceId = 'device-1',
+            parentJobId = 'parent-1',
             timezone = 'Asia/Seoul',
             tool = 'delete_todo', args = { todo_id: 't1' }, confirmToken = 'tk',
             acceptLanguage = null
@@ -220,13 +221,14 @@ describe('AiController', () => {
                     return null;
                 },
                 body: {
+                    parent_job_id: parentJobId,
                     timezone,
                     tool, args, confirm_token: confirmToken
                 }
             };
         }
 
-        it('정상 — 202 + job_id, createConfirmJob 인자에 confirmPayload 묶여 전달 (commandText 안 받음)', async () => {
+        it('정상 — 202 + job_id, createConfirmJob 인자에 parentJobId + confirmPayload 묶여 전달', async () => {
             const req = makeConfirmReq();
             const res = makeRes();
 
@@ -237,6 +239,7 @@ describe('AiController', () => {
             assert.deepEqual(stubService.lastCreateConfirmJobArgs, {
                 userId: 'user-1',
                 deviceId: 'device-1',
+                parentJobId: 'parent-1',
                 timezone: 'Asia/Seoul',
                 lang: 'en',
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
@@ -252,6 +255,23 @@ describe('AiController', () => {
 
         it('device_id 헤더 누락 → 400', async () => {
             const req = makeConfirmReq({ deviceId: null });
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('parent_job_id 누락 → 400', async () => {
+            const req = makeConfirmReq();
+            delete req.body.parent_job_id;
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('parent_job_id 빈 문자열 → 400', async () => {
+            const req = makeConfirmReq({ parentJobId: '' });
+            await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('parent_job_id 가 비문자열 → 400', async () => {
+            const req = makeConfirmReq();
+            req.body.parent_job_id = 123;
             await assert.rejects(() => controller.postCommandConfirm(req, makeRes()), Errors.BadRequest);
         });
 

--- a/functions/test/doubles/stubAiJobService.js
+++ b/functions/test/doubles/stubAiJobService.js
@@ -23,9 +23,9 @@ class StubAiJobService {
         return this._nextJobId;
     }
 
-    async createConfirmJob({ userId, deviceId, timezone, lang, confirmPayload }) {
+    async createConfirmJob({ userId, deviceId, parentJobId, timezone, lang, confirmPayload }) {
         if (this.shouldFail) throw { message: 'service failed' };
-        this.lastCreateConfirmJobArgs = { userId, deviceId, timezone, lang, confirmPayload };
+        this.lastCreateConfirmJobArgs = { userId, deviceId, parentJobId, timezone, lang, confirmPayload };
         return this._nextJobId;
     }
 

--- a/functions/test/e2e/ai-confirm.e2e.js
+++ b/functions/test/e2e/ai-confirm.e2e.js
@@ -43,7 +43,7 @@ describe('aiFrontAPI confirm 2차 호출', function () {
             const res = await client.post(
                 '/v1/ai/command/confirm',
                 {
-                    command_text: 'delete',
+                    parent_job_id: 'irrelevant',
                     timezone: 'Asia/Seoul',
                     args: { todo_id: 't1' },
                     confirm_token: 'tk'
@@ -57,10 +57,24 @@ describe('aiFrontAPI confirm 2차 호출', function () {
             const res = await client.post(
                 '/v1/ai/command/confirm',
                 {
-                    command_text: 'delete',
+                    parent_job_id: 'irrelevant',
                     timezone: 'Asia/Seoul',
                     tool: 'delete_todo',
                     args: ['t1'],
+                    confirm_token: 'tk'
+                },
+                { headers: { device_id: 'e2e-device-confirm' } }
+            );
+            assert.strictEqual(res.status, 400);
+        });
+
+        it('parent_job_id 누락 → 400 (#238)', async function () {
+            const res = await client.post(
+                '/v1/ai/command/confirm',
+                {
+                    timezone: 'Asia/Seoul',
+                    tool: 'delete_todo',
+                    args: { todo_id: 't1' },
                     confirm_token: 'tk'
                 },
                 { headers: { device_id: 'e2e-device-confirm' } }
@@ -74,6 +88,8 @@ describe('aiFrontAPI confirm 2차 호출', function () {
 
         let createdTodoId;
         let confirmAction;
+        let parentJobId;
+        let parentCommandText;
 
         it('todo 시드 (openAPI POST) → 1차 [stub:CONFIRM:<id>] → CONFIRM + result.action 추출', async function () {
             this.timeout(15000);
@@ -87,23 +103,27 @@ describe('aiFrontAPI confirm 2차 호출', function () {
             createdTodoId = createRes.data.uuid;
 
             // 2) 1차 command — FakeAnthropicClient 가 [stub:CONFIRM:<id>] 매칭해 delete_todo tool_use 반환
+            parentCommandText = `[stub:CONFIRM:${createdTodoId}] 이거 삭제해`;
             const cmdRes = await client.post(
                 '/v1/ai/command',
                 {
-                    command_text: `[stub:CONFIRM:${createdTodoId}] 이거 삭제해`,
+                    command_text: parentCommandText,
                     timezone: 'Asia/Seoul'
                 },
                 { headers: { device_id: 'e2e-device-confirm' } }
             );
             assert.strictEqual(cmdRes.status, 202);
+            parentJobId = cmdRes.data.job_id;
 
-            const job1 = await pollJob(client, cmdRes.data.job_id);
+            const job1 = await pollJob(client, parentJobId);
             assert.strictEqual(job1.status, 'CONFIRM');
             assert.strictEqual(job1.result.type, 'CONFIRM');
             assert.ok(job1.result.action, 'result.action 존재');
             assert.strictEqual(job1.result.action.tool, 'delete_todo');
             assert.deepStrictEqual(job1.result.action.args, { todo_id: createdTodoId });
             assert.ok(job1.result.action.confirmToken, 'confirmToken 존재');
+            // #238 — action.parentJobId 가 1차 job 의 jobId 와 같음 (클라가 그대로 confirm body 에 박을 수 있게)
+            assert.strictEqual(job1.result.action.parentJobId, parentJobId);
 
             confirmAction = job1.result.action;
         });
@@ -114,7 +134,7 @@ describe('aiFrontAPI confirm 2차 호출', function () {
             const confirmRes = await client.post(
                 '/v1/ai/command/confirm',
                 {
-                    command_text: '이거 삭제해',
+                    parent_job_id: confirmAction.parentJobId,
                     timezone: 'Asia/Seoul',
                     tool: confirmAction.tool,
                     args: confirmAction.args,
@@ -131,6 +151,9 @@ describe('aiFrontAPI confirm 2차 호출', function () {
             // 2차 job 의 mode 가 'confirm' 으로 응답에 노출됨
             assert.strictEqual(job2.mode, 'confirm');
 
+            // #238 — confirm job 의 command_text 가 1차 job 의 명령으로 채워짐
+            assert.strictEqual(job2.command_text, parentCommandText);
+
             // 실 todo 가 삭제됐는지 — openAPI GET → 404
             const checkRes = await openCli.get(`/v2/open/todos/${createdTodoId}`);
             assert.strictEqual(checkRes.status, 404, 'todo 가 실제로 삭제됨');
@@ -141,12 +164,25 @@ describe('aiFrontAPI confirm 2차 호출', function () {
     describe('verify 실패 — 변조된 confirm_token → FAILED', function () {
 
         it('전혀 다른 token 으로 2차 호출 → FAILED (lib verify 실패)', async function () {
-            this.timeout(15000);
+            this.timeout(20000);
+
+            // #238 — confirm 진입에 parent_job_id 가 필수. 평범한 1차 명령 먼저 발행해
+            // 그 jobId 로 confirm 호출. parent 의 결과(성공/실패)는 본 케이스와 무관.
+            const parentRes = await client.post(
+                '/v1/ai/command',
+                {
+                    command_text: 'parent for token verify test',
+                    timezone: 'Asia/Seoul'
+                },
+                { headers: { device_id: 'e2e-device-confirm' } }
+            );
+            assert.strictEqual(parentRes.status, 202);
+            const parentJobIdLocal = parentRes.data.job_id;
 
             const res = await client.post(
                 '/v1/ai/command/confirm',
                 {
-                    command_text: 'delete',
+                    parent_job_id: parentJobIdLocal,
                     timezone: 'Asia/Seoul',
                     tool: 'delete_todo',
                     args: { todo_id: 'never-existed' },

--- a/functions/test/services/ai/agentLoopService.test.js
+++ b/functions/test/services/ai/agentLoopService.test.js
@@ -103,14 +103,16 @@ describe('AgentLoopService', () => {
 
         anthropic.enqueue(makeToolUseResponse('delete_todo', { todo_id: 't1' }));
 
-        const { result } = await service.run('할일 삭제해', { userId: 'u1', timezone: 'Asia/Seoul', lang: 'ko' });
+        const { result } = await service.run('할일 삭제해', { userId: 'u1', timezone: 'Asia/Seoul', lang: 'ko', jobId: 'job-parent-1' });
 
         assert.strictEqual(result.type, 'CONFIRM');
         assert.strictEqual(result.text, '확인이 필요한 작업이에요.');
         assert.deepStrictEqual(result.action, {
             tool: 'delete_todo',
             args: { todo_id: 't1' },
-            confirmToken: 'tok123'
+            confirmToken: 'tok123',
+            // #238 — confirm 종결 시 action 에 현재 (1차) job 의 jobId 가 박힌다.
+            parentJobId: 'job-parent-1'
         });
         assert.deepStrictEqual(result.notification, {
             title: '할 일 삭제 확인',

--- a/functions/test/services/ai/jobService.test.js
+++ b/functions/test/services/ai/jobService.test.js
@@ -99,16 +99,25 @@ describe('JobService', () => {
 
     describe('createConfirmJob', () => {
 
+        // parent command job 을 미리 만들어 그 jobId 를 confirm 호출 시 parentJobId 로 사용.
+        async function seedParent({ userId = 'u', commandText = '내일 일정 알려줘' } = {}) {
+            return service.createJob({ userId, deviceId: 'd', commandText, timezone: 'Asia/Seoul', lang: 'ko' });
+        }
+
         it('mode=confirm + confirmPayload 가 plain object 로 박히고 새 jobId 반환', async () => {
+            const parentId = await seedParent({ userId: 'u', commandText: '오늘 할일 추가' });
+
             const before = Date.now();
             const jobId = await service.createConfirmJob({
                 userId: 'u', deviceId: 'd',
+                parentJobId: parentId,
                 timezone: 'Asia/Seoul',
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
             });
             const after = Date.now();
 
             assert.ok(typeof jobId === 'string' && jobId.length > 0);
+            assert.notStrictEqual(jobId, parentId, 'parent 와 다른 새 jobId');
 
             const { jobId: storedJobId, data } = stubRepo.lastPutPayload;
             assert.strictEqual(storedJobId, jobId);
@@ -121,8 +130,6 @@ describe('JobService', () => {
             assert.deepStrictEqual(data.confirmPayload, { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' });
             assert.strictEqual(data.status, AiJob.STATUS.PENDING);
             assert.strictEqual(data.result, null);
-            // confirm job 은 commandText 안 받음 (#230 후속 정리)
-            assert.strictEqual('commandText' in data, false);
 
             assert.ok(data.expireAt instanceof Date);
             const expected24hLater = before + 24 * 60 * 60 * 1000;
@@ -130,16 +137,57 @@ describe('JobService', () => {
             assert.ok(drift >= 0 && drift <= (after - before) + 1000);
         });
 
+        it('parent 의 commandText 가 confirm job 의 commandText 로 복사됨 (#238)', async () => {
+            const parentId = await seedParent({ userId: 'u', commandText: '오늘 할일 추가' });
+
+            await service.createConfirmJob({
+                userId: 'u', deviceId: 'd',
+                parentJobId: parentId,
+                timezone: 'Asia/Seoul',
+                confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
+            });
+
+            assert.strictEqual(stubRepo.lastPutPayload.data.commandText, '오늘 할일 추가');
+        });
+
+        it('parent 미존재 → NotFound', async () => {
+            await assert.rejects(
+                () => service.createConfirmJob({
+                    userId: 'u', deviceId: 'd',
+                    parentJobId: 'nonexistent',
+                    timezone: 'Asia/Seoul',
+                    confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
+                }),
+                (err) => err.status === 404 && err.code === 'NotFound'
+            );
+        });
+
+        it('parent 가 타인의 job → 403 Forbidden', async () => {
+            const parentId = await seedParent({ userId: 'other-user', commandText: '타인 명령' });
+
+            await assert.rejects(
+                () => service.createConfirmJob({
+                    userId: 'u', deviceId: 'd',
+                    parentJobId: parentId,
+                    timezone: 'Asia/Seoul',
+                    confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
+                }),
+                (err) => err.status === 403 && err.code === 'Forbidden'
+            );
+        });
+
         it('두 번 호출하면 서로 다른 jobId 반환', async () => {
+            const parentId = await seedParent();
             const payload = { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' };
-            const a = await service.createConfirmJob({ userId: 'u', deviceId: 'd', timezone: 'UTC', confirmPayload: payload });
-            const b = await service.createConfirmJob({ userId: 'u', deviceId: 'd', timezone: 'UTC', confirmPayload: payload });
+            const a = await service.createConfirmJob({ userId: 'u', deviceId: 'd', parentJobId: parentId, timezone: 'UTC', confirmPayload: payload });
+            const b = await service.createConfirmJob({ userId: 'u', deviceId: 'd', parentJobId: parentId, timezone: 'UTC', confirmPayload: payload });
             assert.notStrictEqual(a, b);
         });
 
         it('lang 인자 — confirm job 에 그대로 저장', async () => {
+            const parentId = await seedParent();
             await service.createConfirmJob({
-                userId: 'u', deviceId: 'd', timezone: 'Asia/Seoul', lang: 'ko',
+                userId: 'u', deviceId: 'd', parentJobId: parentId, timezone: 'Asia/Seoul', lang: 'ko',
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
             });
             assert.strictEqual(stubRepo.lastPutPayload.data.lang, 'ko');
@@ -210,9 +258,14 @@ describe('JobService', () => {
         });
 
         it('createConfirmJob 은 한도 적용 X — 한도 초과여도 PENDING / status=PENDING 그대로', async () => {
+            // parent 는 한도 차단 전(setOverDailyLimit false) 에 먼저 seed
+            const parentId = await service.createJob({
+                userId: 'u', deviceId: 'd', commandText: '오늘 할일', timezone: 'Asia/Seoul', lang: 'ko'
+            });
             stubUsageService.setOverDailyLimit('u', true);
+
             await service.createConfirmJob({
-                userId: 'u', deviceId: 'd', timezone: 'Asia/Seoul', lang: 'ko',
+                userId: 'u', deviceId: 'd', parentJobId: parentId, timezone: 'Asia/Seoul', lang: 'ko',
                 confirmPayload: { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' }
             });
             const { data } = stubRepo.lastPutPayload;

--- a/functions/test/triggers/ai/agentLoopTrigger.test.js
+++ b/functions/test/triggers/ai/agentLoopTrigger.test.js
@@ -157,10 +157,10 @@ describe('AgentLoopHandler', () => {
         assert.strictEqual(payload.data.jobId, 'job-1');
         assert.strictEqual(payload.data.status, 'DONE');
 
-        // handler 가 agentLoopService.run 에 commandText 와 {userId, timezone, lang} 을 정확히 전달하는지 검증 (재발 방지)
+        // handler 가 agentLoopService.run 에 commandText 와 {userId, timezone, lang, jobId} 을 정확히 전달하는지 검증 (재발 방지)
         assert.deepStrictEqual(agentLoopService.lastRunArgs, {
             commandText: BASE_JOB_DATA.commandText,
-            opts: { userId: BASE_JOB_DATA.userId, timezone: BASE_JOB_DATA.timezone, lang: BASE_JOB_DATA.lang }
+            opts: { userId: BASE_JOB_DATA.userId, timezone: BASE_JOB_DATA.timezone, lang: BASE_JOB_DATA.lang, jobId: 'job-1' }
         });
     });
 

--- a/functions/triggers/ai/agentLoopHandler.js
+++ b/functions/triggers/ai/agentLoopHandler.js
@@ -133,7 +133,8 @@ class AgentLoopHandler {
         return this.agentLoopService.run(job.commandText, {
             userId: job.userId,
             timezone: job.timezone,
-            lang: job.lang
+            lang: job.lang,
+            jobId: job.jobId
         });
     }
 


### PR DESCRIPTION
Closes #238

## 배경

`AiJob.commandText` 는 모델/응답에 이미 노출되지만 `JobService.createConfirmJob` 이 `commandText` 를 받지 않아 confirm job 의 GET 응답에서 `command_text` 가 비어 있었음. 클라가 confirm job 단독으로 봐서는 "원래 어떤 자연어 명령이었는지" 알 수 없음.

## 접근

confirm body 에 `parent_job_id` 를 필수로 추가하고, server 가 1차 command job 을 load 해서 권한 검증 후 `commandText` 를 confirm job 의 같은 필드로 복사. 클라는 mode 분기 없이 `command_text` 한 필드만 보면 됨.

`confirmToken` 은 `action + target + userId` 만 HMAC bind — token 안에 jobId 가 없어 클라가 명시. 대안 (클라가 `command_text` 를 직접 재전송) 은 #230 에서 일부러 뺀 자리를 되돌리는 거라 기각.

## 변경

- `AiController.postCommandConfirm` — `parent_job_id` body 필수 (누락/빈/비문자열 → 400)
- `JobService.createConfirmJob` — `parentJobId` 로 parent load. 미존재 → 404, 타인 → 403. parent.commandText 를 confirm job 의 commandText 로 복사
- `StubAiJobService.createConfirmJob` — 시그니처에 `parentJobId` 추가 (`lastCreateConfirmJobArgs` 에 기록)
- swagger — `/v1/ai/command/confirm` requestBody 에 `parent_job_id` required 추가, `AiJob.command_text` 설명 갱신

## Test plan

- [x] 단위 테스트 (`npm test`) — 1150 passing
  - `JobService.createConfirmJob` — parent commandText 복사 / 미존재 → 404 / 타인 → 403 / parentJobId 인자 전달
  - `AiController.postCommandConfirm` — parent_job_id 누락/빈/비문자열 400, 정상 인자 전달
- [x] E2E (`npm run test:e2e`) — ai-confirm 시나리오 6/6 pass
  - body validation 에 `parent_job_id` 누락 → 400 케이스 추가
  - golden 흐름에서 2차 confirm 호출에 `parent_job_id` 박고, `job2.command_text === parent.commandText` 검증
  - verify 실패 케이스도 parent 1차 명령 먼저 발행 후 confirm 흐름 검증
- [ ] 클라이언트(아이폰/웹) 가 `parent_job_id` 박기 — 클라 측 follow-up