### PR TITLE
[#245] 피처플래그 모듈 도입 — 미완성 기능 composition-root env 게이트

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -37,7 +37,7 @@ const settingRouter = require('./routes/settingRoutes');
 const holidayRouter = require('./routes/holidayRoutes');
 const syncRouter = require('./routes/dataSyncRoutes.js');
 const testRouter = require('./routes/testRoutes');
-const aiRouter = require('./routes/ai/aiRoutes');
+const { isEnabled } = require('./services/featureFlags');
 
 const todoOpenRouter = require('./routes/openapi/todoOpenRoutes');
 const doneTodoOpenRouter = require('./routes/openapi/doneTodoOpenRoutes');
@@ -119,7 +119,11 @@ app.use('/v2/sync', authValidator, setVersion('v2'), syncRouter);
 // aiFrontAPI (/v1/ai/*) — 앱이 호출하는 자연어 명령 진입점 (#153). Firebase Auth.
 // 처리는 비동기 — POST /command 가 ai_jobs/{jobId} doc 만 만들고 jobId 즉시 반환.
 // 실제 Agent Loop 은 aiAgentLoop trigger (별도 export, Firestore onCreate) 가 실행.
-app.use('/v1/ai', authValidator, setVersion('v1'), aiRouter);
+// 미완성 기능 — FEATURE_AI 게이트 (#245). off면 require·mount 자체를 안 해 완전 dark.
+if (isEnabled('ai')) {
+    const aiRouter = require('./routes/ai/aiRoutes');
+    app.use('/v1/ai', authValidator, setVersion('v1'), aiRouter);
+}
 
 // openAPI (/v2/open/*) — PAT (서비스 식별) + signed user JWT (사용자 식별) + scope 인가
 // dones 가 todos 보다 먼저 mount: '/v2/open/todos/dones/...' 가 '/v2/open/todos' 의 prefix 매칭으로 흡수되지 않게.
@@ -194,4 +198,7 @@ exports.oauthClientCleanup = require('./scheduled/oauthClientCleanup');
 exports.oauthRefreshTokenCleanup = require('./scheduled/oauthRefreshTokenCleanup');
 
 // AI agent loop trigger — ai_jobs/{jobId} 문서 생성 시 발화, stub/실 AI 처리 후 결과 기록
-exports.aiAgentLoop = require('./triggers/ai/agentLoopTrigger');
+// 미완성 기능 — FEATURE_AI 게이트 (#245). off면 require·export 자체를 안 해 trigger 미배포.
+if (isEnabled('ai')) {
+    exports.aiAgentLoop = require('./triggers/ai/agentLoopTrigger');
+}

--- a/functions/secrets/.env.test.example
+++ b/functions/secrets/.env.test.example
@@ -67,6 +67,11 @@ OAUTH_RATE_LIMIT_REGISTER_MAX_PER_HOUR=10000
 # AI Agent Loop (#154) — Anthropic 연동 + emulator stub 분기
 # ──────────────────────────────────────────────────────────────────────
 
+# 피처플래그 (#245) — aiFrontAPI(/v1/ai/*) + aiAgentLoop trigger 게이트.
+# 'true' 일 때만 라우트 마운트 + trigger export. production .env 는 미설정(=off)으로 둬
+# 미완성 AI 기능을 dark 처리. 에뮬레이터/E2E 는 AI 경로를 켜야 하므로 'true'.
+FEATURE_AI=true
+
 # emulator 에서 StubAnthropicClient 로 분기 (실 Anthropic API 호출 차단).
 # production 에서는 이 값이 'true' 여서는 안 됨.
 AI_STUB_ANTHROPIC=true

--- a/functions/services/featureFlags.js
+++ b/functions/services/featureFlags.js
@@ -1,0 +1,8 @@
+// 미완성/실험 기능을 composition root(index.js)에서만 끄고 켜는 env 게이트.
+// FEATURE_<NAME> env가 정확히 'true'일 때만 on. 미설정 포함 그 외 값은 전부 off (default off).
+// 모르는 flag 이름이면 해당 env가 없으니 자연히 off — registry 대조/throw 없음 (fail-safe).
+function isEnabled(name) {
+    return process.env[`FEATURE_${name.toUpperCase()}`] === 'true'
+}
+
+module.exports = { isEnabled }

--- a/functions/test/services/featureFlags.test.js
+++ b/functions/test/services/featureFlags.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert')
+const { isEnabled } = require('../../services/featureFlags')
+
+describe('featureFlags.isEnabled', () => {
+    const ENV = 'FEATURE_AI'
+    let original
+
+    beforeEach(() => { original = process.env[ENV] })
+    afterEach(() => {
+        if (original === undefined) delete process.env[ENV]
+        else process.env[ENV] = original
+    })
+
+    it("env가 정확히 'true'면 on", () => {
+        process.env[ENV] = 'true'
+        assert.equal(isEnabled('ai'), true)
+    })
+
+    it('flag명 대소문자 무관 — env는 대문자 FEATURE_<NAME>', () => {
+        process.env[ENV] = 'true'
+        assert.equal(isEnabled('AI'), true)
+    })
+
+    it('env 미설정이면 off (default)', () => {
+        delete process.env[ENV]
+        assert.equal(isEnabled('ai'), false)
+    })
+
+    it("'true' 외 값('false'/'1'/'on'/임의)은 전부 off", () => {
+        for (const v of ['false', '1', 'on', 'yes', 'TRUE', '']) {
+            process.env[ENV] = v
+            assert.equal(isEnabled('ai'), false, `value=${JSON.stringify(v)}`)
+        }
+    })
+
+    it('모르는 flag 이름은 throw 없이 off (fail-safe)', () => {
+        assert.equal(isEnabled('nope_unknown_flag'), false)
+    })
+})


### PR DESCRIPTION
## 배경

PR #244(#242 openAPI 반복 전개) 배포 검토 중, 아직 개발이 덜 끝난 **aiFrontAPI**(`/v1/ai/*` 라우트 + `aiAgentLoop` Firestore trigger)가 소스에 **무조건 wired** 돼 있는 걸 발견. 이대로 배포하면 off-switch 없이 외부에 노출되고 trigger도 프로덕션에 깔림. (load-time crash 위험은 없음 — Anthropic SDK는 key 없어도 throw 안 하고 todocalendar-tools는 dynamic import. 문제는 "끌 수단이 없다"는 것.)

## 접근

env 기반 피처플래그로 미완성 기능을 **composition root에서만** 게이트. **분기 최소** — registry/메타데이터/런타임 store 없이 helper 한 개 + 적용 지점만.

- `services/featureFlags.isEnabled(name)` — `FEATURE_<NAME>` env가 정확히 `'true'`일 때만 on. 미설정 포함 그 외 값은 전부 off (default off). 모르는 flag명은 throw 없이 off (fail-safe).
- `index.js` — `/v1/ai` 마운트와 `aiAgentLoop` export를 `isEnabled('ai')`로 감쌈. off면 `require` 자체를 안 해 라우트·trigger가 **완전 dark**.
- `secrets/.env.test.example` — `FEATURE_AI=true` 추가. 에뮬레이터/E2E는 AI 경로 그대로 동작, 프로덕션 `.env`는 미설정(off)으로 둬 미완성 AI를 dark 처리.

## 설계 결정 — 왜 JSON registry 없이 최소인가

`plan limit` 류는 순수 lookup 데이터라 JSON 분리가 곧 확장성이지만, 피처플래그 on/off는 이미 env로 외부화돼 있고 flag "존재"는 게이트 코드와 본질적으로 묶임(추가는 항상 코드 변경 동반). 별도 registry는 토글 유연성을 더 주지 않고 파일·간접층만 늘림 → 최소 helper가 정답.

## 검증

- `test/services/featureFlags.test.js` 5케이스 (on / 대소문자 / 미설정 off / `'true'` 외 값 off / 모르는 flag fail-safe) GREEN
- 전체 unit 1215 passing, `index.js` 구문 OK

## 후속

- 런타임 토글(Firestore / Remote Config)이 필요해지면 `isEnabled` 인터페이스 뒤에 store 구현만 교체 — 호출처 변경 없음.
- AI 완성 시 프로덕션 `.env`에 `FEATURE_AI=true` + redeploy.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)