### PR TITLE
[#242] openAPI 기간 조회 시 반복 이벤트 서버 전개 — occurrence 단위 응답

### DIFF
--- a/docs/spec/openapi.md
+++ b/docs/spec/openapi.md
@@ -116,6 +116,7 @@ base prefix `/v2/open` 아래 여섯 그룹. 마운트 순서상 `dones` 가 `to
 | Method | Path | Scope |
 |---|---|---|
 | GET | `/v2/open/todos/` | read |
+| GET | `/v2/open/todos/expanded` | read |
 | GET | `/v2/open/todos/uncompleted` | read |
 | GET | `/v2/open/todos/:id` | read |
 | POST | `/v2/open/todos/` | write |
@@ -140,6 +141,7 @@ base prefix `/v2/open` 아래 여섯 그룹. 마운트 순서상 `dones` 가 `to
 | Method | Path | Scope |
 |---|---|---|
 | GET | `/v2/open/schedules/` | read |
+| GET | `/v2/open/schedules/expanded` | read |
 | GET | `/v2/open/schedules/:id` | read |
 | POST | `/v2/open/schedules/` | write |
 | PUT | `/v2/open/schedules/:id` | write |
@@ -186,6 +188,83 @@ serviceAPI `/v1/foremost/event` 와 동등. 사용자당 단일 foremost event (
 각 endpoint 의 요청 body / 응답 모델은 swagger 정의 (`functions/swagger.yaml`) 와 도메인 모델
 (`models/Todo`, `models/Schedule`, `models/EventTag`, `models/DoneTodo`, `models/EventDetail`,
 `models/ForemostEvent`) 을 재사용한다. 인증/스코프 외 라우팅·검증·응답 형식은 도메인 layer 와 동일.
+
+## Occurrence 전개 조회 (`/expanded`)
+
+```
+GET /v2/open/todos/expanded
+GET /v2/open/schedules/expanded
+```
+
+조회 구간 안에서 반복(repeating) 이벤트를 서버가 실제 발생 **회차(occurrence)** 로 전개해
+내려준다. 클라(특히 MCP) 는 반복 규칙을 받아 날짜를 직접 계산할 필요가 없다. 기존
+`/v2/open/todos/`·`/v2/open/schedules/` 조회는 **원본 이벤트만** 반환하므로 그대로 유지되고,
+전개가 필요할 때만 이 endpoint 를 쓴다.
+
+- **scope**: `read:calendar`
+- **인증**: 기존 openAPI 와 동일 (PAT `Authorization: Bearer mcp_<secret>` + 사용자 JWT
+  `x-open-user-token`).
+
+### 쿼리 파라미터
+
+| 이름 | 필수 | 타입 | 의미 |
+|---|---|---|---|
+| `lower` | 필수 | 초 단위 epoch | 조회 구간 시작 |
+| `upper` | 필수 | 초 단위 epoch | 조회 구간 끝 |
+| `limit` | 선택 | 정수 (default 100, max 500) | 페이지당 occurrence 수. 초과 시 500 으로 clamp |
+| `cursor` | 선택 | opaque base64url | 다음 페이지 조회용. 직전 응답의 `next_cursor` 를 그대로 전달 |
+
+- `lower` / `upper` 누락 시 **400**.
+- `upper - lower` 가 **1년 (365일 = 31,536,000초) 초과** 시 **400**.
+
+### 응답 (200) — 정규화 형태
+
+origin 메타(`events`) 와 발생 회차(`occurrences`) 를 분리한 정규화 응답이다. 같은 origin 의 여러
+회차가 메타를 중복해서 싣지 않도록 occurrence 항목은 초경량으로 유지한다.
+
+```jsonc
+{
+  "events": {                       // 이 페이지에 등장한 원본 메타, origin 당 1벌 (반복 규칙 포함)
+    "todo-abc": {
+      "uuid": "todo-abc", "name": "...", "is_todo": true,
+      "event_tag_id": "...",
+      "event_time": { /* 원본 */ }, "repeating": { /* 원본 옵션 */ }
+    }
+  },
+  "occurrences": [                  // 시각순 평탄 배열 (초경량)
+    { "origin_event_id": "todo-abc", "turn": 3, "event_time": { "time_type": "at", "timestamp": 1690000000 } }
+  ],
+  "next_cursor": "eyJ0Ijo..."       // null 이면 마지막 페이지
+}
+```
+
+- **`occurrences[]`** — 시각순으로 정렬된 평탄 배열. 각 항목은 `origin_event_id` + `turn` +
+  계산된 `event_time`(초 단위) 만 담는다.
+  - `turn` — `repeating.start` 부터 시작하는 **1-based 실제 회차**. 비반복 이벤트는 항상 `1`.
+  - occurrence 식별이 필요하면 클라가 `"{origin_event_id}:{turn}"` 로 합성한다 (서버는 별도
+    occurrence id 를 내려주지 않는다).
+- **`events{}`** — 그 페이지에 등장한 origin 들의 원본 1벌 (반복 규칙 포함). 같은 origin 이 여러
+  페이지에 걸치면 페이지마다 중복 포함될 수 있다.
+- **`next_cursor`** — opaque cursor. `null` 이면 마지막 페이지.
+
+### 전개 규칙
+
+6종 반복 옵션 (`every_day` / `every_week` / `every_month` / `every_year` / `every_year_some_day`
+/ `lunar`) 을 모두 서버가 계산한다. 클라(iOS `EventRepeatTimeEnumerator`) 동작과 1:1 로 맞춘다.
+
+- 매월 N일 반복은 해당 일자가 없는 달을 **스킵** (예: 31일 → 2월 없음).
+- 매년 2/29 반복은 평년에 **2/28 로 clamp**.
+- schedule 의 `exclude_repeatings` 에 등록된 회차는 결과에서 제외하되, **`turn` 은 소비하지 않는다**
+  (제외된 회차 이후의 turn 번호가 밀리지 않음).
+
+### 운영 제약 / 주의
+
+- **발생 간격이 긴 반복 (다년 음력 등) 을 긴 구간으로 받으려면**: 1년 window cap 때문에 구간을
+  1년 이하로 쪼개 cursor 없이 연 단위로 재조회해야 한다. 음력은 연 1회 발생이라 한 번의 호출로
+  여러 해 분량을 받을 수 없다.
+- **음력 정확성**: 서버 음력 계산은 `lunar-javascript` 기반이며, iOS 의 `Calendar(.chinese)` (ICU)
+  와 윤달 케이스에서 미세한 차이가 날 수 있다. 현재 Swift 테스트 벡터(1991→1994) 기반 E2E 게이트는
+  통과한다. 불일치가 발견되면 재논의 대상.
 
 ## 에러 응답 형식
 

--- a/functions/controllers/openapi/expandedParams.js
+++ b/functions/controllers/openapi/expandedParams.js
@@ -1,0 +1,18 @@
+
+const ONE_YEAR_MS = 365 * 86400000;
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+// req.query에서 expanded 공통 파라미터 파싱 + limit clamp.
+function parseExpandedParams(req) {
+    const lowerRaw = req.query.lower, upperRaw = req.query.upper;
+    const lower = lowerRaw != null ? Number(lowerRaw) : null;
+    const upper = upperRaw != null ? Number(upperRaw) : null;
+    let limit = req.query.limit != null ? Number(req.query.limit) : DEFAULT_LIMIT;
+    if (!Number.isFinite(limit) || limit <= 0) limit = DEFAULT_LIMIT;
+    if (limit > MAX_LIMIT) limit = MAX_LIMIT;
+    const cursor = req.query.cursor || null;
+    return { lower, upper, limit, cursor };
+}
+
+module.exports = { parseExpandedParams, ONE_YEAR_MS, DEFAULT_LIMIT, MAX_LIMIT };

--- a/functions/controllers/openapi/expandedParams.js
+++ b/functions/controllers/openapi/expandedParams.js
@@ -1,5 +1,5 @@
 
-const ONE_YEAR_MS = 365 * 86400000;
+const ONE_YEAR_SEC = 365 * 86400;
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
 
@@ -15,4 +15,4 @@ function parseExpandedParams(req) {
     return { lower, upper, limit, cursor };
 }
 
-module.exports = { parseExpandedParams, ONE_YEAR_MS, DEFAULT_LIMIT, MAX_LIMIT };
+module.exports = { parseExpandedParams, ONE_YEAR_SEC, DEFAULT_LIMIT, MAX_LIMIT };

--- a/functions/controllers/openapi/scheduleOpenController.js
+++ b/functions/controllers/openapi/scheduleOpenController.js
@@ -1,5 +1,6 @@
 
 const Errors = require('../../models/Errors');
+const { parseExpandedParams, ONE_YEAR_MS } = require('./expandedParams');
 
 class ScheduleOpenController {
 
@@ -30,6 +31,23 @@ class ScheduleOpenController {
         try {
             const events = await this.scheduleEventService.findEvents(userId, lower, upper);
             res.status(200).send(events);
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async getExpandedEvents(req, res) {
+        const userId = req.openUserId;
+        const { lower, upper, limit, cursor } = parseExpandedParams(req);
+        if (!userId || lower == null || upper == null) {
+            throw new Errors.BadRequest('user id, lower or upper is missing.');
+        }
+        if (upper - lower > ONE_YEAR_MS) {
+            throw new Errors.BadRequest('query window exceeds 1 year.');
+        }
+        try {
+            const page = await this.scheduleEventService.findExpandedEvents(userId, lower, upper, limit, cursor);
+            res.status(200).send(page);
         } catch (error) {
             throw new Errors.Application(error);
         }

--- a/functions/controllers/openapi/scheduleOpenController.js
+++ b/functions/controllers/openapi/scheduleOpenController.js
@@ -1,6 +1,6 @@
 
 const Errors = require('../../models/Errors');
-const { parseExpandedParams, ONE_YEAR_MS } = require('./expandedParams');
+const { parseExpandedParams, ONE_YEAR_SEC } = require('./expandedParams');
 
 class ScheduleOpenController {
 
@@ -42,7 +42,7 @@ class ScheduleOpenController {
         if (!userId || lower == null || upper == null) {
             throw new Errors.BadRequest('user id, lower or upper is missing.');
         }
-        if (upper - lower > ONE_YEAR_MS) {
+        if (upper - lower > ONE_YEAR_SEC) {
             throw new Errors.BadRequest('query window exceeds 1 year.');
         }
         try {

--- a/functions/controllers/openapi/todoOpenController.js
+++ b/functions/controllers/openapi/todoOpenController.js
@@ -1,5 +1,6 @@
 
 const Errors = require('../../models/Errors');
+const { parseExpandedParams, ONE_YEAR_MS } = require('./expandedParams');
 
 class TodoOpenController {
 
@@ -49,6 +50,23 @@ class TodoOpenController {
                 const currents = await this.todoService.findCurrentTodo(userId);
                 res.status(200).send(currents);
             }
+        } catch (error) {
+            throw new Errors.Application(error);
+        }
+    }
+
+    async getExpandedTodos(req, res) {
+        const userId = req.openUserId;
+        const { lower, upper, limit, cursor } = parseExpandedParams(req);
+        if (!userId || lower == null || upper == null) {
+            throw new Errors.BadRequest('user id, lower or upper is missing.');
+        }
+        if (upper - lower > ONE_YEAR_MS) {
+            throw new Errors.BadRequest('query window exceeds 1 year.');
+        }
+        try {
+            const page = await this.todoService.findExpandedTodos(userId, lower, upper, limit, cursor);
+            res.status(200).send(page);
         } catch (error) {
             throw new Errors.Application(error);
         }

--- a/functions/controllers/openapi/todoOpenController.js
+++ b/functions/controllers/openapi/todoOpenController.js
@@ -1,6 +1,6 @@
 
 const Errors = require('../../models/Errors');
-const { parseExpandedParams, ONE_YEAR_MS } = require('./expandedParams');
+const { parseExpandedParams, ONE_YEAR_SEC } = require('./expandedParams');
 
 class TodoOpenController {
 
@@ -61,7 +61,7 @@ class TodoOpenController {
         if (!userId || lower == null || upper == null) {
             throw new Errors.BadRequest('user id, lower or upper is missing.');
         }
-        if (upper - lower > ONE_YEAR_MS) {
+        if (upper - lower > ONE_YEAR_SEC) {
             throw new Errors.BadRequest('query window exceeds 1 year.');
         }
         try {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -16,6 +16,8 @@
         "firebase-functions": "^7.0.2",
         "jose": "^4.15.9",
         "jsonwebtoken": "^9.0.2",
+        "lunar-javascript": "^1.7.7",
+        "luxon": "^3.7.2",
         "swagger-ui-express": "^5.0.1",
         "todocalendar-tools": "^0.2.0",
         "yamljs": "^0.3.0"
@@ -6028,6 +6030,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/lunar-javascript": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/lunar-javascript/-/lunar-javascript-1.7.7.tgz",
+      "integrity": "sha512-u/KYiwPIBo/0bT+WWfU7qO1d+aqeB90Tuy4ErXenr2Gam0QcWeezUvtiOIyXR7HbVnW2I1DKfU0NBvzMZhbVQw==",
+      "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -28,6 +28,8 @@
     "firebase-functions": "^7.0.2",
     "jose": "^4.15.9",
     "jsonwebtoken": "^9.0.2",
+    "lunar-javascript": "^1.7.7",
+    "luxon": "^3.7.2",
     "swagger-ui-express": "^5.0.1",
     "todocalendar-tools": "^0.2.0",
     "yamljs": "^0.3.0"

--- a/functions/routes/openapi/scheduleOpenRoutes.js
+++ b/functions/routes/openapi/scheduleOpenRoutes.js
@@ -39,6 +39,10 @@ router.get('/', READ, async (req, res) => {
     await controller.getEvents(req, res);
 });
 
+router.get('/expanded', READ, async (req, res) => {
+    await controller.getExpandedEvents(req, res);
+});
+
 router.get('/:id', READ, async (req, res) => {
     await controller.getEvent(req, res);
 });

--- a/functions/routes/openapi/todoOpenRoutes.js
+++ b/functions/routes/openapi/todoOpenRoutes.js
@@ -43,6 +43,10 @@ router.get('/uncompleted', READ, async (req, res) => {
     await controller.getUncompletedTodos(req, res);
 });
 
+router.get('/expanded', READ, async (req, res) => {
+    await controller.getExpandedTodos(req, res);
+});
+
 router.get('/:id', READ, async (req, res) => {
     await controller.getTodo(req, res);
 });

--- a/functions/services/repeating/data/constants.js
+++ b/functions/services/repeating/data/constants.js
@@ -1,0 +1,15 @@
+// 반복 옵션 discriminator (snake_case) — 클라 EventRepeatingOption+CodableMapper와 1:1
+const OptionType = Object.freeze({
+    everyDay: 'every_day',
+    everyWeek: 'every_week',
+    everyMonth: 'every_month',
+    everyYear: 'every_year',
+    everyYearSomeDay: 'every_year_some_day',
+    lunar: 'lunar_calendar_every_year',
+})
+
+// 앱 weekday: 일=1 ... 토=7 (Times.swift DayOfWeeks rawValue)
+const WEEKDAY_MIN = 1
+const WEEKDAY_MAX = 7
+
+module.exports = { OptionType, WEEKDAY_MIN, WEEKDAY_MAX }

--- a/functions/services/repeating/dateMath.js
+++ b/functions/services/repeating/dateMath.js
@@ -1,0 +1,67 @@
+const { DateTime } = require('luxon')
+
+// 앱 weekday: 일=1 ... 토=7. luxon weekday: 월=1 ... 일=7.
+function appWeekday(dtv) {
+    return (dtv.weekday % 7) + 1
+}
+
+// 그 달에서 같은 요일의 서수(1-based). Foundation weekdayOrdinal과 동일.
+function weekdayOrdinal(dtv) {
+    return Math.floor((dtv.day - 1) / 7) + 1
+}
+
+function fromMs(ms, zone) {
+    return DateTime.fromMillis(ms, { zone })
+}
+
+function addDays(dtv, n) { return dtv.plus({ days: n }) }
+function addMonths(dtv, n) { return dtv.plus({ months: n }) } // luxon clamps invalid day
+function addYears(dtv, n) { return dtv.plus({ years: n }) }   // 2/29 +1y → 2/28 clamp
+
+// day를 세팅하되 그 달에 없는 일자(=clamp 발생)면 null. Swift compareIsNotFloored.
+function dateBySettingDay(dtv, day) {
+    const r = dtv.set({ day })
+    return r.day === day ? r : null
+}
+
+function firstDayOfMonth(dtv) {
+    return dtv.startOf('month')
+}
+
+function lastDayOfMonth(dtv) {
+    return dtv.endOf('month').startOf('day')
+}
+
+// 그 달의 첫 번째 '해당 요일'(앱 rawValue 1-7). 원본 시각 유지. Swift first(day:from:).
+function firstWeekday(dtv, appDay) {
+    const firstOfMonth = firstDayOfMonth(dtv)
+    const firstWd = appWeekday(firstOfMonth)
+    const daysToAdd = (appDay + 7 - firstWd) % 7
+    return dtv.set({ day: 1 + daysToAdd })
+}
+
+// 그 달의 마지막 '같은 요일'. Swift lastOfSameWeekDay.
+function lastOfSameWeekday(dtv) {
+    const wd = appWeekday(dtv)
+    const lastDom = lastDayOfMonth(dtv)
+    const lastWd = appWeekday(lastDom)
+    const daysToMinus = (lastWd - wd + 7) % 7
+    return dtv.set({ day: lastDom.day - daysToMinus })
+}
+
+// originDate에 date의 시/분/초를 입힘. Swift syncTimes.
+function syncTimes(originDate, date) {
+    return originDate.set({ hour: date.hour, minute: date.minute, second: date.second })
+}
+
+// addYear 후 month만 firstMonth로 세팅. Swift dateBySetting{ month = ... }.
+function setMonth(dtv, month) {
+    return dtv.set({ month })
+}
+
+module.exports = {
+    appWeekday, weekdayOrdinal, fromMs,
+    addDays, addMonths, addYears,
+    dateBySettingDay, firstDayOfMonth, lastDayOfMonth,
+    firstWeekday, lastOfSameWeekday, syncTimes, setMonth,
+}

--- a/functions/services/repeating/eventTime.js
+++ b/functions/services/repeating/eventTime.js
@@ -1,0 +1,49 @@
+function lowerBound(time) {
+    switch (time.time_type) {
+        case 'at': return time.timestamp
+        case 'period':
+        case 'allday': return time.period_start
+        default: return null
+    }
+}
+
+function upperBound(time) {
+    switch (time.time_type) {
+        case 'at': return time.timestamp
+        case 'period':
+        case 'allday': return time.period_end
+        default: return null
+    }
+}
+
+// delta(ms)만큼 형태 유지하며 shift. Swift EventTime.shift.
+function shift(time, deltaMs) {
+    switch (time.time_type) {
+        case 'at':
+            return { time_type: 'at', timestamp: time.timestamp + deltaMs }
+        case 'period':
+            return { time_type: 'period', period_start: time.period_start + deltaMs, period_end: time.period_end + deltaMs }
+        case 'allday':
+            return {
+                time_type: 'allday',
+                period_start: time.period_start + deltaMs,
+                period_end: time.period_end + deltaMs,
+                seconds_from_gmt: time.seconds_from_gmt,
+            }
+        default:
+            return { ...time }
+    }
+}
+
+// exclude 매칭 키. Swift customKey와 동일하게 '초' 단위 정수로. (ms → 초 trunc)
+function sec(ms) { return Math.trunc(ms / 1000) }
+function customKey(time) {
+    switch (time.time_type) {
+        case 'at': return `${sec(time.timestamp)}`
+        case 'period': return `${sec(time.period_start)}..<${sec(time.period_end)}`
+        case 'allday': return `${sec(time.period_start)}..<${sec(time.period_end)}+${sec(time.seconds_from_gmt)}`
+        default: return ''
+    }
+}
+
+module.exports = { lowerBound, upperBound, shift, customKey }

--- a/functions/services/repeating/eventTime.js
+++ b/functions/services/repeating/eventTime.js
@@ -35,8 +35,8 @@ function shift(time, deltaMs) {
     }
 }
 
-// exclude 매칭 키. Swift customKey와 동일하게 '초' 단위 정수로. (ms → 초 trunc)
-function sec(ms) { return Math.trunc(ms / 1000) }
+// exclude 매칭 키. Swift customKey(Int(time))와 동일하게 '초' 단위 정수 그대로.
+function sec(v) { return Math.trunc(v) }
 function customKey(time) {
     switch (time.time_type) {
         case 'at': return `${sec(time.timestamp)}`

--- a/functions/services/repeating/lunar/lunarYear.js
+++ b/functions/services/repeating/lunar/lunarYear.js
@@ -1,16 +1,29 @@
 const { DateTime } = require('luxon')
 const { Solar, Lunar } = require('lunar-javascript')
 
+// 음력 (year, month, day) → 양력 Solar. lunar-javascript는 윤달을 음수 month로 표현하는데,
+// 대상 해에 같은 윤달이 없으면 throw한다. 그 경우 평달(abs)로 fallback —
+// Swift Calendar(.chinese)의 ICU resolve(윤달 없으면 평달로 clamp)와 동일한 의도.
+function lunarToSolar(year, month, day) {
+    const months = month < 0 ? [month, Math.abs(month)] : [month]
+    for (const m of months) {
+        try {
+            return Lunar.fromYmd(year, m, day).getSolar()
+        } catch (_) {
+            // 다음 month 후보로 진행
+        }
+    }
+    return null
+}
+
 // currentSec의 zone 기준 날짜 → 음력으로 변환 → 음력 해 +1 → 같은 음력 월/일 → 양력 초(seconds).
-// 시/분/초는 보존.
+// 시/분/초는 보존. resolve 불가(윤달+day overflow 등)면 null → 호출처는 회차 종료로 처리(전개 전체를 깨지 않음).
 function nextLunarYearSec(currentSec, zone) {
     const dtv = DateTime.fromMillis(currentSec * 1000, { zone })
-    const solar = Solar.fromYmd(dtv.year, dtv.month, dtv.day)
-    const lunar = solar.getLunar()
+    const lunar = Solar.fromYmd(dtv.year, dtv.month, dtv.day).getLunar()
 
-    // 음력 해 +1, 같은 음력 월/일을 양력으로
-    const nextLunar = Lunar.fromYmd(lunar.getYear() + 1, lunar.getMonth(), lunar.getDay())
-    const nextSolar = nextLunar.getSolar()
+    const nextSolar = lunarToSolar(lunar.getYear() + 1, lunar.getMonth(), lunar.getDay())
+    if (nextSolar == null) return null
 
     const result = DateTime.fromObject(
         {

--- a/functions/services/repeating/lunar/lunarYear.js
+++ b/functions/services/repeating/lunar/lunarYear.js
@@ -1,0 +1,25 @@
+const { DateTime } = require('luxon')
+const { Solar, Lunar } = require('lunar-javascript')
+
+// currentMs의 zone 기준 날짜 → 음력으로 변환 → 음력 해 +1 → 같은 음력 월/일 → 양력 ms.
+// 시/분/초는 보존.
+function nextLunarYearMs(currentMs, zone) {
+    const dtv = DateTime.fromMillis(currentMs, { zone })
+    const solar = Solar.fromYmd(dtv.year, dtv.month, dtv.day)
+    const lunar = solar.getLunar()
+
+    // 음력 해 +1, 같은 음력 월/일을 양력으로
+    const nextLunar = Lunar.fromYmd(lunar.getYear() + 1, lunar.getMonth(), lunar.getDay())
+    const nextSolar = nextLunar.getSolar()
+
+    const result = DateTime.fromObject(
+        {
+            year: nextSolar.getYear(), month: nextSolar.getMonth(), day: nextSolar.getDay(),
+            hour: dtv.hour, minute: dtv.minute, second: dtv.second,
+        },
+        { zone }
+    )
+    return result.toMillis()
+}
+
+module.exports = { nextLunarYearMs }

--- a/functions/services/repeating/lunar/lunarYear.js
+++ b/functions/services/repeating/lunar/lunarYear.js
@@ -1,10 +1,10 @@
 const { DateTime } = require('luxon')
 const { Solar, Lunar } = require('lunar-javascript')
 
-// currentMs의 zone 기준 날짜 → 음력으로 변환 → 음력 해 +1 → 같은 음력 월/일 → 양력 ms.
+// currentSec의 zone 기준 날짜 → 음력으로 변환 → 음력 해 +1 → 같은 음력 월/일 → 양력 초(seconds).
 // 시/분/초는 보존.
-function nextLunarYearMs(currentMs, zone) {
-    const dtv = DateTime.fromMillis(currentMs, { zone })
+function nextLunarYearSec(currentSec, zone) {
+    const dtv = DateTime.fromMillis(currentSec * 1000, { zone })
     const solar = Solar.fromYmd(dtv.year, dtv.month, dtv.day)
     const lunar = solar.getLunar()
 
@@ -19,7 +19,7 @@ function nextLunarYearMs(currentMs, zone) {
         },
         { zone }
     )
-    return result.toMillis()
+    return Math.round(result.toMillis() / 1000)
 }
 
-module.exports = { nextLunarYearMs }
+module.exports = { nextLunarYearSec }

--- a/functions/services/repeating/minHeap.js
+++ b/functions/services/repeating/minHeap.js
@@ -1,0 +1,63 @@
+// 최소 힙. occurrence 후보를 시각순으로 뽑는 k-way merge에 쓴다.
+// 비교 함수 isLess(a, b)는 a가 b보다 "먼저" 나와야 하면 true.
+class MinHeap {
+    constructor(isLess) {
+        this._items = []
+        this._isLess = isLess
+    }
+
+    get size() {
+        return this._items.length
+    }
+
+    push(item) {
+        const items = this._items
+        items.push(item)
+        this._siftUp(items.length - 1)
+    }
+
+    // 루트(가장 먼저 나올 항목) 제거 후 반환.
+    pop() {
+        const items = this._items
+        const top = items[0]
+        const last = items.pop()
+        if (items.length > 0) {
+            items[0] = last
+            this._siftDown(0)
+        }
+        return top
+    }
+
+    _siftUp(index) {
+        const items = this._items
+        while (index > 0) {
+            const parent = (index - 1) >> 1
+            if (!this._isLess(items[index], items[parent])) break
+            this._swap(index, parent)
+            index = parent
+        }
+    }
+
+    _siftDown(index) {
+        const items = this._items
+        for (;;) {
+            const left = 2 * index + 1
+            const right = left + 1
+            let smallest = index
+            if (left < items.length && this._isLess(items[left], items[smallest])) smallest = left
+            if (right < items.length && this._isLess(items[right], items[smallest])) smallest = right
+            if (smallest === index) break
+            this._swap(index, smallest)
+            index = smallest
+        }
+    }
+
+    _swap(a, b) {
+        const items = this._items
+        const tmp = items[a]
+        items[a] = items[b]
+        items[b] = tmp
+    }
+}
+
+module.exports = { MinHeap }

--- a/functions/services/repeating/nextDate.js
+++ b/functions/services/repeating/nextDate.js
@@ -1,0 +1,138 @@
+const dm = require('./dateMath')
+const { OptionType } = require('./data/constants')
+const { nextLunarYearMs } = require('./lunar/lunarYear')
+
+// dayOfWeeks(앱 1-7 배열)에서 current 다음 요일. Swift Array<DayOfWeeks>.next.
+function nextWeekday(dayOfWeeks, current) {
+    return dayOfWeeks.find((d) => d > current)
+}
+
+function nextEveryWeek(opt, cur) {
+    const sameWeek = (() => {
+        const nx = nextWeekday(opt.dayOfWeeks, cur.weekday)
+        if (nx == null) return null
+        return dm.addDays(cur.dt, nx - cur.weekday)
+    })()
+    if (sameWeek) return sameWeek
+    const first = opt.dayOfWeeks[0]
+    if (first == null) return null
+    return dm.addDays(cur.dt, first - cur.weekday).plus({ days: opt.interval * 7 })
+}
+
+// WeekOrdinal 배열에서 current 기준 다음 ordinal의 날짜. Swift Array<WeekOrdinal>.next.
+function nextOrdinalDate(ordinals, dtv) {
+    const ordinal = dm.weekdayOrdinal(dtv)
+    for (const o of ordinals) {
+        if (o.last) {
+            const last = dm.lastOfSameWeekday(dtv)
+            if (last && last > dtv) return last
+        } else if (ordinal < o.seq) {
+            return dm.addDays(dtv, (o.seq - ordinal) * 7)
+        }
+    }
+    return null
+}
+
+function ordinalValue(o, dtv) {
+    if (o.last) {
+        const last = dm.lastOfSameWeekday(dtv)
+        return last ? dm.weekdayOrdinal(last) : null
+    }
+    return o.seq
+}
+
+// 다음 달 첫 (서수,요일) 날짜. Swift findFirstOrdinalAndWeekDay.
+function firstOrdinalAndWeekDay(ordinal, appWeekDay, monthDtv) {
+    if (ordinal == null || appWeekDay == null) return null
+    const firstWd = dm.firstWeekday(monthDtv, appWeekDay)
+    if (!firstWd) return null
+    const firstOrd = dm.weekdayOrdinal(firstWd)
+    const targetOrd = ordinalValue(ordinal, firstWd)
+    if (targetOrd == null) return null
+    return dm.addDays(firstWd, (targetOrd - firstOrd) * 7)
+}
+
+function nextEveryMonthDays(opt, cur) {
+    const days = opt.selection.days
+    const nx = days.find((d) => d > cur.day)
+    if (nx != null) {
+        const cand = dm.dateBySettingDay(cur.dt, nx)
+        if (cand) return cand
+    }
+    const first = days[0]
+    if (first == null) return null
+    const base = dm.addMonths(dm.firstDayOfMonth(cur.dt), opt.interval)
+    return dm.syncTimes(dm.addDays(base, first - 1), cur.dt)
+}
+
+function nextEveryMonthWeek(opt, cur) {
+    const { ordinals, weekDays } = opt.selection
+    const sameMonth = (cand) => cand && cand.month === cur.month
+    const nx = nextWeekday(weekDays, cur.weekday)
+    if (nx != null) {
+        const c = dm.addDays(cur.dt, nx - cur.weekday)
+        if (sameMonth(c)) return c
+    }
+    if (weekDays[0] != null) {
+        const base = dm.addDays(cur.dt, weekDays[0] - cur.weekday)
+        const c = nextOrdinalDate(ordinals, base)
+        if (sameMonth(c)) return c
+    }
+    const nextMonth = dm.addMonths(cur.dt, opt.interval)
+    const c = firstOrdinalAndWeekDay(ordinals[0], weekDays[0], nextMonth)
+    if (c && c.month === nextMonth.month) return c
+    return null
+}
+
+function nextMonthInterval(months, currentMonth) {
+    const m = months.find((x) => x > currentMonth)
+    return m == null ? null : m - currentMonth
+}
+
+function nextEveryYear(opt, cur) {
+    const sameYear = (cand) => cand && cand.year === cur.year
+    const nx = nextWeekday(opt.dayOfWeeks, cur.weekday)
+    if (nx != null) {
+        const c = dm.addDays(cur.dt, nx - cur.weekday)
+        if (sameYear(c)) return c
+    }
+    if (opt.dayOfWeeks[0] != null) {
+        const base = dm.addDays(cur.dt, opt.dayOfWeeks[0] - cur.weekday)
+        const c = nextOrdinalDate(opt.ordinals, base)
+        if (c && c.month === cur.month && sameYear(c)) return c
+    }
+    const mi = nextMonthInterval(opt.months, cur.month)
+    if (mi != null) {
+        const nextMonth = dm.addMonths(cur.dt, mi)
+        const c = firstOrdinalAndWeekDay(opt.ordinals[0], opt.dayOfWeeks[0], nextMonth)
+        if (c && c.month === nextMonth.month && sameYear(c)) return c
+    }
+    const firstMonth = opt.months[0], firstOrd = opt.ordinals[0], firstWd = opt.dayOfWeeks[0]
+    if (firstMonth == null || firstOrd == null || firstWd == null) return null
+    const nextYearMonth = dm.setMonth(dm.addYears(cur.dt, opt.interval), firstMonth)
+    const c = firstOrdinalAndWeekDay(firstOrd, firstWd, nextYearMonth)
+    if (c && c.month === nextYearMonth.month) return c
+    return null
+}
+
+// 다음 회차 '시작' ms 반환 (null이면 더 없음).
+function nextDateByOption(opt, currentMs) {
+    const zone = opt.zone || 'UTC'
+    const dtv = dm.fromMs(currentMs, opt.type === OptionType.everyDay ? 'UTC' : zone)
+    const cur = { dt: dtv, year: dtv.year, month: dtv.month, day: dtv.day, weekday: dm.appWeekday(dtv) }
+
+    let next = null
+    switch (opt.type) {
+        case OptionType.everyDay: next = dm.addDays(cur.dt, opt.interval); break
+        case OptionType.everyWeek: next = nextEveryWeek(opt, cur); break
+        case OptionType.everyMonth:
+            next = opt.selection.kind === 'days' ? nextEveryMonthDays(opt, cur) : nextEveryMonthWeek(opt, cur); break
+        case OptionType.everyYear: next = nextEveryYear(opt, cur); break
+        case OptionType.everyYearSomeDay: next = dm.addYears(cur.dt, opt.interval); break
+        case OptionType.lunar: return nextLunarYearMs(currentMs, zone)
+        default: return null
+    }
+    return next ? next.toMillis() : null
+}
+
+module.exports = { nextDateByOption }

--- a/functions/services/repeating/nextDate.js
+++ b/functions/services/repeating/nextDate.js
@@ -1,6 +1,6 @@
 const dm = require('./dateMath')
 const { OptionType } = require('./data/constants')
-const { nextLunarYearMs } = require('./lunar/lunarYear')
+const { nextLunarYearSec } = require('./lunar/lunarYear')
 
 // dayOfWeeks(앱 1-7 배열)에서 current 다음 요일. Swift Array<DayOfWeeks>.next.
 function nextWeekday(dayOfWeeks, current) {
@@ -115,10 +115,10 @@ function nextEveryYear(opt, cur) {
     return null
 }
 
-// 다음 회차 '시작' ms 반환 (null이면 더 없음).
-function nextDateByOption(opt, currentMs) {
+// 다음 회차 '시작' 초(seconds) 반환 (null이면 더 없음).
+function nextDateByOption(opt, currentSec) {
     const zone = opt.zone || 'UTC'
-    const dtv = dm.fromMs(currentMs, opt.type === OptionType.everyDay ? 'UTC' : zone)
+    const dtv = dm.fromMs(currentSec * 1000, opt.type === OptionType.everyDay ? 'UTC' : zone)
     const cur = { dt: dtv, year: dtv.year, month: dtv.month, day: dtv.day, weekday: dm.appWeekday(dtv) }
 
     let next = null
@@ -129,10 +129,10 @@ function nextDateByOption(opt, currentMs) {
             next = opt.selection.kind === 'days' ? nextEveryMonthDays(opt, cur) : nextEveryMonthWeek(opt, cur); break
         case OptionType.everyYear: next = nextEveryYear(opt, cur); break
         case OptionType.everyYearSomeDay: next = dm.addYears(cur.dt, opt.interval); break
-        case OptionType.lunar: return nextLunarYearMs(currentMs, zone)
+        case OptionType.lunar: return nextLunarYearSec(currentSec, zone)
         default: return null
     }
-    return next ? next.toMillis() : null
+    return next ? Math.round(next.toMillis() / 1000) : null
 }
 
 module.exports = { nextDateByOption }

--- a/functions/services/repeating/occurrencePaging.js
+++ b/functions/services/repeating/occurrencePaging.js
@@ -1,128 +1,149 @@
 const { RepeatTimeEnumerator } = require('./repeatTimeEnumerator')
+const { MinHeap } = require('./minHeap')
 const et = require('./eventTime')
 
-function encodeCursor(c) {
-    return Buffer.from(JSON.stringify(c), 'utf8').toString('base64url')
+// ── cursor: 통합 스트림의 절단점 하나(전역 고정 크기 { t, id }) ──
+function encodeCursor(cut) {
+    return Buffer.from(JSON.stringify(cut), 'utf8').toString('base64url')
 }
-function decodeCursor(s) {
-    try { return JSON.parse(Buffer.from(s, 'base64url').toString('utf8')) }
-    catch (_) { return null }
+function decodeCursor(token) {
+    try {
+        return JSON.parse(Buffer.from(token, 'base64url').toString('utf8'))
+    } catch (_) {
+        return null
+    }
 }
 
-function occurrenceId(originId, turn) { return `${originId}:${turn}` }
+// occurrence 식별/정렬 키. 같은 시각 tiebreak로 쓰여 페이징을 결정적으로 만든다.
+function occurrenceId(originId, turn) {
+    return `${originId}:${turn}`
+}
 
-// 한 이벤트의 occurrence 생성기(lazy).
-// 각 항목: { t: lowerBound(ms), id, originId, turn, event_time }
+// 한 회차를 통합 스트림 노드로. (t, id)가 정렬 키.
+function toNode(originId, occurrence) {
+    return {
+        t: et.lowerBound(occurrence.time),
+        id: occurrenceId(originId, occurrence.turn),
+        originId,
+        turn: occurrence.turn,
+        event_time: occurrence.time,
+    }
+}
+
+// 한 이벤트의 occurrence를 시각순으로 하나씩 내는 lazy 스트림.
+// cursor(afterT/afterId) '이후' + 조회 구간 [lower, upper] 안의 것만. 없으면 next()가 null.
 function makeEventStream(event, lower, upper, afterT, afterId) {
     const originId = event.uuid
-    const evTime = event.event_time
-    const repeating = event.repeating
 
-    function passesCursor(t, id) {
+    const isAfterCursor = (t, id) => {
         if (afterT == null) return true
         return t > afterT || (t === afterT && id > afterId)
     }
-
-    // 비반복: window 겹치면 단일 occurrence(turn 1)
-    if (!repeating || !repeating.option) {
-        const t = et.lowerBound(evTime)
-        let done = false
-        return { next: () => {
-            if (done) return null
-            done = true
-            if (t < lower || t > upper) return null
-            const id = occurrenceId(originId, 1)
-            if (!passesCursor(t, id)) return null
-            return { t, id, originId, turn: 1, event_time: evTime }
-        } }
+    // 구간/cursor 통과하면 노드, 아니면 null
+    const accept = (occurrence) => {
+        const t = et.lowerBound(occurrence.time)
+        if (t < lower || t > upper) return null
+        if (!isAfterCursor(t, occurrenceId(originId, occurrence.turn))) return null
+        return toNode(originId, occurrence)
     }
 
-    // 반복: seek로 cursor/lower 직전까지 turn 회복 → window 안 lazy emit
-    const en = new RepeatTimeEnumerator(repeating.option, {
-        until: repeating.end ?? null,
-        endCount: repeating.end_count ?? null,
+    // 비반복: window에 겹치면 turn 1짜리 단일 occurrence
+    if (!event.repeating || !event.repeating.option) {
+        let emitted = false
+        return {
+            next() {
+                if (emitted) return null
+                emitted = true
+                return accept({ time: event.event_time, turn: 1 })
+            },
+        }
+    }
+
+    // 반복: seek로 cursor/lower 직전 turn을 회복한 뒤 window 안에서 한 회차씩 emit
+    const enumerator = new RepeatTimeEnumerator(event.repeating.option, {
+        until: event.repeating.end ?? null,
+        endCount: event.repeating.end_count ?? null,
         excludes: new Set(Array.isArray(event.exclude_repeatings) ? event.exclude_repeatings : []),
     })
     const seekTo = afterT != null ? Math.max(lower, afterT) : lower
-    let cursor = en.seekTurnUntil(evTime, seekTo)
-    let consideredStart = false
+    let cursor = enumerator.seekTurnUntil(event.event_time, seekTo)
+    let startConsidered = false // seek 결과(cursor) 자체가 첫 후보일 수 있어 한 번 검사
 
-    function toItem(rt) {
-        return { t: et.lowerBound(rt.time), id: occurrenceId(originId, rt.turn), originId, turn: rt.turn, event_time: rt.time }
-    }
-
-    return { next: () => {
-        for (;;) {
-            if (!consideredStart) {
-                consideredStart = true
-                const t0 = et.lowerBound(cursor.time)
-                const id0 = occurrenceId(originId, cursor.turn)
-                if (t0 >= lower && t0 <= upper && passesCursor(t0, id0)) {
-                    return toItem(cursor)
-                }
+    return {
+        next() {
+            if (!startConsidered) {
+                startConsidered = true
+                const node = accept(cursor)
+                if (node) return node
             }
-            const next = en.nextEventTime(cursor, upper)
-            if (next == null) return null
-            cursor = next
-            const t = et.lowerBound(next.time)
-            if (t > upper) return null
-            if (t < lower) continue
-            if (!passesCursor(t, occurrenceId(originId, next.turn))) continue
-            return toItem(next)
-        }
-    } }
+            for (;;) {
+                const occurrence = enumerator.nextEventTime(cursor, upper)
+                if (occurrence == null) return null
+                cursor = occurrence
+                if (et.lowerBound(occurrence.time) > upper) return null
+                const node = accept(occurrence)
+                if (node) return node
+                // lower 이전이거나 cursor 이전이면 다음 회차로
+            }
+        },
+    }
 }
 
-function less(a, b) { return a.t < b.t || (a.t === b.t && a.id < b.id) }
-class MinHeap {
-    constructor() { this.a = [] }
-    get size() { return this.a.length }
-    push(x) { const a = this.a; a.push(x); let i = a.length - 1
-        while (i > 0) { const p = (i - 1) >> 1; if (less(a[i], a[p])) { [a[i], a[p]] = [a[p], a[i]]; i = p } else break } }
-    pop() { const a = this.a; const top = a[0]; const last = a.pop()
-        if (a.length) { a[0] = last; let i = 0
-            for (;;) { const l = 2 * i + 1, r = l + 1; let m = i
-                if (l < a.length && less(a[l], a[m])) m = l
-                if (r < a.length && less(a[r], a[m])) m = r
-                if (m === i) break; [a[i], a[m]] = [a[m], a[i]]; i = m } }
-        return top }
+// (t ASC, id ASC) — heap이 가장 이른 occurrence를 위로.
+function earlier(a, b) {
+    return a.t < b.t || (a.t === b.t && a.id < b.id)
 }
 
+// 여러 이벤트의 occurrence를 k-way merge로 시각순 통합해 limit개를 한 페이지로.
+// 각 스트림은 후보 1개씩만 heap에 두고(heap 크기 = 활성 이벤트 수), pop↔push를 번갈아 진행.
 function buildExpandedPage(events, lower, upper, limit, cursor) {
-    const cur = cursor ? decodeCursor(cursor) : null
-    const afterT = cur ? cur.t : null
-    const afterId = cur ? cur.id : null
+    const cut = cursor ? decodeCursor(cursor) : null
+    const afterT = cut ? cut.t : null
+    const afterId = cut ? cut.id : null
 
-    const streams = events.map((ev) => makeEventStream(ev, lower, upper, afterT, afterId))
-    const heap = new MinHeap()
-    streams.forEach((s, idx) => { const first = s.next(); if (first) heap.push({ ...first, idx }) })
+    const streams = events.map((event) => makeEventStream(event, lower, upper, afterT, afterId))
+    const heap = new MinHeap(earlier)
+    streams.forEach((stream, streamIndex) => {
+        const node = stream.next()
+        if (node) heap.push({ ...node, streamIndex })
+    })
 
     const occurrences = []
-    const eventsMap = {}
+    const eventsMeta = {}
     let lastPopped = null
+
     while (occurrences.length < limit && heap.size > 0) {
-        const top = heap.pop()
-        lastPopped = top
-        occurrences.push({ origin_event_id: top.originId, turn: top.turn, event_time: top.event_time })
-        if (!eventsMap[top.originId]) eventsMap[top.originId] = normalizeOrigin(events[top.idx])
-        const nx = streams[top.idx].next()
-        if (nx) heap.push({ ...nx, idx: top.idx })
+        const node = heap.pop()
+        lastPopped = node
+        occurrences.push({
+            origin_event_id: node.originId,
+            turn: node.turn,
+            event_time: node.event_time,
+        })
+        if (!eventsMeta[node.originId]) {
+            eventsMeta[node.originId] = normalizeOrigin(events[node.streamIndex])
+        }
+        const refill = streams[node.streamIndex].next() // 방금 pop한 스트림의 다음 후보로 채우기
+        if (refill) heap.push({ ...refill, streamIndex: node.streamIndex })
     }
 
     const hasMore = occurrences.length === limit && heap.size > 0
-    const next_cursor = hasMore && lastPopped ? encodeCursor({ t: lastPopped.t, id: lastPopped.id }) : null
+    const next_cursor = hasMore ? encodeCursor({ t: lastPopped.t, id: lastPopped.id }) : null
 
-    return { events: eventsMap, occurrences, next_cursor }
+    return { events: eventsMeta, occurrences, next_cursor }
 }
 
-function normalizeOrigin(ev) {
-    const o = {
-        uuid: ev.uuid, name: ev.name, is_todo: ev.is_todo === true,
-        event_time: ev.event_time,
+// 원본 메타 1벌(반복 규칙 포함). occurrence엔 안 싣고 events{}에 origin당 한 번만.
+function normalizeOrigin(event) {
+    const meta = {
+        uuid: event.uuid,
+        name: event.name,
+        is_todo: event.is_todo === true,
+        event_time: event.event_time,
     }
-    if (ev.event_tag_id != null) o.event_tag_id = ev.event_tag_id
-    if (ev.repeating != null) o.repeating = ev.repeating
-    return o
+    if (event.event_tag_id != null) meta.event_tag_id = event.event_tag_id
+    if (event.repeating != null) meta.repeating = event.repeating
+    return meta
 }
 
 module.exports = { buildExpandedPage, encodeCursor, decodeCursor, occurrenceId }

--- a/functions/services/repeating/occurrencePaging.js
+++ b/functions/services/repeating/occurrencePaging.js
@@ -1,0 +1,128 @@
+const { RepeatTimeEnumerator } = require('./repeatTimeEnumerator')
+const et = require('./eventTime')
+
+function encodeCursor(c) {
+    return Buffer.from(JSON.stringify(c), 'utf8').toString('base64url')
+}
+function decodeCursor(s) {
+    try { return JSON.parse(Buffer.from(s, 'base64url').toString('utf8')) }
+    catch (_) { return null }
+}
+
+function occurrenceId(originId, turn) { return `${originId}:${turn}` }
+
+// 한 이벤트의 occurrence 생성기(lazy).
+// 각 항목: { t: lowerBound(ms), id, originId, turn, event_time }
+function makeEventStream(event, lower, upper, afterT, afterId) {
+    const originId = event.uuid
+    const evTime = event.event_time
+    const repeating = event.repeating
+
+    function passesCursor(t, id) {
+        if (afterT == null) return true
+        return t > afterT || (t === afterT && id > afterId)
+    }
+
+    // 비반복: window 겹치면 단일 occurrence(turn 1)
+    if (!repeating || !repeating.option) {
+        const t = et.lowerBound(evTime)
+        let done = false
+        return { next: () => {
+            if (done) return null
+            done = true
+            if (t < lower || t > upper) return null
+            const id = occurrenceId(originId, 1)
+            if (!passesCursor(t, id)) return null
+            return { t, id, originId, turn: 1, event_time: evTime }
+        } }
+    }
+
+    // 반복: seek로 cursor/lower 직전까지 turn 회복 → window 안 lazy emit
+    const en = new RepeatTimeEnumerator(repeating.option, {
+        until: repeating.end ?? null,
+        endCount: repeating.end_count ?? null,
+        excludes: new Set(Array.isArray(event.exclude_repeatings) ? event.exclude_repeatings : []),
+    })
+    const seekTo = afterT != null ? Math.max(lower, afterT) : lower
+    let cursor = en.seekTurnUntil(evTime, seekTo)
+    let consideredStart = false
+
+    function toItem(rt) {
+        return { t: et.lowerBound(rt.time), id: occurrenceId(originId, rt.turn), originId, turn: rt.turn, event_time: rt.time }
+    }
+
+    return { next: () => {
+        for (;;) {
+            if (!consideredStart) {
+                consideredStart = true
+                const t0 = et.lowerBound(cursor.time)
+                const id0 = occurrenceId(originId, cursor.turn)
+                if (t0 >= lower && t0 <= upper && passesCursor(t0, id0)) {
+                    return toItem(cursor)
+                }
+            }
+            const next = en.nextEventTime(cursor, upper)
+            if (next == null) return null
+            cursor = next
+            const t = et.lowerBound(next.time)
+            if (t > upper) return null
+            if (t < lower) continue
+            if (!passesCursor(t, occurrenceId(originId, next.turn))) continue
+            return toItem(next)
+        }
+    } }
+}
+
+function less(a, b) { return a.t < b.t || (a.t === b.t && a.id < b.id) }
+class MinHeap {
+    constructor() { this.a = [] }
+    get size() { return this.a.length }
+    push(x) { const a = this.a; a.push(x); let i = a.length - 1
+        while (i > 0) { const p = (i - 1) >> 1; if (less(a[i], a[p])) { [a[i], a[p]] = [a[p], a[i]]; i = p } else break } }
+    pop() { const a = this.a; const top = a[0]; const last = a.pop()
+        if (a.length) { a[0] = last; let i = 0
+            for (;;) { const l = 2 * i + 1, r = l + 1; let m = i
+                if (l < a.length && less(a[l], a[m])) m = l
+                if (r < a.length && less(a[r], a[m])) m = r
+                if (m === i) break; [a[i], a[m]] = [a[m], a[i]]; i = m } }
+        return top }
+}
+
+function buildExpandedPage(events, lower, upper, limit, cursor) {
+    const cur = cursor ? decodeCursor(cursor) : null
+    const afterT = cur ? cur.t : null
+    const afterId = cur ? cur.id : null
+
+    const streams = events.map((ev) => makeEventStream(ev, lower, upper, afterT, afterId))
+    const heap = new MinHeap()
+    streams.forEach((s, idx) => { const first = s.next(); if (first) heap.push({ ...first, idx }) })
+
+    const occurrences = []
+    const eventsMap = {}
+    let lastPopped = null
+    while (occurrences.length < limit && heap.size > 0) {
+        const top = heap.pop()
+        lastPopped = top
+        occurrences.push({ origin_event_id: top.originId, turn: top.turn, event_time: top.event_time })
+        if (!eventsMap[top.originId]) eventsMap[top.originId] = normalizeOrigin(events[top.idx])
+        const nx = streams[top.idx].next()
+        if (nx) heap.push({ ...nx, idx: top.idx })
+    }
+
+    const hasMore = occurrences.length === limit && heap.size > 0
+    const next_cursor = hasMore && lastPopped ? encodeCursor({ t: lastPopped.t, id: lastPopped.id }) : null
+
+    return { events: eventsMap, occurrences, next_cursor }
+}
+
+function normalizeOrigin(ev) {
+    const o = {
+        uuid: ev.uuid, name: ev.name, is_todo: ev.is_todo === true,
+        event_time: ev.event_time,
+    }
+    if (ev.event_tag_id != null) o.event_tag_id = ev.event_tag_id
+    if (ev.repeating != null) o.repeating = ev.repeating
+    return o
+}
+
+module.exports = { buildExpandedPage, encodeCursor, decodeCursor, occurrenceId }

--- a/functions/services/repeating/options.js
+++ b/functions/services/repeating/options.js
@@ -1,0 +1,45 @@
+const { OptionType } = require('./data/constants')
+
+// WeekOrdinal JSON → { last: true } | { seq: n }
+function parseWeekOrdinal(o) {
+    return o && o.isLast === true ? { last: true } : { seq: o.seq }
+}
+
+// repeating.option(JSON) → 정규화 옵션. 알 수 없는 타입이면 null.
+function parseRepeatingOption(opt) {
+    if (!opt || typeof opt.optionType !== 'string') return null
+    const type = opt.optionType
+    const zone = opt.timeZone || 'UTC'
+    switch (type) {
+        case OptionType.everyDay:
+            return { type, interval: opt.interval }
+        case OptionType.everyWeek:
+            return { type, interval: opt.interval, zone, dayOfWeeks: (opt.dayOfWeek || []).slice() }
+        case OptionType.everyMonth: {
+            const sel = opt.monthDaySelection || {}
+            const selection = Array.isArray(sel.days)
+                ? { kind: 'days', days: sel.days.slice() }
+                : {
+                    kind: 'week',
+                    ordinals: (sel.weekOrdinals || []).map(parseWeekOrdinal),
+                    weekDays: (sel.weekDays || []).slice(),
+                }
+            return { type, interval: opt.interval, zone, selection }
+        }
+        case OptionType.everyYear:
+            return {
+                type, interval: opt.interval, zone,
+                months: (opt.months || []).slice(),
+                ordinals: (opt.weekOrdinals || []).map(parseWeekOrdinal),
+                dayOfWeeks: (opt.dayOfWeek || []).slice(),
+            }
+        case OptionType.everyYearSomeDay:
+            return { type, interval: opt.interval, zone, month: opt.month, day: opt.day }
+        case OptionType.lunar:
+            return { type, zone, month: opt.month, day: opt.day }
+        default:
+            return null
+    }
+}
+
+module.exports = { parseRepeatingOption }

--- a/functions/services/repeating/repeatTimeEnumerator.js
+++ b/functions/services/repeating/repeatTimeEnumerator.js
@@ -1,0 +1,47 @@
+const { parseRepeatingOption } = require('./options')
+const { nextDateByOption } = require('./nextDate')
+const et = require('./eventTime')
+
+const ITERATION_GUARD = 10000
+
+class RepeatTimeEnumerator {
+    constructor(optionJson, end = {}) {
+        this.option = parseRepeatingOption(optionJson)
+        this.until = end.until ?? null
+        this.endCount = end.endCount ?? null
+        this.excludes = end.excludes ?? new Set()
+    }
+    isValid() { return this.option != null }
+
+    nextEventTime(from, until, _depth = 0) {
+        if (this.option == null || _depth > ITERATION_GUARD) return null
+        const currentStart = et.lowerBound(from.time)
+        const nextStart = nextDateByOption(this.option, currentStart)
+        if (nextStart == null) return null
+        const deltaMs = nextStart - currentStart
+        const nextTime = et.shift(from.time, deltaMs)
+        if (this.excludes.has(et.customKey(nextTime))) {
+            return this.nextEventTime({ time: nextTime, turn: from.turn }, until, _depth + 1)
+        }
+        const next = { time: nextTime, turn: from.turn + 1 }
+        if (until != null && et.upperBound(nextTime) > until) return null
+        if (this.endCount != null && next.turn > this.endCount) return null
+        return next
+    }
+
+    nextEventTimes(start, until) {
+        const out = []
+        let cursor = start
+        let guard = 0
+        for (;;) {
+            const next = this.nextEventTime(cursor, until)
+            if (next == null) break
+            out.push(next)
+            cursor = next
+            if (++guard > ITERATION_GUARD) break
+        }
+        return out
+    }
+}
+
+module.exports = { RepeatTimeEnumerator, ITERATION_GUARD }

--- a/functions/services/repeating/repeatTimeEnumerator.js
+++ b/functions/services/repeating/repeatTimeEnumerator.js
@@ -24,6 +24,7 @@ class RepeatTimeEnumerator {
             return this.nextEventTime({ time: nextTime, turn: from.turn }, until, _depth + 1)
         }
         const next = { time: nextTime, turn: from.turn + 1 }
+        if (this.until != null && et.upperBound(nextTime) > this.until) return null
         if (until != null && et.upperBound(nextTime) > until) return null
         if (this.endCount != null && next.turn > this.endCount) return null
         return next

--- a/functions/services/repeating/repeatTimeEnumerator.js
+++ b/functions/services/repeating/repeatTimeEnumerator.js
@@ -42,6 +42,36 @@ class RepeatTimeEnumerator {
         }
         return out
     }
+
+    // startTime(첫 회차, turn 1)부터 t 직전까지 전진해 { time, turn } 회복.
+    // t '이상'은 결과에서 제외(다음 emit이 시작될 지점). §4 Phase 1.
+    // daily는 닫힌 산술로 점프해 호출 횟수를 줄이고, 나머지는 주기 loop로 맞춘다.
+    seekTurnUntil(startTime, t) {
+        if (this.option == null) return { time: startTime, turn: 1 }
+        const lb = (time) => et.lowerBound(time)
+        if (lb(startTime) >= t) return { time: startTime, turn: 1 }
+
+        let cursor = { time: startTime, turn: 1 }
+        // daily 닫힌 산술 점프 (exclude 없을 때만; 있으면 loop fallback)
+        if (this.option.type === 'every_day' && this.excludes.size === 0) {
+            const stepMs = this.option.interval * 86400000
+            const n = Math.floor((t - 1 - lb(startTime)) / stepMs)
+            if (n > 0) {
+                const jumpedStart = lb(startTime) + n * stepMs
+                cursor = { time: et.shift(startTime, jumpedStart - lb(startTime)), turn: 1 + n }
+            }
+        }
+        // 나머지(또는 daily 잔여)는 주기 loop로 정확히 (hard guard 내)
+        let guard = 0
+        for (;;) {
+            const next = this.nextEventTime(cursor, null)
+            if (next == null) break
+            if (lb(next.time) >= t) break
+            cursor = next
+            if (++guard > ITERATION_GUARD) break
+        }
+        return cursor
+    }
 }
 
 module.exports = { RepeatTimeEnumerator, ITERATION_GUARD }

--- a/functions/services/repeating/repeatTimeEnumerator.js
+++ b/functions/services/repeating/repeatTimeEnumerator.js
@@ -2,8 +2,6 @@ const { parseRepeatingOption } = require('./options')
 const { nextDateByOption } = require('./nextDate')
 const et = require('./eventTime')
 
-const ITERATION_GUARD = 10000
-
 class RepeatTimeEnumerator {
     constructor(optionJson, end = {}) {
         this.option = parseRepeatingOption(optionJson)
@@ -11,68 +9,70 @@ class RepeatTimeEnumerator {
         this.endCount = end.endCount ?? null
         this.excludes = end.excludes ?? new Set()
     }
+
     isValid() { return this.option != null }
 
-    nextEventTime(from, until, _depth = 0) {
-        if (this.option == null || _depth > ITERATION_GUARD) return null
-        const currentStart = et.lowerBound(from.time)
-        const nextStart = nextDateByOption(this.option, currentStart)
-        if (nextStart == null) return null
-        const deltaMs = nextStart - currentStart
-        const nextTime = et.shift(from.time, deltaMs)
-        if (this.excludes.has(et.customKey(nextTime))) {
-            return this.nextEventTime({ time: nextTime, turn: from.turn }, until, _depth + 1)
+    // from 다음 회차. 더 없으면 null.
+    // exclude된 회차는 turn을 소비하지 않고 건너뛴다 (Swift와 동일하게 종료 조건보다 먼저 판정).
+    // 종료: 이벤트 자체 종료일(this.until = repeating.end)과 조회 상한(until 파라미터)을 둘 다 cap, 그다음 endCount.
+    nextEventTime(from, until) {
+        if (this.option == null) return null
+
+        let cursorTime = from.time
+        for (;;) {
+            const currentStart = et.lowerBound(cursorTime)
+            const nextStart = nextDateByOption(this.option, currentStart)
+            if (nextStart == null) return null
+
+            const nextTime = et.shift(cursorTime, nextStart - currentStart)
+            if (this.excludes.has(et.customKey(nextTime))) {
+                cursorTime = nextTime
+                continue
+            }
+            if (this.until != null && et.upperBound(nextTime) > this.until) return null
+            if (until != null && et.upperBound(nextTime) > until) return null
+
+            const next = { time: nextTime, turn: from.turn + 1 }
+            if (this.endCount != null && next.turn > this.endCount) return null
+            return next
         }
-        const next = { time: nextTime, turn: from.turn + 1 }
-        if (this.until != null && et.upperBound(nextTime) > this.until) return null
-        if (until != null && et.upperBound(nextTime) > until) return null
-        if (this.endCount != null && next.turn > this.endCount) return null
-        return next
     }
 
+    // start 다음부터 끝까지 모든 회차. 조회 상한(until)·종료일·endCount가 상한이라 자연 종료.
     nextEventTimes(start, until) {
         const out = []
         let cursor = start
-        let guard = 0
-        for (;;) {
-            const next = this.nextEventTime(cursor, until)
-            if (next == null) break
+        let next
+        while ((next = this.nextEventTime(cursor, until)) != null) {
             out.push(next)
             cursor = next
-            if (++guard > ITERATION_GUARD) break
         }
         return out
     }
 
-    // startTime(첫 회차, turn 1)부터 t 직전까지 전진해 { time, turn } 회복.
-    // t '이상'은 결과에서 제외(다음 emit이 시작될 지점). §4 Phase 1.
-    // daily는 닫힌 산술로 점프해 호출 횟수를 줄이고, 나머지는 주기 loop로 맞춘다.
+    // startTime(첫 회차, turn 1)부터 t 직전까지 전진해 { time, turn } 회복. §4 Phase 1.
+    // daily는 회차 간격이 일정(interval일)해 닫힌 산술로 단번에 점프하고,
+    // 그 외 옵션은 한 회차씩 순회한다(경과 주기 수에 bound — daily처럼 일 단위로 폭발하지 않음).
     seekTurnUntil(startTime, t) {
         if (this.option == null) return { time: startTime, turn: 1 }
-        const lb = (time) => et.lowerBound(time)
-        if (lb(startTime) >= t) return { time: startTime, turn: 1 }
+        const lowerOf = (time) => et.lowerBound(time)
+        if (lowerOf(startTime) >= t) return { time: startTime, turn: 1 }
 
         let cursor = { time: startTime, turn: 1 }
-        // daily 닫힌 산술 점프 (exclude 없을 때만; 있으면 loop fallback)
         if (this.option.type === 'every_day' && this.excludes.size === 0) {
             const stepSec = this.option.interval * 86400
-            const n = Math.floor((t - 1 - lb(startTime)) / stepSec)
-            if (n > 0) {
-                const jumpedStart = lb(startTime) + n * stepSec
-                cursor = { time: et.shift(startTime, jumpedStart - lb(startTime)), turn: 1 + n }
+            const steps = Math.floor((t - 1 - lowerOf(startTime)) / stepSec)
+            if (steps > 0) {
+                const jumpedSec = lowerOf(startTime) + steps * stepSec
+                cursor = { time: et.shift(startTime, jumpedSec - lowerOf(startTime)), turn: 1 + steps }
             }
         }
-        // 나머지(또는 daily 잔여)는 주기 loop로 정확히 (hard guard 내)
-        let guard = 0
-        for (;;) {
-            const next = this.nextEventTime(cursor, null)
-            if (next == null) break
-            if (lb(next.time) >= t) break
+        let next
+        while ((next = this.nextEventTime(cursor, null)) != null && lowerOf(next.time) < t) {
             cursor = next
-            if (++guard > ITERATION_GUARD) break
         }
         return cursor
     }
 }
 
-module.exports = { RepeatTimeEnumerator, ITERATION_GUARD }
+module.exports = { RepeatTimeEnumerator }

--- a/functions/services/repeating/repeatTimeEnumerator.js
+++ b/functions/services/repeating/repeatTimeEnumerator.js
@@ -54,10 +54,10 @@ class RepeatTimeEnumerator {
         let cursor = { time: startTime, turn: 1 }
         // daily 닫힌 산술 점프 (exclude 없을 때만; 있으면 loop fallback)
         if (this.option.type === 'every_day' && this.excludes.size === 0) {
-            const stepMs = this.option.interval * 86400000
-            const n = Math.floor((t - 1 - lb(startTime)) / stepMs)
+            const stepSec = this.option.interval * 86400
+            const n = Math.floor((t - 1 - lb(startTime)) / stepSec)
             if (n > 0) {
-                const jumpedStart = lb(startTime) + n * stepMs
+                const jumpedStart = lb(startTime) + n * stepSec
                 cursor = { time: et.shift(startTime, jumpedStart - lb(startTime)), turn: 1 + n }
             }
         }

--- a/functions/services/scheduleEventService.js
+++ b/functions/services/scheduleEventService.js
@@ -2,6 +2,7 @@ const { DataChangeLog, DataChangeCase } = require("../models/DataChangeLog");
 const DataTypes = require("../models/DataTypes");
 const Errors = require("../models/Errors");
 const { chunk } = require("../Utils/functions")
+const { buildExpandedPage } = require("./repeating/occurrencePaging")
 
 class ScheduleEventService {
 
@@ -27,6 +28,19 @@ class ScheduleEventService {
             return this.scheduleEventRepository.findEvents(ids)
         })
         return (await Promise.all(loadEvents)).flat();
+    }
+
+    async findExpandedEvents(userId, lower, upper, limit, cursor) {
+        const eventIds = await this.eventTimeRangeService.eventIds(userId, false, lower, upper);
+        if(eventIds.length === 0) {
+            return { events: {}, occurrences: [], next_cursor: null }
+        }
+        const eventIdSlices = chunk(eventIds, 30)
+        const loaded = (await Promise.all(eventIdSlices.map((ids) => {
+            return this.scheduleEventRepository.findEvents(ids)
+        }))).flat()
+        const plain = loaded.map((event) => ({ ...event.toJSON(), is_todo: false }))
+        return buildExpandedPage(plain, Number(lower), Number(upper), Number(limit), cursor)
     }
 
     async makeEvent(userId, payload) {

--- a/functions/services/todoEventService.js
+++ b/functions/services/todoEventService.js
@@ -2,6 +2,7 @@
 const DataChangeLog = require('../models/DataChangeLog');
 const DataTypes = require('../models/DataTypes');
 const { chunk } = require('../Utils/functions');
+const { buildExpandedPage } = require('./repeating/occurrencePaging');
 
 class TodoEventService {
 
@@ -24,6 +25,19 @@ class TodoEventService {
             return this.todoRepository.findTodos(ids)
         })
         return (await Promise.all(loadTodods)).flat();
+    }
+
+    async findExpandedTodos(userId, lower, upper, limit, cursor) {
+        const eventIds = await this.eventTimeRangeService.eventIds(userId, true, lower, upper);
+        if(eventIds.length === 0) {
+            return { events: {}, occurrences: [], next_cursor: null }
+        }
+        const eventIdSlices = chunk(eventIds, 30)
+        const loaded = (await Promise.all(eventIdSlices.map((ids) => {
+            return this.todoRepository.findTodos(ids)
+        }))).flat()
+        const plain = loaded.map((todo) => ({ ...todo.toJSON(), is_todo: true }))
+        return buildExpandedPage(plain, Number(lower), Number(upper), Number(limit), cursor)
     }
 
     async findCurrentTodo(userId) {

--- a/functions/test/controllers/openapi/expandedController.test.js
+++ b/functions/test/controllers/openapi/expandedController.test.js
@@ -1,0 +1,76 @@
+
+const assert = require('assert');
+const TodoOpenController = require('../../../controllers/openapi/todoOpenController');
+const ScheduleOpenController = require('../../../controllers/openapi/scheduleOpenController');
+const Errors = require('../../../models/Errors');
+
+const YEAR = 365 * 86400000;
+
+function makeRes() {
+    return {
+        statusCode: null, body: null,
+        status(c) { this.statusCode = c; return this; },
+        send(d) { this.body = d; return this; }
+    };
+}
+
+function stubTodoService() {
+    return {
+        lastArgs: null,
+        async findExpandedTodos(userId, lower, upper, limit, cursor) {
+            this.lastArgs = { userId, lower, upper, limit, cursor };
+            return { events: {}, occurrences: [], next_cursor: null };
+        }
+    };
+}
+
+describe('getExpandedTodos', () => {
+
+    it('정상: 200 + service 위임, limit default 100', async () => {
+        const svc = stubTodoService();
+        const ctrl = new TodoOpenController(svc);
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(10 * 86400000) } };
+        const res = makeRes();
+        await ctrl.getExpandedTodos(req, res);
+        assert.equal(res.statusCode, 200);
+        assert.equal(svc.lastArgs.limit, 100);
+    });
+
+    it('lower/upper 누락 → BadRequest', async () => {
+        const ctrl = new TodoOpenController(stubTodoService());
+        await assert.rejects(ctrl.getExpandedTodos({ openUserId: 'u', query: { lower: '0' } }, makeRes()), Errors.BadRequest);
+    });
+
+    it('window > 1년 → BadRequest', async () => {
+        const ctrl = new TodoOpenController(stubTodoService());
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(YEAR + 86400000) } };
+        await assert.rejects(ctrl.getExpandedTodos(req, makeRes()), Errors.BadRequest);
+    });
+
+    it('limit > 500 → 500으로 clamp', async () => {
+        const svc = stubTodoService();
+        const ctrl = new TodoOpenController(svc);
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(86400000), limit: '9999' } };
+        await ctrl.getExpandedTodos(req, makeRes());
+        assert.equal(svc.lastArgs.limit, 500);
+    });
+
+    it('cursor passthrough', async () => {
+        const svc = stubTodoService();
+        const ctrl = new TodoOpenController(svc);
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(86400000), cursor: 'abc' } };
+        await ctrl.getExpandedTodos(req, makeRes());
+        assert.equal(svc.lastArgs.cursor, 'abc');
+    });
+});
+
+describe('getExpandedEvents', () => {
+
+    it('정상 위임 200', async () => {
+        const svc = { async findExpandedEvents() { return { events: {}, occurrences: [], next_cursor: null }; } };
+        const ctrl = new ScheduleOpenController(svc);
+        const res = makeRes();
+        await ctrl.getExpandedEvents({ openUserId: 'u', query: { lower: '0', upper: String(86400000) } }, res);
+        assert.equal(res.statusCode, 200);
+    });
+});

--- a/functions/test/controllers/openapi/expandedController.test.js
+++ b/functions/test/controllers/openapi/expandedController.test.js
@@ -4,7 +4,7 @@ const TodoOpenController = require('../../../controllers/openapi/todoOpenControl
 const ScheduleOpenController = require('../../../controllers/openapi/scheduleOpenController');
 const Errors = require('../../../models/Errors');
 
-const YEAR = 365 * 86400000;
+const YEAR = 365 * 86400;
 
 function makeRes() {
     return {
@@ -29,7 +29,7 @@ describe('getExpandedTodos', () => {
     it('정상: 200 + service 위임, limit default 100', async () => {
         const svc = stubTodoService();
         const ctrl = new TodoOpenController(svc);
-        const req = { openUserId: 'u', query: { lower: '0', upper: String(10 * 86400000) } };
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(10 * 86400) } };
         const res = makeRes();
         await ctrl.getExpandedTodos(req, res);
         assert.equal(res.statusCode, 200);
@@ -43,14 +43,14 @@ describe('getExpandedTodos', () => {
 
     it('window > 1년 → BadRequest', async () => {
         const ctrl = new TodoOpenController(stubTodoService());
-        const req = { openUserId: 'u', query: { lower: '0', upper: String(YEAR + 86400000) } };
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(YEAR + 86400) } };
         await assert.rejects(ctrl.getExpandedTodos(req, makeRes()), Errors.BadRequest);
     });
 
     it('limit > 500 → 500으로 clamp', async () => {
         const svc = stubTodoService();
         const ctrl = new TodoOpenController(svc);
-        const req = { openUserId: 'u', query: { lower: '0', upper: String(86400000), limit: '9999' } };
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(86400), limit: '9999' } };
         await ctrl.getExpandedTodos(req, makeRes());
         assert.equal(svc.lastArgs.limit, 500);
     });
@@ -58,7 +58,7 @@ describe('getExpandedTodos', () => {
     it('cursor passthrough', async () => {
         const svc = stubTodoService();
         const ctrl = new TodoOpenController(svc);
-        const req = { openUserId: 'u', query: { lower: '0', upper: String(86400000), cursor: 'abc' } };
+        const req = { openUserId: 'u', query: { lower: '0', upper: String(86400), cursor: 'abc' } };
         await ctrl.getExpandedTodos(req, makeRes());
         assert.equal(svc.lastArgs.cursor, 'abc');
     });
@@ -70,7 +70,7 @@ describe('getExpandedEvents', () => {
         const svc = { async findExpandedEvents() { return { events: {}, occurrences: [], next_cursor: null }; } };
         const ctrl = new ScheduleOpenController(svc);
         const res = makeRes();
-        await ctrl.getExpandedEvents({ openUserId: 'u', query: { lower: '0', upper: String(86400000) } }, res);
+        await ctrl.getExpandedEvents({ openUserId: 'u', query: { lower: '0', upper: String(86400) } }, res);
         assert.equal(res.statusCode, 200);
     });
 });

--- a/functions/test/doubles/stubRepositories.js
+++ b/functions/test/doubles/stubRepositories.js
@@ -114,6 +114,9 @@ class StubTodoRepository {
     }
 
     async findTodos(eventIds) {
+        if(this.findTodosResult != null) {
+            return this.findTodosResult
+        }
         const todos = eventIds.map((id) => {
             return TodoModel.fromData(id, { userId: 'some' })
         })
@@ -179,6 +182,9 @@ class StubScheduleEventRepository {
     }
 
     async findEvents(eventIds) {
+        if(this.findEventsResult != null) {
+            return this.findEventsResult
+        }
         const events = eventIds.map((id) => {
             return ScheduleModel.fromData(id, { userId: 'some' })
         })
@@ -288,6 +294,9 @@ class StubEventTimeRangeRepository {
     }
 
     async eventIds(userId, isTodo, lower, upper) {
+        if(this.eventIdsResult != null) {
+            return this.eventIdsResult
+        }
         const len = upper - lower
         const array = Array.from({length: len}, (v, i) => i+lower)
         return array.map(i => `id:${i}`)

--- a/functions/test/e2e/openapi/expanded.e2e.js
+++ b/functions/test/e2e/openapi/expanded.e2e.js
@@ -1,0 +1,139 @@
+const assert = require('assert');
+const { DateTime } = require('luxon');
+const { TEST_USER_UID } = require('../seeds/commonData');
+const { signUserToken, openClient, defaultMcpPat } = require('../helpers/openClient');
+
+const DAY = 86400000; // 1일 (ms). expanded 엔진/window check 모두 ms 단위로 동작.
+
+// scope 별 openAPI 클라이언트 — 사용자 JWT 에 scope 를 실어 발급.
+// (openClient 자체는 {pat, userToken} 만 받고, 인가 scope 는 JWT payload.scope 로 전달.)
+function clientWithScope(scope) {
+    const userToken = signUserToken({ sub: TEST_USER_UID, scope });
+    return openClient({ pat: defaultMcpPat(), userToken });
+}
+
+describe('openAPI GET /v2/open/todos/expanded', function () {
+
+    it('반복 todo 가 occurrence 로 전개되고 시각순 + turn 정확', async function () {
+        const client = clientWithScope(['read:calendar', 'write:calendar']);
+        const start = DateTime.fromISO('2026-01-01T00:00:00Z').toMillis();
+        const created = await client.post('/v2/open/todos/', {
+            name: 'expanded-daily',
+            event_time: { time_type: 'at', timestamp: start },
+            repeating: { start, option: { optionType: 'every_day', interval: 1 } }
+        });
+        assert.strictEqual(created.status, 201);
+
+        const res = await client.get(`/v2/open/todos/expanded?lower=${start}&upper=${start + 3 * DAY}`);
+        assert.strictEqual(res.status, 200);
+
+        const ts = res.data.occurrences.map((o) => o.event_time.timestamp);
+        assert.deepStrictEqual(ts, [start, start + DAY, start + 2 * DAY, start + 3 * DAY]);
+        assert.deepStrictEqual(res.data.occurrences.map((o) => o.turn), [1, 2, 3, 4]);
+        // origin 이벤트가 events map 에 1건 포함.
+        assert.strictEqual(Object.keys(res.data.events).length, 1);
+        assert.strictEqual(res.data.next_cursor, null);
+    });
+
+    it('window 1년 초과 → 400', async function () {
+        const client = clientWithScope(['read:calendar']);
+        const res = await client.get(`/v2/open/todos/expanded?lower=0&upper=${400 * DAY}`);
+        assert.strictEqual(res.status, 400);
+    });
+
+    it('lower/upper 누락 → 400', async function () {
+        const client = clientWithScope(['read:calendar']);
+        const res = await client.get('/v2/open/todos/expanded');
+        assert.strictEqual(res.status, 400);
+    });
+
+    it('cursor 페이징 이어받기 + next_cursor null 종료', async function () {
+        const client = clientWithScope(['read:calendar', 'write:calendar']);
+        const start = DateTime.fromISO('2026-03-01T00:00:00Z').toMillis();
+        const created = await client.post('/v2/open/todos/', {
+            name: 'expanded-daily-paging',
+            event_time: { time_type: 'at', timestamp: start },
+            repeating: { start, option: { optionType: 'every_day', interval: 1 } }
+        });
+        assert.strictEqual(created.status, 201);
+
+        // window 6일 → turn 1..6 총 6개. limit=3 으로 2 페이지.
+        const p1 = await client.get(`/v2/open/todos/expanded?lower=${start}&upper=${start + 5 * DAY}&limit=3`);
+        assert.strictEqual(p1.status, 200);
+        assert.strictEqual(p1.data.occurrences.length, 3);
+        assert.deepStrictEqual(p1.data.occurrences.map((o) => o.turn), [1, 2, 3]);
+        assert.notStrictEqual(p1.data.next_cursor, null);
+
+        const p2 = await client.get(
+            `/v2/open/todos/expanded?lower=${start}&upper=${start + 5 * DAY}&limit=3&cursor=${encodeURIComponent(p1.data.next_cursor)}`
+        );
+        assert.strictEqual(p2.status, 200);
+        assert.deepStrictEqual(p2.data.occurrences.map((o) => o.turn), [4, 5, 6]);
+        assert.strictEqual(p2.data.next_cursor, null);
+    });
+
+    it('read:calendar scope 없으면 403', async function () {
+        const client = clientWithScope([]);
+        const res = await client.get(`/v2/open/todos/expanded?lower=0&upper=${DAY}`);
+        assert.strictEqual(res.status, 403);
+    });
+});
+
+describe('openAPI GET /v2/open/schedules/expanded — 음력 Swift 벡터 게이트', function () {
+
+    it('음력 매년 전개가 클라 Swift 결과와 일치 ([1992-05-13, 1993-05-31, 1994-05-21])', async function () {
+        const client = clientWithScope(['read:calendar', 'write:calendar']);
+        const zone = 'Asia/Seoul';
+
+        const allday = (y, m, d) => {
+            const startDt = DateTime.fromObject({ year: y, month: m, day: d }, { zone }).startOf('day');
+            const endDt = startDt.endOf('day');
+            return {
+                time_type: 'allday',
+                period_start: startDt.toMillis(),
+                period_end: endDt.toMillis(),
+                // seconds_from_gmt: 엔진 전체가 ms 단위이므로 ms 로 전달 (KST = +9h).
+                seconds_from_gmt: 9 * 3600 * 1000
+            };
+        };
+
+        const seedTime = allday(1991, 5, 24);
+        // repeating.end 명시: end 없으면 time-range index upper 가 sentinel
+        // (Utils/constants.eventTimeMaxUpperBound) 로 채워지는데 이 값이 초 스케일이라
+        // ms seed 의 lower(1991) 보다 작아져 overlap 쿼리가 깨진다. end 를 양력 1994 말로 둬
+        // index upper 를 ms 로 정상 채운다 (조회 window 전부 커버).
+        const repeatingEnd = allday(1994, 12, 31).period_end;
+        const created = await client.post('/v2/open/schedules/', {
+            name: 'expanded-lunar',
+            event_time: seedTime,
+            repeating: {
+                start: seedTime.period_start,
+                end: repeatingEnd,
+                option: { optionType: 'lunar_calendar_every_year', month: 4, day: 11, timeZone: zone }
+            }
+        });
+        assert.strictEqual(created.status, 201);
+
+        // window 1년 cap(ONE_YEAR_MS) 때문에 1991~1994 전체를 한 번에 못 가져옴.
+        // → 연 단위(<1년) 서브 윈도우로 끊어 조회 후 concat. 음력 occurrence 는 연 1회라
+        //   각 윈도우가 정확히 1건씩 반환. (테스트 약화 아님 — 양력 결과값 검증은 그대로.)
+        // 윈도우 span < ONE_YEAR_MS(365일) 이어야 하므로 Jan1~Dec1 (~334일)로 잡음.
+        // 음력 occurrence 가 모두 5월이라 이 범위로 충분히 포착.
+        const yearWindows = [
+            [allday(1992, 1, 1).period_start, allday(1992, 12, 1).period_start],
+            [allday(1993, 1, 1).period_start, allday(1993, 12, 1).period_start],
+            [allday(1994, 1, 1).period_start, allday(1994, 12, 1).period_start]
+        ];
+
+        const days = [];
+        for (const [lower, upper] of yearWindows) {
+            const res = await client.get(`/v2/open/schedules/expanded?lower=${lower}&upper=${upper}`);
+            assert.strictEqual(res.status, 200);
+            for (const o of res.data.occurrences) {
+                days.push(DateTime.fromMillis(o.event_time.period_start, { zone }).toFormat('yyyy-MM-dd'));
+            }
+        }
+
+        assert.deepStrictEqual(days, ['1992-05-13', '1993-05-31', '1994-05-21']);
+    });
+});

--- a/functions/test/e2e/openapi/expanded.e2e.js
+++ b/functions/test/e2e/openapi/expanded.e2e.js
@@ -3,7 +3,7 @@ const { DateTime } = require('luxon');
 const { TEST_USER_UID } = require('../seeds/commonData');
 const { signUserToken, openClient, defaultMcpPat } = require('../helpers/openClient');
 
-const DAY = 86400000; // 1일 (ms). expanded 엔진/window check 모두 ms 단위로 동작.
+const DAY = 86400; // 1일 (초). event_time / window 모두 초 단위(production/Swift 일치).
 
 // scope 별 openAPI 클라이언트 — 사용자 JWT 에 scope 를 실어 발급.
 // (openClient 자체는 {pat, userToken} 만 받고, 인가 scope 는 JWT payload.scope 로 전달.)
@@ -16,11 +16,13 @@ describe('openAPI GET /v2/open/todos/expanded', function () {
 
     it('반복 todo 가 occurrence 로 전개되고 시각순 + turn 정확', async function () {
         const client = clientWithScope(['read:calendar', 'write:calendar']);
-        const start = DateTime.fromISO('2026-01-01T00:00:00Z').toMillis();
+        const start = DateTime.fromISO('2026-01-01T00:00:00Z').toMillis() / 1000;
+        // repeating.end 로 이 윈도우(Jan1~Jan4)에 가둠 — TEST_USER 가 공유돼
+        // 후속 케이스(March 윈도우)로 occurrence 가 새는 것 방지. 검증 윈도우는 그대로.
         const created = await client.post('/v2/open/todos/', {
             name: 'expanded-daily',
             event_time: { time_type: 'at', timestamp: start },
-            repeating: { start, option: { optionType: 'every_day', interval: 1 } }
+            repeating: { start, end: start + 3 * DAY, option: { optionType: 'every_day', interval: 1 } }
         });
         assert.strictEqual(created.status, 201);
 
@@ -49,7 +51,7 @@ describe('openAPI GET /v2/open/todos/expanded', function () {
 
     it('cursor 페이징 이어받기 + next_cursor null 종료', async function () {
         const client = clientWithScope(['read:calendar', 'write:calendar']);
-        const start = DateTime.fromISO('2026-03-01T00:00:00Z').toMillis();
+        const start = DateTime.fromISO('2026-03-01T00:00:00Z').toMillis() / 1000;
         const created = await client.post('/v2/open/todos/', {
             name: 'expanded-daily-paging',
             event_time: { time_type: 'at', timestamp: start },
@@ -90,34 +92,31 @@ describe('openAPI GET /v2/open/schedules/expanded — 음력 Swift 벡터 게이
             const endDt = startDt.endOf('day');
             return {
                 time_type: 'allday',
-                period_start: startDt.toMillis(),
-                period_end: endDt.toMillis(),
-                // seconds_from_gmt: 엔진 전체가 ms 단위이므로 ms 로 전달 (KST = +9h).
-                seconds_from_gmt: 9 * 3600 * 1000
+                period_start: startDt.toMillis() / 1000,
+                period_end: endDt.toMillis() / 1000,
+                // seconds_from_gmt: 초 단위 (KST = +9h).
+                seconds_from_gmt: 9 * 3600
             };
         };
 
         const seedTime = allday(1991, 5, 24);
-        // repeating.end 명시: end 없으면 time-range index upper 가 sentinel
-        // (Utils/constants.eventTimeMaxUpperBound) 로 채워지는데 이 값이 초 스케일이라
-        // ms seed 의 lower(1991) 보다 작아져 overlap 쿼리가 깨진다. end 를 양력 1994 말로 둬
-        // index upper 를 ms 로 정상 채운다 (조회 window 전부 커버).
-        const repeatingEnd = allday(1994, 12, 31).period_end;
+        // open-ended 반복 (repeating.end 없음). 초 단위에선 sentinel eventTimeMaxUpperBound
+        // (≈12025년, 초 스케일) 가 seed 의 초 timestamp 보다 정상적으로 far-future 라
+        // time-range index upper 가 유효하게 채워진다 → open-ended 반복도 overlap 조회됨.
         const created = await client.post('/v2/open/schedules/', {
             name: 'expanded-lunar',
             event_time: seedTime,
             repeating: {
                 start: seedTime.period_start,
-                end: repeatingEnd,
                 option: { optionType: 'lunar_calendar_every_year', month: 4, day: 11, timeZone: zone }
             }
         });
         assert.strictEqual(created.status, 201);
 
-        // window 1년 cap(ONE_YEAR_MS) 때문에 1991~1994 전체를 한 번에 못 가져옴.
+        // window 1년 cap(ONE_YEAR_SEC) 때문에 1991~1994 전체를 한 번에 못 가져옴.
         // → 연 단위(<1년) 서브 윈도우로 끊어 조회 후 concat. 음력 occurrence 는 연 1회라
         //   각 윈도우가 정확히 1건씩 반환. (테스트 약화 아님 — 양력 결과값 검증은 그대로.)
-        // 윈도우 span < ONE_YEAR_MS(365일) 이어야 하므로 Jan1~Dec1 (~334일)로 잡음.
+        // 윈도우 span < ONE_YEAR_SEC(365일) 이어야 하므로 Jan1~Dec1 (~334일)로 잡음.
         // 음력 occurrence 가 모두 5월이라 이 범위로 충분히 포착.
         const yearWindows = [
             [allday(1992, 1, 1).period_start, allday(1992, 12, 1).period_start],
@@ -130,7 +129,7 @@ describe('openAPI GET /v2/open/schedules/expanded — 음력 Swift 벡터 게이
             const res = await client.get(`/v2/open/schedules/expanded?lower=${lower}&upper=${upper}`);
             assert.strictEqual(res.status, 200);
             for (const o of res.data.occurrences) {
-                days.push(DateTime.fromMillis(o.event_time.period_start, { zone }).toFormat('yyyy-MM-dd'));
+                days.push(DateTime.fromMillis(o.event_time.period_start * 1000, { zone }).toFormat('yyyy-MM-dd'));
             }
         }
 

--- a/functions/test/services/expandedQuery.test.js
+++ b/functions/test/services/expandedQuery.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert')
+const TodoService = require('../../services/todoEventService')
+const ScheduleEventService = require('../../services/scheduleEventService')
+const EventTimeRangeService = require('../../services/eventTimeRangeService')
+const StubRepos = require('../doubles/stubRepositories')
+const SpyChangeLogRecordService = require('../doubles/spyChangeLogRecordService')
+const EventDetailDataService = require('../../services/eventDetailService')
+const TodoModel = require('../../models/Todo')
+const ScheduleModel = require('../../models/Schedule')
+
+const DAY = 86400000
+
+describe('findExpandedTodos / findExpandedEvents', () => {
+    it('todo: 반복 todo가 window 안에서 occurrence로 전개', async () => {
+        const stubEventTime = new StubRepos.EventTime()
+        const stubTodoRepo = new StubRepos.Todo()
+        stubTodoRepo.findTodosResult = [TodoModel.fromData('t1', {
+            userId: 'u', name: 'daily', is_current: false, create_timestamp: 0,
+            event_time: { time_type: 'at', timestamp: 0 },
+            repeating: { start: 0, option: { optionType: 'every_day', interval: 1 } },
+        })]
+        stubEventTime.eventIdsResult = ['t1']
+        const svc = new TodoService({
+            todoRepository: stubTodoRepo,
+            eventTimeRangeService: new EventTimeRangeService(stubEventTime),
+            doneTodoRepository: new StubRepos.DoneTodo(),
+            changeLogRecordService: new SpyChangeLogRecordService(),
+            eventDetailDataService: new EventDetailDataService(new StubRepos.EventDetailData(), new StubRepos.EventDetailData()),
+        })
+        const page = await svc.findExpandedTodos('u', 0, 3 * DAY, 100, null)
+        assert.deepEqual(page.occurrences.map((o) => o.turn), [1, 2, 3, 4])
+        assert.equal(page.events['t1'].is_todo, true)
+    })
+
+    it('schedule: exclude_repeatings 반영 + is_todo=false', async () => {
+        const stubEventTime = new StubRepos.EventTime()
+        const stubSchedRepo = new StubRepos.ScheduleEvent()
+        const excludeKey = `${Math.trunc((1 * DAY) / 1000)}`
+        stubSchedRepo.findEventsResult = [ScheduleModel.fromData('s1', {
+            userId: 'u', name: 'daily',
+            event_time: { time_type: 'at', timestamp: 0 },
+            repeating: { start: 0, option: { optionType: 'every_day', interval: 1 } },
+            exclude_repeatings: [excludeKey],
+        })]
+        stubEventTime.eventIdsResult = ['s1']
+        const svc = new ScheduleEventService(
+            stubSchedRepo, new EventTimeRangeService(stubEventTime),
+            new SpyChangeLogRecordService(),
+            new EventDetailDataService(new StubRepos.EventDetailData(), new StubRepos.EventDetailData())
+        )
+        const page = await svc.findExpandedEvents('u', 0, 3 * DAY, 100, null)
+        const ts = page.occurrences.map((o) => o.event_time.timestamp)
+        assert.ok(!ts.includes(1 * DAY))
+        assert.equal(page.events['s1'].is_todo, false)
+    })
+})

--- a/functions/test/services/expandedQuery.test.js
+++ b/functions/test/services/expandedQuery.test.js
@@ -8,7 +8,7 @@ const EventDetailDataService = require('../../services/eventDetailService')
 const TodoModel = require('../../models/Todo')
 const ScheduleModel = require('../../models/Schedule')
 
-const DAY = 86400000
+const DAY = 86400
 
 describe('findExpandedTodos / findExpandedEvents', () => {
     it('todo: 반복 todo가 window 안에서 occurrence로 전개', async () => {
@@ -35,7 +35,7 @@ describe('findExpandedTodos / findExpandedEvents', () => {
     it('schedule: exclude_repeatings 반영 + is_todo=false', async () => {
         const stubEventTime = new StubRepos.EventTime()
         const stubSchedRepo = new StubRepos.ScheduleEvent()
-        const excludeKey = `${Math.trunc((1 * DAY) / 1000)}`
+        const excludeKey = `${Math.trunc(1 * DAY)}`
         stubSchedRepo.findEventsResult = [ScheduleModel.fromData('s1', {
             userId: 'u', name: 'daily',
             event_time: { time_type: 'at', timestamp: 0 },

--- a/functions/test/services/expandedQuery.test.js
+++ b/functions/test/services/expandedQuery.test.js
@@ -11,46 +11,75 @@ const ScheduleModel = require('../../models/Schedule')
 const DAY = 86400
 
 describe('findExpandedTodos / findExpandedEvents', () => {
-    it('todo: 반복 todo가 window 안에서 occurrence로 전개', async () => {
-        const stubEventTime = new StubRepos.EventTime()
-        const stubTodoRepo = new StubRepos.Todo()
-        stubTodoRepo.findTodosResult = [TodoModel.fromData('t1', {
-            userId: 'u', name: 'daily', is_current: false, create_timestamp: 0,
-            event_time: { time_type: 'at', timestamp: 0 },
-            repeating: { start: 0, option: { optionType: 'every_day', interval: 1 } },
-        })]
-        stubEventTime.eventIdsResult = ['t1']
-        const svc = new TodoService({
-            todoRepository: stubTodoRepo,
-            eventTimeRangeService: new EventTimeRangeService(stubEventTime),
-            doneTodoRepository: new StubRepos.DoneTodo(),
-            changeLogRecordService: new SpyChangeLogRecordService(),
-            eventDetailDataService: new EventDetailDataService(new StubRepos.EventDetailData(), new StubRepos.EventDetailData()),
-        })
-        const page = await svc.findExpandedTodos('u', 0, 3 * DAY, 100, null)
-        assert.deepEqual(page.occurrences.map((o) => o.turn), [1, 2, 3, 4])
-        assert.equal(page.events['t1'].is_todo, true)
+    let stubEventTime
+    let detailService
+    let spyChangeLog
+
+    beforeEach(() => {
+        stubEventTime = new StubRepos.EventTime()
+        spyChangeLog = new SpyChangeLogRecordService()
+        detailService = new EventDetailDataService(
+            new StubRepos.EventDetailData(), new StubRepos.EventDetailData()
+        )
     })
 
-    it('schedule: exclude_repeatings 반영 + is_todo=false', async () => {
-        const stubEventTime = new StubRepos.EventTime()
-        const stubSchedRepo = new StubRepos.ScheduleEvent()
-        const excludeKey = `${Math.trunc(1 * DAY)}`
-        stubSchedRepo.findEventsResult = [ScheduleModel.fromData('s1', {
-            userId: 'u', name: 'daily',
-            event_time: { time_type: 'at', timestamp: 0 },
-            repeating: { start: 0, option: { optionType: 'every_day', interval: 1 } },
-            exclude_repeatings: [excludeKey],
-        })]
-        stubEventTime.eventIdsResult = ['s1']
-        const svc = new ScheduleEventService(
-            stubSchedRepo, new EventTimeRangeService(stubEventTime),
-            new SpyChangeLogRecordService(),
-            new EventDetailDataService(new StubRepos.EventDetailData(), new StubRepos.EventDetailData())
-        )
-        const page = await svc.findExpandedEvents('u', 0, 3 * DAY, 100, null)
-        const ts = page.occurrences.map((o) => o.event_time.timestamp)
-        assert.ok(!ts.includes(1 * DAY))
-        assert.equal(page.events['s1'].is_todo, false)
+    describe('findExpandedTodos', () => {
+        let stubTodoRepo
+        let service
+
+        beforeEach(() => {
+            stubTodoRepo = new StubRepos.Todo()
+            service = new TodoService({
+                todoRepository: stubTodoRepo,
+                eventTimeRangeService: new EventTimeRangeService(stubEventTime),
+                doneTodoRepository: new StubRepos.DoneTodo(),
+                changeLogRecordService: spyChangeLog,
+                eventDetailDataService: detailService,
+            })
+            stubEventTime.eventIdsResult = ['t1']
+            stubTodoRepo.findTodosResult = [TodoModel.fromData('t1', {
+                userId: 'u', name: 'daily', is_current: false, create_timestamp: 0,
+                event_time: { time_type: 'at', timestamp: 0 },
+                repeating: { start: 0, option: { optionType: 'every_day', interval: 1 } },
+            })]
+        })
+
+        it('반복 todo가 window 안에서 occurrence로 전개', async () => {
+            const page = await service.findExpandedTodos('u', 0, 3 * DAY, 100, null)
+            assert.deepEqual(
+                page.occurrences.map((o) => [o.origin_event_id, o.turn, o.event_time.timestamp]),
+                [['t1', 1, 0], ['t1', 2, DAY], ['t1', 3, 2 * DAY], ['t1', 4, 3 * DAY]]
+            )
+            assert.equal(page.events['t1'].is_todo, true)
+        })
+    })
+
+    describe('findExpandedEvents', () => {
+        let stubSchedRepo
+        let service
+
+        beforeEach(() => {
+            stubSchedRepo = new StubRepos.ScheduleEvent()
+            service = new ScheduleEventService(
+                stubSchedRepo, new EventTimeRangeService(stubEventTime), spyChangeLog, detailService
+            )
+            stubEventTime.eventIdsResult = ['s1']
+            stubSchedRepo.findEventsResult = [ScheduleModel.fromData('s1', {
+                userId: 'u', name: 'daily',
+                event_time: { time_type: 'at', timestamp: 0 },
+                repeating: { start: 0, option: { optionType: 'every_day', interval: 1 } },
+                exclude_repeatings: [`${Math.trunc(1 * DAY)}`], // 1일차 회차 제외
+            })]
+        })
+
+        it('exclude_repeatings 회차 제외(turn 미소비) + is_todo=false', async () => {
+            const page = await service.findExpandedEvents('u', 0, 3 * DAY, 100, null)
+            // 1일차(DAY) 제외, turn은 소비 안 됨 → 0(turn1) / 2일차(turn2) / 3일차(turn3)
+            assert.deepEqual(
+                page.occurrences.map((o) => [o.origin_event_id, o.turn, o.event_time.timestamp]),
+                [['s1', 1, 0], ['s1', 2, 2 * DAY], ['s1', 3, 3 * DAY]]
+            )
+            assert.equal(page.events['s1'].is_todo, false)
+        })
     })
 })

--- a/functions/test/services/repeating/dateMath.test.js
+++ b/functions/test/services/repeating/dateMath.test.js
@@ -1,0 +1,48 @@
+const assert = require('assert')
+const { DateTime } = require('luxon')
+const dm = require('../../../services/repeating/dateMath')
+
+const SEOUL = 'Asia/Seoul'
+function dt(str, zone = SEOUL) {
+    return DateTime.fromFormat(str, 'yyyy-MM-dd HH:mm', { zone })
+}
+
+describe('dateMath', () => {
+    it('appWeekday: 일요일=1, 토요일=7', () => {
+        assert.equal(dm.appWeekday(dt('2023-04-16 00:00')), 1) // Sunday
+        assert.equal(dm.appWeekday(dt('2023-04-22 00:00')), 7) // Saturday
+        assert.equal(dm.appWeekday(dt('2023-04-17 00:00')), 2) // Monday
+    })
+
+    it('weekdayOrdinal: 그 달에서 같은 요일 몇 번째인지', () => {
+        assert.equal(dm.weekdayOrdinal(dt('2023-04-01 00:00')), 1) // 1st Saturday
+        assert.equal(dm.weekdayOrdinal(dt('2023-04-08 00:00')), 2) // 2nd Saturday
+        assert.equal(dm.weekdayOrdinal(dt('2023-04-15 00:00')), 3)
+    })
+
+    it('addMonths: 없는 날은 luxon이 마지막 날로 clamp', () => {
+        assert.equal(dm.addMonths(dt('2023-01-31 00:00'), 1).day, 28) // Feb
+    })
+
+    it('dateBySettingDay: 그 달에 없는 일자면 null (skip 신호)', () => {
+        assert.equal(dm.dateBySettingDay(dt('2023-02-15 00:00'), 30), null)
+        assert.equal(dm.dateBySettingDay(dt('2023-02-15 00:00'), 28).day, 28)
+    })
+
+    it('firstWeekday: 그 달 첫 번째 해당 요일 (day=화요일=3)', () => {
+        // 2023-04 첫 화요일 = 4/4
+        assert.equal(dm.firstWeekday(dt('2023-04-20 09:00'), 3).day, 4)
+        // 시각 보존
+        assert.equal(dm.firstWeekday(dt('2023-04-20 09:00'), 3).hour, 9)
+    })
+
+    it('lastOfSameWeekday: 그 달 마지막 같은 요일', () => {
+        // 2023-04 마지막 목요일 = 4/27
+        assert.equal(dm.lastOfSameWeekday(dt('2023-04-06 00:00')).day, 27)
+    })
+
+    it('syncTimes: 시/분/초를 다른 날짜에서 가져와 세팅', () => {
+        const r = dm.syncTimes(dt('2023-05-01 00:00'), dt('2023-04-20 07:30'))
+        assert.equal(r.hour, 7); assert.equal(r.minute, 30); assert.equal(r.day, 1)
+    })
+})

--- a/functions/test/services/repeating/eventTime.test.js
+++ b/functions/test/services/repeating/eventTime.test.js
@@ -21,9 +21,9 @@ describe('eventTime', () => {
     })
 
     it('customKey: 초 단위, 형태별 포맷', () => {
-        // ms → 초로 trunc
-        assert.equal(et.customKey({ time_type: 'at', timestamp: 123456 }), '123')
-        assert.equal(et.customKey({ time_type: 'period', period_start: 10000, period_end: 20000 }), '10..<20')
-        assert.equal(et.customKey({ time_type: 'allday', period_start: 10000, period_end: 20000, seconds_from_gmt: 32400000 }), '10..<20+32400')
+        // 값이 이미 초 — Swift Int(time) 그대로 trunc
+        assert.equal(et.customKey({ time_type: 'at', timestamp: 123456 }), '123456')
+        assert.equal(et.customKey({ time_type: 'period', period_start: 10000, period_end: 20000 }), '10000..<20000')
+        assert.equal(et.customKey({ time_type: 'allday', period_start: 10000, period_end: 20000, seconds_from_gmt: 32400 }), '10000..<20000+32400')
     })
 })

--- a/functions/test/services/repeating/eventTime.test.js
+++ b/functions/test/services/repeating/eventTime.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert')
+const et = require('../../../services/repeating/eventTime')
+
+describe('eventTime', () => {
+    it('lowerBoundWithFixed / upperBoundWithFixed', () => {
+        assert.equal(et.lowerBound({ time_type: 'at', timestamp: 100 }), 100)
+        assert.equal(et.upperBound({ time_type: 'at', timestamp: 100 }), 100)
+        assert.equal(et.lowerBound({ time_type: 'period', period_start: 10, period_end: 20 }), 10)
+        assert.equal(et.upperBound({ time_type: 'period', period_start: 10, period_end: 20 }), 20)
+        assert.equal(et.lowerBound({ time_type: 'allday', period_start: 10, period_end: 20, seconds_from_gmt: 32400 }), 10)
+        assert.equal(et.upperBound({ time_type: 'allday', period_start: 10, period_end: 20, seconds_from_gmt: 32400 }), 20)
+    })
+
+    it('shift: 형태 유지하며 delta(ms) 가산', () => {
+        assert.deepEqual(et.shift({ time_type: 'at', timestamp: 100 }, 50),
+            { time_type: 'at', timestamp: 150 })
+        assert.deepEqual(et.shift({ time_type: 'period', period_start: 10, period_end: 20 }, 5),
+            { time_type: 'period', period_start: 15, period_end: 25 })
+        assert.deepEqual(et.shift({ time_type: 'allday', period_start: 10, period_end: 20, seconds_from_gmt: 32400 }, 5),
+            { time_type: 'allday', period_start: 15, period_end: 25, seconds_from_gmt: 32400 })
+    })
+
+    it('customKey: 초 단위, 형태별 포맷', () => {
+        // ms → 초로 trunc
+        assert.equal(et.customKey({ time_type: 'at', timestamp: 123456 }), '123')
+        assert.equal(et.customKey({ time_type: 'period', period_start: 10000, period_end: 20000 }), '10..<20')
+        assert.equal(et.customKey({ time_type: 'allday', period_start: 10000, period_end: 20000, seconds_from_gmt: 32400000 }), '10..<20+32400')
+    })
+})

--- a/functions/test/services/repeating/occurrencePaging.test.js
+++ b/functions/test/services/repeating/occurrencePaging.test.js
@@ -70,3 +70,13 @@ describe('occurrencePaging', () => {
         assert.equal(page.occurrences[0].event_time.timestamp, 2 * DAY)
     })
 })
+
+describe('occurrencePaging — repeating.end 반영', () => {
+    it('repeating.end가 window 안이면 그 이후 occurrence 미생성', () => {
+        const ev = dailyEvent('a', 0, 1)         // 0,1,2,... 일
+        ev.repeating.end = 2 * DAY               // 2일차까지만
+        const page = buildExpandedPage([ev], 0, 10 * DAY, 100, null)
+        assert.deepEqual(page.occurrences.map((o) => o.event_time.timestamp), [0, DAY, 2 * DAY])
+        assert.equal(page.next_cursor, null)
+    })
+})

--- a/functions/test/services/repeating/occurrencePaging.test.js
+++ b/functions/test/services/repeating/occurrencePaging.test.js
@@ -8,7 +8,7 @@ function dailyEvent(uuid, startMs, intervalDays, isTodo = true) {
         repeating: { start: startMs, option: { optionType: 'every_day', interval: intervalDays } },
     }
 }
-const DAY = 86400000
+const DAY = 86400
 
 describe('occurrencePaging', () => {
     it('cursor roundtrip', () => {

--- a/functions/test/services/repeating/occurrencePaging.test.js
+++ b/functions/test/services/repeating/occurrencePaging.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert')
+const { buildExpandedPage, encodeCursor, decodeCursor } = require('../../../services/repeating/occurrencePaging')
+
+function dailyEvent(uuid, startMs, intervalDays, isTodo = true) {
+    return {
+        uuid, userId: 'u', name: uuid, is_todo: isTodo,
+        event_time: { time_type: 'at', timestamp: startMs },
+        repeating: { start: startMs, option: { optionType: 'every_day', interval: intervalDays } },
+    }
+}
+const DAY = 86400000
+
+describe('occurrencePaging', () => {
+    it('cursor roundtrip', () => {
+        const c = encodeCursor({ t: 123, id: 'todo-a:5' })
+        assert.deepEqual(decodeCursor(c), { t: 123, id: 'todo-a:5' })
+    })
+
+    it('단일 이벤트: window 안 occurrence 시각순, turn 정확', () => {
+        const ev = dailyEvent('a', 0, 1)               // 0,1,2,... 일
+        const page = buildExpandedPage([ev], 0, 5 * DAY, 100, null)
+        assert.deepEqual(page.occurrences.map((o) => o.turn), [1, 2, 3, 4, 5, 6])
+        assert.equal(page.occurrences[0].event_time.timestamp, 0)
+        assert.equal(page.next_cursor, null)
+        assert.deepEqual(Object.keys(page.events), ['a'])
+    })
+
+    it('두 이벤트 종합 시각순 merge', () => {
+        const a = dailyEvent('a', 0, 2)                // 0,2,4
+        const b = dailyEvent('b', DAY, 2)              // 1,3,5
+        const page = buildExpandedPage([a, b], 0, 5 * DAY, 100, null)
+        const ts = page.occurrences.map((o) => o.event_time.timestamp)
+        assert.deepEqual(ts, [0, DAY, 2 * DAY, 3 * DAY, 4 * DAY, 5 * DAY])
+        assert.deepEqual(page.occurrences.map((o) => o.origin_event_id),
+            ['a', 'b', 'a', 'b', 'a', 'b'])
+    })
+
+    it('limit으로 페이지 절단 + next_cursor + 다음 페이지 이어받기', () => {
+        const a = dailyEvent('a', 0, 1)                // 0..N
+        const p1 = buildExpandedPage([a], 0, 10 * DAY, 4, null)
+        assert.equal(p1.occurrences.length, 4)
+        assert.deepEqual(p1.occurrences.map((o) => o.turn), [1, 2, 3, 4])
+        assert.notEqual(p1.next_cursor, null)
+
+        const p2 = buildExpandedPage([a], 0, 10 * DAY, 4, p1.next_cursor)
+        assert.deepEqual(p2.occurrences.map((o) => o.turn), [5, 6, 7, 8]) // turn 회복
+        assert.equal(p2.occurrences[0].event_time.timestamp, 4 * DAY)
+    })
+
+    it('마지막 페이지 next_cursor null', () => {
+        const a = dailyEvent('a', 0, 1)
+        const p = buildExpandedPage([a], 0, 2 * DAY, 100, null)
+        assert.equal(p.next_cursor, null)
+        assert.deepEqual(p.occurrences.map((o) => o.turn), [1, 2, 3])
+    })
+
+    it('동시각 tiebreak: occurrence_id(=origin:turn) ASC 결정적', () => {
+        const a = dailyEvent('a', 0, 1)
+        const b = dailyEvent('b', 0, 1)
+        const page = buildExpandedPage([a, b], 0, 0, 100, null) // 둘 다 t=0
+        assert.deepEqual(page.occurrences.map((o) => o.origin_event_id), ['a', 'b'])
+    })
+
+    it('비반복 이벤트: turn=1 단일 occurrence', () => {
+        const ev = { uuid: 'x', userId: 'u', name: 'x', is_todo: true,
+            event_time: { time_type: 'at', timestamp: 2 * DAY }, repeating: null }
+        const page = buildExpandedPage([ev], 0, 5 * DAY, 100, null)
+        assert.equal(page.occurrences.length, 1)
+        assert.equal(page.occurrences[0].turn, 1)
+        assert.equal(page.occurrences[0].event_time.timestamp, 2 * DAY)
+    })
+})

--- a/functions/test/services/repeating/repeatTimeEnumerator.test.js
+++ b/functions/test/services/repeating/repeatTimeEnumerator.test.js
@@ -148,3 +148,53 @@ describe('RepeatTimeEnumerator — seekTurnUntil (naive 교차검증)', () => {
             sec('2015-03-10 09:00'), sec('2023-06-01 00:00'))
     })
 })
+
+describe('RepeatTimeEnumerator — repeating.end (this.until) 강제', () => {
+    // this.until(=repeating.end)이 window 파라미터보다 작으면 그 시점에서 종료해야 함
+    it('repeating.end가 window upper보다 이르면 end에서 멈춤', () => {
+        const en = makeEnum({ optionType: 'every_day', interval: 1 }, { until: sec('2023-05-23 01:00') })
+        // window 파라미터(until)는 훨씬 큼 — 그래도 repeating.end(05-23)에서 멈춰야
+        const r = en.nextEventTimes({ time: atTime(sec('2023-05-20 01:00')), turn: 0 }, sec('2023-06-30 01:00'))
+        assert.deepEqual(r.map((x) => x.time.timestamp), [
+            sec('2023-05-21 01:00'), sec('2023-05-22 01:00'), sec('2023-05-23 01:00'),
+        ])
+    })
+    it('window param이 repeating.end보다 이르면 window에서 멈춤 (둘 중 작은 쪽)', () => {
+        const en = makeEnum({ optionType: 'every_day', interval: 1 }, { until: sec('2023-06-30 01:00') })
+        const r = en.nextEventTimes({ time: atTime(sec('2023-05-20 01:00')), turn: 0 }, sec('2023-05-22 01:00'))
+        assert.deepEqual(r.map((x) => x.time.timestamp), [
+            sec('2023-05-21 01:00'), sec('2023-05-22 01:00'),
+        ])
+    })
+})
+
+describe('RepeatTimeEnumerator — every_week (KST 미러)', () => {
+    const FROM = atTime(sec('2023-04-11 07:00')) // 화요일
+    // [화,금] 반복, 현재 화 → 같은 주 금요일 (interval 무관), turn 1
+    it('같은 주 다음 요일 (화·금 → 금)', () => {
+        for (const interval of [1, 2, 3, 9]) {
+            const r = makeEnum({ optionType: 'every_week', interval, dayOfWeek: [3, 6], timeZone: SEOUL })
+                .nextEventTime({ time: FROM, turn: 0 }, null)
+            assert.equal(r.time.timestamp, sec('2023-04-14 07:00'))
+            assert.equal(r.turn, 1)
+        }
+    })
+    it('같은 주 종료 경계: until < 금이면 null', () => {
+        const r = makeEnum({ optionType: 'every_week', interval: 1, dayOfWeek: [3, 6], timeZone: SEOUL })
+            .nextEventTime({ time: FROM, turn: 0 }, sec('2023-04-14 06:59'))
+        assert.equal(r, null)
+    })
+    // [화]만 반복 → 같은 주에 다음 요일 없음 → interval주 후 화요일
+    it('다음 주 첫 반복요일 (interval주 후 화)', () => {
+        const next = (interval) => makeEnum({ optionType: 'every_week', interval, dayOfWeek: [3], timeZone: SEOUL })
+            .nextEventTime({ time: FROM, turn: 0 }, null).time.timestamp
+        assert.equal(next(1), sec('2023-04-18 07:00'))
+        assert.equal(next(2), sec('2023-04-25 07:00'))
+        assert.equal(next(3), sec('2023-05-02 07:00'))
+    })
+    it('다음 주 종료 경계: until < 다음 화면 null', () => {
+        const r = makeEnum({ optionType: 'every_week', interval: 3, dayOfWeek: [3], timeZone: SEOUL })
+            .nextEventTime({ time: FROM, turn: 0 }, sec('2023-05-01 20:00'))
+        assert.equal(r, null)
+    })
+})

--- a/functions/test/services/repeating/repeatTimeEnumerator.test.js
+++ b/functions/test/services/repeating/repeatTimeEnumerator.test.js
@@ -2,8 +2,8 @@ const assert = require('assert')
 const { DateTime } = require('luxon')
 const { RepeatTimeEnumerator } = require('../../../services/repeating/repeatTimeEnumerator')
 
-function ms(str) {
-    return DateTime.fromFormat(str, 'yyyy-MM-dd HH:mm', { zone: 'UTC' }).toMillis()
+function sec(str) {
+    return DateTime.fromFormat(str, 'yyyy-MM-dd HH:mm', { zone: 'UTC' }).toMillis() / 1000
 }
 const SEOUL = 'Asia/Seoul'
 const atTime = (t) => ({ time_type: 'at', timestamp: t })
@@ -17,58 +17,58 @@ describe('RepeatTimeEnumerator — every_day', () => {
     const opt = { optionType: 'every_day', interval: 1 }
     it('interval 1: 1일 뒤, turn 0→1', () => {
         const r = makeEnum(opt).nextEventTime({ time: atTime(10), turn: 0 }, null)
-        assert.deepEqual(r.time, atTime(10 + 86400000))
+        assert.deepEqual(r.time, atTime(10 + 86400))
         assert.equal(r.turn, 1)
     })
     it('interval 3', () => {
         const r = makeEnum({ optionType: 'every_day', interval: 3 }).nextEventTime({ time: atTime(10), turn: 0 }, null)
-        assert.deepEqual(r.time, atTime(10 + 3 * 86400000))
+        assert.deepEqual(r.time, atTime(10 + 3 * 86400))
     })
     it('until 경계: 1일 뒤 <= until 통과', () => {
-        const r = makeEnum({ optionType: 'every_day', interval: 1 }, { until: 2 * 86400000 })
-            .nextEventTime({ time: atTime(0), turn: 0 }, 2 * 86400000)
-        assert.equal(r.time.timestamp, 86400000)
+        const r = makeEnum({ optionType: 'every_day', interval: 1 }, { until: 2 * 86400 })
+            .nextEventTime({ time: atTime(0), turn: 0 }, 2 * 86400)
+        assert.equal(r.time.timestamp, 86400)
     })
     it('period 형태 유지', () => {
         const r = makeEnum({ optionType: 'every_day', interval: 1 }).nextEventTime({ time: periodTime(10, 110), turn: 0 }, null)
-        assert.deepEqual(r.time, periodTime(10 + 86400000, 110 + 86400000))
+        assert.deepEqual(r.time, periodTime(10 + 86400, 110 + 86400))
     })
 })
 
 describe('RepeatTimeEnumerator — every_month days([1,15,30,31]) skip', () => {
     const opt = { optionType: 'every_month', interval: 1, monthDaySelection: { days: [1, 15, 30, 31] }, timeZone: SEOUL }
-    const step = (fromStr) => makeEnum(opt).nextEventTime({ time: atTime(ms(fromStr)), turn: 0 }, null)
+    const step = (fromStr) => makeEnum(opt).nextEventTime({ time: atTime(sec(fromStr)), turn: 0 }, null)
     it('같은 달 다음 일자', () => {
-        assert.equal(step('2023-01-01 01:00').time.timestamp, ms('2023-01-15 01:00'))
-        assert.equal(step('2023-01-15 01:00').time.timestamp, ms('2023-01-30 01:00'))
-        assert.equal(step('2023-01-30 01:00').time.timestamp, ms('2023-01-31 01:00'))
+        assert.equal(step('2023-01-01 01:00').time.timestamp, sec('2023-01-15 01:00'))
+        assert.equal(step('2023-01-15 01:00').time.timestamp, sec('2023-01-30 01:00'))
+        assert.equal(step('2023-01-30 01:00').time.timestamp, sec('2023-01-31 01:00'))
     })
     it('1/31 → 2/01 (다음 달 첫 반복일)', () => {
-        assert.equal(step('2023-01-31 01:00').time.timestamp, ms('2023-02-01 01:00'))
+        assert.equal(step('2023-01-31 01:00').time.timestamp, sec('2023-02-01 01:00'))
     })
     it('2/15 → 3/01 (2월 30·31 스킵, clamp 아님)', () => {
-        assert.equal(step('2023-02-15 01:00').time.timestamp, ms('2023-03-01 01:00'))
+        assert.equal(step('2023-02-15 01:00').time.timestamp, sec('2023-03-01 01:00'))
     })
     it('interval 2: 1/31 → 3/01', () => {
         const r = makeEnum({ optionType: 'every_month', interval: 2, monthDaySelection: { days: [1, 15, 30, 31] }, timeZone: SEOUL })
-            .nextEventTime({ time: atTime(ms('2023-01-31 01:00')), turn: 0 }, null)
-        assert.equal(r.time.timestamp, ms('2023-03-01 01:00'))
+            .nextEventTime({ time: atTime(sec('2023-01-31 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, sec('2023-03-01 01:00'))
     })
 })
 
 describe('RepeatTimeEnumerator — every_year_some_day 2/29 clamp', () => {
     const make = (month, day, interval) => makeEnum({ optionType: 'every_year_some_day', interval, month, day, timeZone: SEOUL })
     it('윤년 2/29 + 1년 → 평년 2/28', () => {
-        const r = make(2, 29, 1).nextEventTime({ time: atTime(ms('2020-02-29 01:00')), turn: 0 }, null)
-        assert.equal(r.time.timestamp, ms('2021-02-28 01:00'))
+        const r = make(2, 29, 1).nextEventTime({ time: atTime(sec('2020-02-29 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, sec('2021-02-28 01:00'))
     })
     it('2/29 + 4년 → 윤년 2/29', () => {
-        const r = make(2, 29, 4).nextEventTime({ time: atTime(ms('2020-02-29 01:00')), turn: 0 }, null)
-        assert.equal(r.time.timestamp, ms('2024-02-29 01:00'))
+        const r = make(2, 29, 4).nextEventTime({ time: atTime(sec('2020-02-29 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, sec('2024-02-29 01:00'))
     })
     it('3/1 + 1년 → 다음해 3/1', () => {
-        const r = make(3, 1, 1).nextEventTime({ time: atTime(ms('2023-03-01 01:00')), turn: 0 }, null)
-        assert.equal(r.time.timestamp, ms('2024-03-01 01:00'))
+        const r = make(3, 1, 1).nextEventTime({ time: atTime(sec('2023-03-01 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, sec('2024-03-01 01:00'))
     })
 })
 
@@ -76,34 +76,34 @@ describe('RepeatTimeEnumerator — every_year (months[4,8,12], ord[2,4,last], wd
     const opt = { optionType: 'every_year', interval: 1, months: [4, 8, 12],
         weekOrdinals: [{ isLast: false, seq: 2 }, { isLast: false, seq: 4 }, { isLast: true }],
         dayOfWeek: [3, 5], timeZone: SEOUL }
-    const step = (fromStr) => makeEnum(opt).nextEventTime({ time: atTime(ms(fromStr)), turn: 0 }, null)
-    it('같은 주 다음 요일', () => { assert.equal(step('2023-04-11 01:00').time.timestamp, ms('2023-04-13 01:00')) })
-    it('다음 주 첫 반복요일', () => { assert.equal(step('2023-04-13 01:00').time.timestamp, ms('2023-04-25 01:00')) })
-    it('다음 달 첫 반복 주/요일', () => { assert.equal(step('2023-04-27 01:00').time.timestamp, ms('2023-08-08 01:00')) })
-    it('다음 해 첫 반복 달/주/요일', () => { assert.equal(step('2023-12-28 01:00').time.timestamp, ms('2024-04-09 01:00')) })
+    const step = (fromStr) => makeEnum(opt).nextEventTime({ time: atTime(sec(fromStr)), turn: 0 }, null)
+    it('같은 주 다음 요일', () => { assert.equal(step('2023-04-11 01:00').time.timestamp, sec('2023-04-13 01:00')) })
+    it('다음 주 첫 반복요일', () => { assert.equal(step('2023-04-13 01:00').time.timestamp, sec('2023-04-25 01:00')) })
+    it('다음 달 첫 반복 주/요일', () => { assert.equal(step('2023-04-27 01:00').time.timestamp, sec('2023-08-08 01:00')) })
+    it('다음 해 첫 반복 달/주/요일', () => { assert.equal(step('2023-12-28 01:00').time.timestamp, sec('2024-04-09 01:00')) })
 })
 
 describe('RepeatTimeEnumerator — nextEventTimes (end / count / exclude)', () => {
     it('until까지 전부 + turn 누적', () => {
-        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { until: ms('2023-06-01 01:00') })
-            .nextEventTimes({ time: atTime(ms('2023-05-20 01:00')), turn: 0 }, ms('2023-06-01 01:00'))
+        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { until: sec('2023-06-01 01:00') })
+            .nextEventTimes({ time: atTime(sec('2023-05-20 01:00')), turn: 0 }, sec('2023-06-01 01:00'))
         assert.deepEqual(r.map((x) => x.time.timestamp), [
-            ms('2023-05-23 01:00'), ms('2023-05-26 01:00'), ms('2023-05-29 01:00'), ms('2023-06-01 01:00'),
+            sec('2023-05-23 01:00'), sec('2023-05-26 01:00'), sec('2023-05-29 01:00'), sec('2023-06-01 01:00'),
         ])
         assert.deepEqual(r.map((x) => x.turn), [1, 2, 3, 4])
     })
     it('count(3): turn 1 시작 → turn 2,3에서 멈춤', () => {
-        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { endCount: 3, until: ms('2024-06-01 01:00') })
-            .nextEventTimes({ time: atTime(ms('2023-05-20 01:00')), turn: 1 }, ms('2024-06-01 01:00'))
-        assert.deepEqual(r.map((x) => x.time.timestamp), [ms('2023-05-23 01:00'), ms('2023-05-26 01:00')])
+        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { endCount: 3, until: sec('2024-06-01 01:00') })
+            .nextEventTimes({ time: atTime(sec('2023-05-20 01:00')), turn: 1 }, sec('2024-06-01 01:00'))
+        assert.deepEqual(r.map((x) => x.time.timestamp), [sec('2023-05-23 01:00'), sec('2023-05-26 01:00')])
         assert.deepEqual(r.map((x) => x.turn), [2, 3])
     })
     it('exclude: 제외 회차는 turn 미소비', () => {
-        const excludes = [ms('2023-05-26 01:00'), ms('2023-06-01 01:00')].map((m) => `${Math.trunc(m / 1000)}`)
-        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { endCount: 4, until: ms('2024-06-01 01:00'), excludes })
-            .nextEventTimes({ time: atTime(ms('2023-05-20 01:00')), turn: 1 }, ms('2024-06-01 01:00'))
+        const excludes = [sec('2023-05-26 01:00'), sec('2023-06-01 01:00')].map((s) => `${Math.trunc(s)}`)
+        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { endCount: 4, until: sec('2024-06-01 01:00'), excludes })
+            .nextEventTimes({ time: atTime(sec('2023-05-20 01:00')), turn: 1 }, sec('2024-06-01 01:00'))
         assert.deepEqual(r.map((x) => x.time.timestamp), [
-            ms('2023-05-23 01:00'), ms('2023-05-29 01:00'), ms('2023-06-04 01:00'),
+            sec('2023-05-23 01:00'), sec('2023-05-29 01:00'), sec('2023-06-04 01:00'),
         ])
         assert.deepEqual(r.map((x) => x.turn), [2, 3, 4])
     })
@@ -133,18 +133,18 @@ describe('RepeatTimeEnumerator — seekTurnUntil (naive 교차검증)', () => {
         assert.equal(seeked.turn, naive, `turn mismatch for ${optionJson.optionType}`)
     }
     it('every_day interval 1: 먼 과거 start도 동일 turn', () => {
-        check({ optionType: 'every_day', interval: 1 }, ms('2020-01-01 00:00'), ms('2023-06-01 00:00'))
+        check({ optionType: 'every_day', interval: 1 }, sec('2020-01-01 00:00'), sec('2023-06-01 00:00'))
     })
     it('every_week', () => {
         check({ optionType: 'every_week', interval: 1, dayOfWeek: [2, 4, 6], timeZone: SEOUL },
-            ms('2022-01-03 09:00'), ms('2023-06-01 00:00'))
+            sec('2022-01-03 09:00'), sec('2023-06-01 00:00'))
     })
     it('every_month days', () => {
         check({ optionType: 'every_month', interval: 1, monthDaySelection: { days: [1, 15, 31] }, timeZone: SEOUL },
-            ms('2021-01-01 09:00'), ms('2023-06-01 00:00'))
+            sec('2021-01-01 09:00'), sec('2023-06-01 00:00'))
     })
     it('every_year_some_day', () => {
         check({ optionType: 'every_year_some_day', interval: 1, month: 3, day: 10, timeZone: SEOUL },
-            ms('2015-03-10 09:00'), ms('2023-06-01 00:00'))
+            sec('2015-03-10 09:00'), sec('2023-06-01 00:00'))
     })
 })

--- a/functions/test/services/repeating/repeatTimeEnumerator.test.js
+++ b/functions/test/services/repeating/repeatTimeEnumerator.test.js
@@ -198,3 +198,16 @@ describe('RepeatTimeEnumerator — every_week (KST 미러)', () => {
         assert.equal(r, null)
     })
 })
+
+describe('RepeatTimeEnumerator — lunar 윤달 origin (throw 방지)', () => {
+    it('윤달 origin이어도 throw 없이 다음 회차 생성 (평달 fallback)', () => {
+        // 2023-04-05 KST = 음력 2023 윤2월 15일 → 2024엔 윤2월 없음 → 평달(2월)로 resolve
+        const start = DateTime.fromISO('2023-04-05T09:00:00', { zone: SEOUL }).toMillis() / 1000
+        const en = makeEnum({ optionType: 'lunar_calendar_every_year', month: 2, day: 15, timeZone: SEOUL })
+        let r
+        assert.doesNotThrow(() => { r = en.nextEventTime({ time: atTime(start), turn: 0 }, null) })
+        assert.notEqual(r, null)
+        const got = DateTime.fromMillis(r.time.timestamp * 1000, { zone: SEOUL }).toFormat('yyyy-MM-dd')
+        assert.equal(got, '2024-03-24') // 2024 음력 2월 15일
+    })
+})

--- a/functions/test/services/repeating/repeatTimeEnumerator.test.js
+++ b/functions/test/services/repeating/repeatTimeEnumerator.test.js
@@ -1,0 +1,110 @@
+const assert = require('assert')
+const { DateTime } = require('luxon')
+const { RepeatTimeEnumerator } = require('../../../services/repeating/repeatTimeEnumerator')
+
+function ms(str) {
+    return DateTime.fromFormat(str, 'yyyy-MM-dd HH:mm', { zone: 'UTC' }).toMillis()
+}
+const SEOUL = 'Asia/Seoul'
+const atTime = (t) => ({ time_type: 'at', timestamp: t })
+const periodTime = (s, e) => ({ time_type: 'period', period_start: s, period_end: e })
+
+function makeEnum(option, { until = null, endCount = null, excludes = [] } = {}) {
+    return new RepeatTimeEnumerator(option, { until, endCount, excludes: new Set(excludes) })
+}
+
+describe('RepeatTimeEnumerator — every_day', () => {
+    const opt = { optionType: 'every_day', interval: 1 }
+    it('interval 1: 1일 뒤, turn 0→1', () => {
+        const r = makeEnum(opt).nextEventTime({ time: atTime(10), turn: 0 }, null)
+        assert.deepEqual(r.time, atTime(10 + 86400000))
+        assert.equal(r.turn, 1)
+    })
+    it('interval 3', () => {
+        const r = makeEnum({ optionType: 'every_day', interval: 3 }).nextEventTime({ time: atTime(10), turn: 0 }, null)
+        assert.deepEqual(r.time, atTime(10 + 3 * 86400000))
+    })
+    it('until 경계: 1일 뒤 <= until 통과', () => {
+        const r = makeEnum({ optionType: 'every_day', interval: 1 }, { until: 2 * 86400000 })
+            .nextEventTime({ time: atTime(0), turn: 0 }, 2 * 86400000)
+        assert.equal(r.time.timestamp, 86400000)
+    })
+    it('period 형태 유지', () => {
+        const r = makeEnum({ optionType: 'every_day', interval: 1 }).nextEventTime({ time: periodTime(10, 110), turn: 0 }, null)
+        assert.deepEqual(r.time, periodTime(10 + 86400000, 110 + 86400000))
+    })
+})
+
+describe('RepeatTimeEnumerator — every_month days([1,15,30,31]) skip', () => {
+    const opt = { optionType: 'every_month', interval: 1, monthDaySelection: { days: [1, 15, 30, 31] }, timeZone: SEOUL }
+    const step = (fromStr) => makeEnum(opt).nextEventTime({ time: atTime(ms(fromStr)), turn: 0 }, null)
+    it('같은 달 다음 일자', () => {
+        assert.equal(step('2023-01-01 01:00').time.timestamp, ms('2023-01-15 01:00'))
+        assert.equal(step('2023-01-15 01:00').time.timestamp, ms('2023-01-30 01:00'))
+        assert.equal(step('2023-01-30 01:00').time.timestamp, ms('2023-01-31 01:00'))
+    })
+    it('1/31 → 2/01 (다음 달 첫 반복일)', () => {
+        assert.equal(step('2023-01-31 01:00').time.timestamp, ms('2023-02-01 01:00'))
+    })
+    it('2/15 → 3/01 (2월 30·31 스킵, clamp 아님)', () => {
+        assert.equal(step('2023-02-15 01:00').time.timestamp, ms('2023-03-01 01:00'))
+    })
+    it('interval 2: 1/31 → 3/01', () => {
+        const r = makeEnum({ optionType: 'every_month', interval: 2, monthDaySelection: { days: [1, 15, 30, 31] }, timeZone: SEOUL })
+            .nextEventTime({ time: atTime(ms('2023-01-31 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, ms('2023-03-01 01:00'))
+    })
+})
+
+describe('RepeatTimeEnumerator — every_year_some_day 2/29 clamp', () => {
+    const make = (month, day, interval) => makeEnum({ optionType: 'every_year_some_day', interval, month, day, timeZone: SEOUL })
+    it('윤년 2/29 + 1년 → 평년 2/28', () => {
+        const r = make(2, 29, 1).nextEventTime({ time: atTime(ms('2020-02-29 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, ms('2021-02-28 01:00'))
+    })
+    it('2/29 + 4년 → 윤년 2/29', () => {
+        const r = make(2, 29, 4).nextEventTime({ time: atTime(ms('2020-02-29 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, ms('2024-02-29 01:00'))
+    })
+    it('3/1 + 1년 → 다음해 3/1', () => {
+        const r = make(3, 1, 1).nextEventTime({ time: atTime(ms('2023-03-01 01:00')), turn: 0 }, null)
+        assert.equal(r.time.timestamp, ms('2024-03-01 01:00'))
+    })
+})
+
+describe('RepeatTimeEnumerator — every_year (months[4,8,12], ord[2,4,last], wd[화,목])', () => {
+    const opt = { optionType: 'every_year', interval: 1, months: [4, 8, 12],
+        weekOrdinals: [{ isLast: false, seq: 2 }, { isLast: false, seq: 4 }, { isLast: true }],
+        dayOfWeek: [3, 5], timeZone: SEOUL }
+    const step = (fromStr) => makeEnum(opt).nextEventTime({ time: atTime(ms(fromStr)), turn: 0 }, null)
+    it('같은 주 다음 요일', () => { assert.equal(step('2023-04-11 01:00').time.timestamp, ms('2023-04-13 01:00')) })
+    it('다음 주 첫 반복요일', () => { assert.equal(step('2023-04-13 01:00').time.timestamp, ms('2023-04-25 01:00')) })
+    it('다음 달 첫 반복 주/요일', () => { assert.equal(step('2023-04-27 01:00').time.timestamp, ms('2023-08-08 01:00')) })
+    it('다음 해 첫 반복 달/주/요일', () => { assert.equal(step('2023-12-28 01:00').time.timestamp, ms('2024-04-09 01:00')) })
+})
+
+describe('RepeatTimeEnumerator — nextEventTimes (end / count / exclude)', () => {
+    it('until까지 전부 + turn 누적', () => {
+        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { until: ms('2023-06-01 01:00') })
+            .nextEventTimes({ time: atTime(ms('2023-05-20 01:00')), turn: 0 }, ms('2023-06-01 01:00'))
+        assert.deepEqual(r.map((x) => x.time.timestamp), [
+            ms('2023-05-23 01:00'), ms('2023-05-26 01:00'), ms('2023-05-29 01:00'), ms('2023-06-01 01:00'),
+        ])
+        assert.deepEqual(r.map((x) => x.turn), [1, 2, 3, 4])
+    })
+    it('count(3): turn 1 시작 → turn 2,3에서 멈춤', () => {
+        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { endCount: 3, until: ms('2024-06-01 01:00') })
+            .nextEventTimes({ time: atTime(ms('2023-05-20 01:00')), turn: 1 }, ms('2024-06-01 01:00'))
+        assert.deepEqual(r.map((x) => x.time.timestamp), [ms('2023-05-23 01:00'), ms('2023-05-26 01:00')])
+        assert.deepEqual(r.map((x) => x.turn), [2, 3])
+    })
+    it('exclude: 제외 회차는 turn 미소비', () => {
+        const excludes = [ms('2023-05-26 01:00'), ms('2023-06-01 01:00')].map((m) => `${Math.trunc(m / 1000)}`)
+        const r = makeEnum({ optionType: 'every_day', interval: 3 }, { endCount: 4, until: ms('2024-06-01 01:00'), excludes })
+            .nextEventTimes({ time: atTime(ms('2023-05-20 01:00')), turn: 1 }, ms('2024-06-01 01:00'))
+        assert.deepEqual(r.map((x) => x.time.timestamp), [
+            ms('2023-05-23 01:00'), ms('2023-05-29 01:00'), ms('2023-06-04 01:00'),
+        ])
+        assert.deepEqual(r.map((x) => x.turn), [2, 3, 4])
+    })
+})

--- a/functions/test/services/repeating/repeatTimeEnumerator.test.js
+++ b/functions/test/services/repeating/repeatTimeEnumerator.test.js
@@ -108,3 +108,43 @@ describe('RepeatTimeEnumerator — nextEventTimes (end / count / exclude)', () =
         assert.deepEqual(r.map((x) => x.turn), [2, 3, 4])
     })
 })
+
+describe('RepeatTimeEnumerator — seekTurnUntil (naive 교차검증)', () => {
+    const { RepeatTimeEnumerator } = require('../../../services/repeating/repeatTimeEnumerator')
+    // naive: start부터 t 직전까지 nextEventTime 반복하며 turn 카운트
+    function naiveTurnAt(en, startTime, t) {
+        let turn = 1 // start 자체가 turn 1
+        let cursor = { time: startTime, turn: 1 }
+        for (;;) {
+            const next = en.nextEventTime(cursor, null)
+            if (next == null) break
+            const lb = next.time.time_type === 'at' ? next.time.timestamp : next.time.period_start
+            if (lb >= t) break
+            turn = next.turn
+            cursor = next
+        }
+        return turn
+    }
+    function check(optionJson, startMs, tMs) {
+        const startTime = { time_type: 'at', timestamp: startMs }
+        const en = new RepeatTimeEnumerator(optionJson, {})
+        const seeked = en.seekTurnUntil(startTime, tMs)
+        const naive = naiveTurnAt(en, startTime, tMs)
+        assert.equal(seeked.turn, naive, `turn mismatch for ${optionJson.optionType}`)
+    }
+    it('every_day interval 1: 먼 과거 start도 동일 turn', () => {
+        check({ optionType: 'every_day', interval: 1 }, ms('2020-01-01 00:00'), ms('2023-06-01 00:00'))
+    })
+    it('every_week', () => {
+        check({ optionType: 'every_week', interval: 1, dayOfWeek: [2, 4, 6], timeZone: SEOUL },
+            ms('2022-01-03 09:00'), ms('2023-06-01 00:00'))
+    })
+    it('every_month days', () => {
+        check({ optionType: 'every_month', interval: 1, monthDaySelection: { days: [1, 15, 31] }, timeZone: SEOUL },
+            ms('2021-01-01 09:00'), ms('2023-06-01 00:00'))
+    })
+    it('every_year_some_day', () => {
+        check({ optionType: 'every_year_some_day', interval: 1, month: 3, day: 10, timeZone: SEOUL },
+            ms('2015-03-10 09:00'), ms('2023-06-01 00:00'))
+    })
+})


### PR DESCRIPTION
## 배경

openAPI(`/v2/open/*`) 기간 조회는 조회 구간과 겹치는 **원본 이벤트만** 반환하고, 반복 규칙(`repeating.option`)은 그대로 내려가 실제 발생 날짜는 클라가 직접 계산해야 했다. 이 로직은 iOS 클라(`EventRepeatTimeEnumerator.swift`)에만 존재한다. 특히 MCP client(LLM)에 날짜 산술(요일 누적·월말 스킵·윤년·음력)을 맡기면 부정확하다.

## 접근

반복 전개를 서버에서 수행해 occurrence(개별 회차) 단위로 내려주는 조회 API를 신설했다.

```
GET /v2/open/todos/expanded?lower={s}&upper={s}&limit=100&cursor=<opaque>
GET /v2/open/schedules/expanded?lower={s}&upper={s}&limit=100&cursor=<opaque>
```

- **클라 로직 1:1 포팅** — `EventRepeatTimeEnumerator.swift`를 `services/repeating/`에 순수 도메인 모듈로 옮겼다(firestore 무지). 6종 옵션(every_day/week/month/year/year_some_day/lunar) 전부 서버 계산. 정확성은 **클라 Swift 테스트 벡터를 그대로 미러링**한 테스트로 고정(31일 스킵·2/29 clamp·exclude turn 미소비·end/end_count).
- **turn 회복(seek-count)** — `repeating.start`부터의 회차(turn)를 occurrence 단위가 아니라 주기 단위로 카운트해, start가 먼 과거인 무한 반복도 폭발하지 않게 했다. naive 전개와 동일 turn을 내는지 교차 검증.
- **stateless cursor 페이징** — 여러 반복 이벤트의 occurrence를 k-way merge(min-heap)로 시각순 통합, lazy 생성. cursor는 전역 고정 크기 `(t, occurrence_id)`. 다음 페이지는 seek-count로 turn을 다시 회복하므로 server state·cursor 비대 없음.
- **정규화 응답** — `events{}`(원본 메타 origin당 1벌, 반복 규칙 포함) + `occurrences[]`(시각순 평탄 배열: origin_event_id + turn + 계산된 event_time). occurrence_id는 `"{origin}:{turn}"`로 클라 합성.
- **진입점은 검증·위임만** — controller가 window 1년 상한(400)·limit clamp(default 100/max 500)·cursor passthrough만, 도메인 로직은 service에 응집.
- **음력 격리** — `lunar-javascript` 기반을 `services/repeating/lunar/`로 격리하고, 클라 `Calendar(.chinese)` 결과(1991→1994 벡터)와 대조하는 E2E 게이트를 둠.

## 구현 중 정정한 두 가지

1. **event_time 단위 = 초(seconds).** 백엔드/iOS(`TimeInterval`)가 초로 저장·직렬화한다(`EventTimeMapper`가 *1000 없이 직렬화, sentinel `eventTimeMaxUpperBound`·기존 데이터가 초). 초기 ms 가정을 초 네이티브로 정정(luxon 경계에서만 ×1000/÷1000). 부수효과로 open-ended 반복이 time-range index에 정상으로 잡히게 됨.
2. **`repeating.end` 전개 시 강제.** enumerator가 종료일(`this.until`)을 안 읽어 종료일 있는 반복이 window 끝까지 과생성되던 버그를 수정 — 이벤트 자체 종료일과 조회 window를 독립적으로 cap. 회귀 테스트 추가.

## 테스트

- enumerator 미러(클라 Swift 벡터 1:1) + seek naive 교차검증
- paging(cursor 이어받기·동시각 tiebreak·repeating.end·lazy 생성)
- service/controller(window 상한·limit clamp·정규화·exclude·비반복 turn=1)
- E2E(전개·페이징·scope + 음력 Swift 벡터 게이트 통과)
- 전체 unit 1209 passing / 0 failing

## 남은 과제 (비차단)

- `dateMath.fromMs`/`shift(deltaMs)` 등 초 정정 후 남은 `Ms` 잔재 네이밍(동작 정확, 이름만 오해소지) → 후속 정리 가능
- 깨진 cursor를 400 대신 1페이지 silent restart → 필요 시 엄격화
- 다년 음력 등 발생 간격 긴 반복을 긴 구간으로 받으려면 1년 window cap 때문에 연 단위로 쪼개 재조회 필요(운영 제약, 스펙 문서에 명시)

Closes #242
