### PR TITLE
[#240] GET /v1/ai/usage 응답에 resets_at(사용량 초기화 시각) 노출

### DIFF
--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -115,7 +115,8 @@ class AiController {
             this.aiUsageService.getTodayUsage(userId),
             this.aiUsageService.getDailyLimit(userId)
         ]);
-        res.status(200).send({ ...usage.toJSON(), daily_limit: dailyLimit });
+        const resetsAt = this.aiUsageService.getResetAt();
+        res.status(200).send({ ...usage.toJSON(), daily_limit: dailyLimit, resets_at: resetsAt });
     }
 }
 

--- a/functions/services/ai/aiUsageService.js
+++ b/functions/services/ai/aiUsageService.js
@@ -67,6 +67,21 @@ class AiUsageService {
     }
 
     /**
+     * 사용량이 0 으로 재시작되는 다음 UTC 자정의 ISO string.
+     *
+     * dateKey 가 server UTC 'YYYY-MM-DD' 로 끊기므로 (`_todayUtcKey`), 초기화 시점은
+     * 항상 다음 UTC 00:00:00.000Z. 저장하지 않고 같은 clock 으로 계산해 dateKey 와
+     * 롤오버 규칙을 단일 source 로 유지. 클라가 로컬 변환해 "X 뒤 초기화" 표시.
+     *
+     * @returns {string}  예: '2026-06-08T00:00:00.000Z'
+     */
+    getResetAt() {
+        const now = this._clock();
+        const nextMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
+        return new Date(nextMidnight).toISOString();
+    }
+
+    /**
      * 본 user 가 오늘 일일 한도를 소진했는지 (input+output 합산 ≥ limit).
      * controller 가 새 명령 진입 시 사전 차단 판단에 사용.
      *

--- a/functions/swagger/swagger.yaml
+++ b/functions/swagger/swagger.yaml
@@ -3707,7 +3707,13 @@ components:
             본 유저의 오늘 일일 토큰 한도 (input + output 합산 기준).
             #157 MVP 는 무료 단일 5000, 추후 #166 에서 plan 별 분기.
           example: 5000
-      required: [date, input_tokens, output_tokens, daily_limit]
+        resets_at:
+          type: string
+          description: |
+            사용량이 0 으로 재시작되는 다음 UTC 자정 (#240). 항상 노출.
+            UTC 기준이므로 유저 로컬 자정과 다름 — 클라가 로컬 변환해 "X 뒤 초기화" 표시.
+          example: "2026-05-31T00:00:00.000Z"
+      required: [date, input_tokens, output_tokens, daily_limit, resets_at]
 
     # ──────────────── OAuth 2.1 AS schemas ────────────────
     OAuthClientRegistrationRequest:

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -395,7 +395,8 @@ describe('AiController', () => {
                 input_tokens: 1234,
                 output_tokens: 567,
                 updated_at: '2026-05-22T10:00:00.000Z',
-                daily_limit: 5000
+                daily_limit: 5000,
+                resets_at: '2026-05-23T00:00:00.000Z'
             });
         });
 
@@ -411,6 +412,7 @@ describe('AiController', () => {
             assert.equal(res.body.output_tokens, 0);
             assert.equal(res.body.updated_at, null);
             assert.ok(typeof res.body.date === 'string', 'date 필드는 비어있지 않음');
+            assert.equal(res.body.resets_at, '2026-05-23T00:00:00.000Z', '사용량 미존재여도 초기화 시각은 노출');
         });
 
         it('응답에 daily_limit 노출', async () => {

--- a/functions/test/doubles/stubAiUsageService.js
+++ b/functions/test/doubles/stubAiUsageService.js
@@ -14,6 +14,7 @@ class StubAiUsageService {
         this._usageByUser = new Map();   // userId → AiUsage
         this._defaultDateKey = '2026-05-22';
         this._dailyLimit = 5000;
+        this._resetAt = '2026-05-23T00:00:00.000Z';   // _defaultDateKey 다음 UTC 자정
         this._overByUser = new Map();    // userId → boolean override; 미설정 시 false
 
         this.shouldFailGetTodayUsage = false;
@@ -69,6 +70,10 @@ class StubAiUsageService {
 
     async getDailyLimit(_userId) {
         return this._dailyLimit;
+    }
+
+    getResetAt() {
+        return this._resetAt;
     }
 
     async isOverDailyLimit(userId) {

--- a/functions/test/services/ai/aiUsageService.test.js
+++ b/functions/test/services/ai/aiUsageService.test.js
@@ -162,4 +162,36 @@ describe('AiUsageService', () => {
             assert.strictEqual(over, true);
         });
     });
+
+    // ------------------------------------------------------------------ //
+    // getResetAt — 사용량이 0 으로 재시작되는 다음 UTC 자정 (#240)
+    // ------------------------------------------------------------------ //
+
+    describe('getResetAt', () => {
+
+        it('낮 시각 → 같은 날 다음 UTC 자정 ISO string 반환', () => {
+            const service = makeService({ now: '2026-05-22T10:00:00.000Z' });
+            assert.strictEqual(service.getResetAt(), '2026-05-23T00:00:00.000Z');
+        });
+
+        it('UTC 자정 직전(23:59:59) → 바로 다음 자정', () => {
+            const service = makeService({ now: '2026-05-22T23:59:59.000Z' });
+            assert.strictEqual(service.getResetAt(), '2026-05-23T00:00:00.000Z');
+        });
+
+        it('UTC 자정 정각(00:00:00) → 그날 끝의 다음 자정 (이미 새 dateKey 시작)', () => {
+            const service = makeService({ now: '2026-05-22T00:00:00.000Z' });
+            assert.strictEqual(service.getResetAt(), '2026-05-23T00:00:00.000Z');
+        });
+
+        it('월말 → 다음 달 1일 자정으로 롤오버', () => {
+            const service = makeService({ now: '2026-05-31T12:00:00.000Z' });
+            assert.strictEqual(service.getResetAt(), '2026-06-01T00:00:00.000Z');
+        });
+
+        it('연말 → 다음 해 1월 1일 자정으로 롤오버', () => {
+            const service = makeService({ now: '2026-12-31T23:00:00.000Z' });
+            assert.strictEqual(service.getResetAt(), '2027-01-01T00:00:00.000Z');
+        });
+    });
 });


### PR DESCRIPTION
## 문제

`GET /v1/ai/usage` 응답엔 현재 사용량(`input/output_tokens`, `updated_at`)과 한도(`daily_limit`)만 있고, **사용량이 언제 다시 초기화되는지** 클라가 알 방법이 없었다. 사용량은 server UTC `dateKey` 로 끊겨 다음 UTC 자정에 0 부터 재시작하는데, 그 시점을 응답에서 노출하지 않았기 때문.

## 접근

초기화 시점은 저장 불필요한 결정적 값(다음 UTC 자정)이라, 조회 시 계산해 응답에 머지한다.

- **`AiUsageService.getResetAt`** — 주입된 clock 기준 다음 UTC `00:00:00.000Z` 의 ISO string 계산. `dateKey` 를 만드는 `_todayUtcKey()` 와 같은 clock·같은 롤오버 규칙을 단일 source 로 유지 (저장 X).
- **`AiController.getUsage`** — `daily_limit` 과 동일하게 `resets_at` 를 응답에 머지. usage doc 미존재여도 항상 노출.
- **`StubAiUsageService.getResetAt`** — 인터페이스 동기화 (record-only 고정값).
- **swagger `AiUsage` 스키마** — `resets_at` 필드 + required 추가.

응답 예시:
```json
{ "date": "2026-06-07", "input_tokens": 1234, "output_tokens": 567,
  "updated_at": "2026-06-07T10:00:00.000Z", "daily_limit": 5000,
  "resets_at": "2026-06-08T00:00:00.000Z" }
```

## 정책 메모

초기화는 **UTC 기준** (유저 로컬 자정 아님). 절대 ISO timestamp 로 내려주므로 클라가 로컬 변환해 "X 뒤 초기화" 표시 가능. 유저 로컬 자정 기준 초기화는 `dateKey` 자체를 timezone-aware 하게 바꾸는 별개 과제 — 본 PR 범위 밖.

## 검증

- service 단위 테스트: 낮 시각 / 자정 직전 / 자정 정각 / 월말 / 연말 롤오버
- controller 단위 테스트: usage 존재·미존재 양쪽 응답 shape 에 `resets_at` 포함
- 전체 1155 passing

읽기 경로만 추가, record/repository 무변경 (하위호환).

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)