### PR TITLE
[#243] confirm 미동의(거부) API 추가

### DIFF
--- a/docs/spec/aiFront.md
+++ b/docs/spec/aiFront.md
@@ -45,7 +45,7 @@
 | 객체 | 위치 | 책임 |
 |---|---|---|
 | `AiController` | `controllers/ai/aiController.js` | HTTP body / header 검증, `jobId` 즉시 반환 (202) |
-| `JobService` | `services/ai/jobService.js` | job doc create, state CAS (PENDING→RUNNING→종결) |
+| `JobService` | `services/ai/jobService.js` | job doc create, state CAS (PENDING→RUNNING→종결, CONFIRM→REJECTED 거부) |
 | `JobRepository` | `repositories/ai/jobRepository.js` | Firestore `ai_jobs` 컬렉션 IO (transaction 기반 CAS) |
 | `agentLoopTrigger` | `triggers/ai/agentLoopTrigger.js` | `ai_jobs/{jobId}` onCreate trigger (composition root) |
 | `AgentLoopHandler` | `triggers/ai/agentLoopHandler.js` | 전이 가드, usage record, FCM 발송, 에러 sanitize |
@@ -64,6 +64,7 @@
 |---|---|---|---|---|
 | POST | `/v1/ai/command` | `{ command_text, timezone }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
 | POST | `/v1/ai/command/confirm` | `{ parent_job_id, tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
+| POST | `/v1/ai/command/reject` | `{ job_id }` | `Authorization`, `device_id` | `204 No Content` |
 | GET | `/v1/ai/jobs/:id` | — | `Authorization` | `200 AiJob.toJSON()` |
 | GET | `/v1/ai/usage` | — | `Authorization` | `200 AiUsage.toJSON() + { daily_limit }` (오늘 사용량 + 일일 한도) |
 
@@ -72,10 +73,11 @@
 - `Accept-Language` 헤더에서 `ko` / `en` 자동 결정 → `job.lang` 저장. 누락 / unsupported → `en` default. 표준 q-factor / region tag (`ko-KR`) 처리.
 - 누락 / invalid → 400.
 - `POST /v1/ai/command` 은 일일 토큰 한도 (`daily_limit`) 초과 시 controller 가 agent loop 진입 전 차단 → `202 { job_id }` 그대로 + Firestore 의 해당 job 은 즉시 `FAILED` (`errorCode: DailyLimitExceeded`). `/confirm` 은 한도 적용 X (#157).
+- `POST /v1/ai/command/reject` 는 confirm 대기 (`CONFIRM`) 1차 job 을 사용자 미동의 (거부) 로 종결 (#243). body 의 `job_id` 는 confirm path 의 `parent_job_id` 와 같은 대상 (1차 command job). 해당 job 을 `CONFIRM → REJECTED` 로 전이만 하고 **데이터 mutation·confirmToken 검증·trigger·FCM 없음**. 클라가 **fire-and-forget** 으로 호출 — 응답 안 기다리고 즉시 미동의 UI 로 전환. **멱등**: 이미 종결 (`REJECTED`/`DONE`/`FAILED`) 된 job 중복 호출도 `204`. 소유권 불일치 403 / 미존재 404. (전이 성공/no-op 여부와 무관하게 항상 `204` — 클라는 본문·상태코드 분기 불필요.)
 
 ## Firestore Collections
 
-- **`ai_jobs/{jobId}`** — 단일 job. status: `PENDING` → `RUNNING` → `{DONE | CONFIRM | FAILED}`.
+- **`ai_jobs/{jobId}`** — 단일 job. status: `PENDING` → `RUNNING` → `{DONE | CONFIRM | FAILED}`, 그리고 `CONFIRM` → `REJECTED` (사용자 미동의, #243).
   필드: `userId`, `deviceId`, `commandText`, `timezone`, `lang` (`ko`|`en`), `mode` (`command`|`confirm`), `confirmPayload`,
   `status`, `result` (`AiJobResult` plain object), `createdAt`, `updatedAt`, `expireAt` (24h).
 - **`aiUsage/{userId}/dailyUsage/{YYYY-MM-DD}`** — UTC 기준 일별 토큰 누적.
@@ -210,6 +212,34 @@ sequenceDiagram
 
 ---
 
+## 시퀀스: REJECT 흐름 (CONFIRM 미동의)
+
+`CONFIRM` 응답을 받은 사용자가 **미동의 (거부)** 를 선택. confirm 2차 흐름과 달리 **trigger·Claude·lib·FCM 을 거치지 않는 동기 처리** — confirm 대기 job 의 status 만 `CONFIRM → REJECTED` 로 전이하고 즉시 응답. 데이터 mutation 없음.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App
+    participant Ctrl as AiController
+    participant JobSvc as JobService
+    participant FS as Firestore ai_jobs
+    App->>Ctrl: POST /v1/ai/command/reject with job_id, device_id
+    Ctrl->>Ctrl: validate device_id and job_id
+    Ctrl->>JobSvc: rejectConfirm with userId, jobId
+    JobSvc->>FS: load jobId
+    Note over JobSvc: 미존재 404, job.userId 불일치 403
+    JobSvc->>FS: tx CONFIRM to REJECTED via CAS
+    Note over JobSvc,FS: status 가 CONFIRM 이 아니면 no-op false (멱등) — result 보존
+    JobSvc-->>Ctrl: transitioned boolean
+    Ctrl-->>App: 204 No Content
+    Note over App: 응답·전이 결과와 무관하게 즉시 미동의 UI 전환 (fire-and-forget)
+    Note over JobSvc,FS: 데이터 mutation 없음, confirmToken 검증 없음, FCM 없음
+```
+
+reject 와 trigger 의 race 는 안전하다 — handler 는 `RUNNING → 종결` 로만, reject 는 `CONFIRM → REJECTED` 로만 전이해 **source 상태가 disjoint**. 동시 인입돼도 서로 덮어쓰지 않는다.
+
+---
+
 ## 시퀀스: GET /v1/ai/usage
 
 ```mermaid
@@ -266,11 +296,11 @@ Content-Type: application/json
 
 ```
 PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
-                                       ├─▶ CONFIRM   (terminal)
+                                       ├─▶ CONFIRM ──(POST /command/reject)──▶ REJECTED
                                        └─▶ FAILED
 ```
 
-`status` 가 terminal (`DONE` / `CONFIRM` / `FAILED`) 이면 `result` 필드에 `AiJobResult` 가 박혀 있다.
+`status` 가 terminal (`DONE` / `CONFIRM` / `FAILED` / `REJECTED`) 이면 `result` 필드에 `AiJobResult` 가 박혀 있다. `REJECTED` 는 거부된 `CONFIRM` 의 `result` (= `type: CONFIRM`, `action` 포함) 를 **그대로 보존**한다 — 무엇을 거부했는지 추적용. 따라서 **상태 판단은 `status` 필드 기준** (`result.type` 아님).
 
 ### `AiJobResult` 응답 형태
 
@@ -317,7 +347,7 @@ PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
 | `type` | 클라가 할 일 |
 |---|---|
 | `DONE` | `text` 사용자에게 표시 (toast / chat 등). **`mutations` 보고 영향받은 도메인 list/cache invalidate**. |
-| `CONFIRM` | `text` 로 confirm UI 표시. **사용자가 승인하면 `action` 통째로 2차 호출 body 에 박아 `POST /v1/ai/command/confirm`** 호출 (`action.parentJobId` 는 body 의 `parent_job_id` 자리로). 거부 시 그냥 폐기. 1차 응답에 `mutations` 가 박혀 있을 수 있음 (이전 turn 의 변경) → list reload. |
+| `CONFIRM` | `text` 로 confirm UI 표시. **승인 시** `action` 통째로 2차 호출 body 에 박아 `POST /v1/ai/command/confirm` 호출 (`action.parentJobId` 는 body 의 `parent_job_id` 자리로). **거부 시** `action.parentJobId` 를 `job_id` 로 담아 `POST /v1/ai/command/reject` fire-and-forget 호출 (아래 "거부 호출" 참고). 1차 응답에 `mutations` 가 박혀 있을 수 있음 (이전 turn 의 변경) → list reload. |
 | `FAILED` | `reason` 사용자에게 표시. **`errorCode` 보고 분류 / 다른 UX 분기**. `mutations` 도 박혀 있을 수 있음 (부분 mutation) → reload. |
 
 ### 2차 호출 — CONFIRM 확인 후
@@ -345,7 +375,27 @@ Content-Type: application/json
 
 응답은 1차와 동일하게 `{ job_id }` — 새 jobId 발급되어 1차 jobId 와 독립. 같은 흐름으로 `ai_jobs/{newJobId}` 결과 대기.
 
-### `mutations` 처리
+### 거부 호출 — CONFIRM 미동의 시 (#243)
+
+사용자가 confirm UI 에서 **미동의 (거부)** 를 누르면 호출. 1차 응답 `action.parentJobId` 를 `job_id` 로 담는다 (confirm 의 `parent_job_id` 와 같은 대상).
+
+```http
+POST /v1/ai/command/reject
+Authorization: Bearer <Firebase ID token>
+device_id: <device id>
+Content-Type: application/json
+
+{
+  "job_id": "<1차 응답의 action.parentJobId>"
+}
+```
+
+응답: `204 No Content`.
+
+- **fire-and-forget** — 응답을 기다리지 말고 즉시 화면을 미동의/취소 상태로 전환. 네트워크 실패·에러는 무시. 서버가 멱등 처리라 중복 호출·재탭 모두 안전.
+- `confirm_token` 불필요 — `job_id` 만 보낸다.
+- **`device_id` 헤더 필수** — 빠지면 `400` 이고 거부 처리가 안 돼 job 이 `CONFIRM` 으로 남는다. fire-and-forget 이라 클라가 `400` 을 못 보니 반드시 포함.
+- 처리 후 해당 job 의 `status` 가 `REJECTED` 로 바뀐다. 히스토리·재진입 등으로 다시 조회하면 `status: REJECTED` + 거부한 `action` 이 보존된 `result` 가 보인다.
 
 도메인 별 reload 결정에 사용. `dataType` × `op` 매핑:
 

--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -109,6 +109,26 @@ class AiController {
         res.status(202).send({ job_id: jobId });
     }
 
+    async postCommandReject(req, res) {
+        const deviceId = req.header('device_id');
+        if (!deviceId) {
+            throw new Errors.BadRequest('device_id header is required');
+        }
+
+        // reject path body:
+        //  - job_id: confirm 대기 중인 1차 command job 의 jobId (confirm path 의
+        //    parent_job_id 와 같은 대상). 그 job 을 REJECTED 로 종결시킨다.
+        const jobId = req.body.job_id;
+        if (!jobId || typeof jobId !== 'string') {
+            throw new Errors.BadRequest('job_id is required');
+        }
+
+        const userId = req.auth.uid;
+        // 클라가 fire-and-forget 으로 호출 — 전이 성공/no-op 여부와 무관하게 204.
+        await this.jobService.rejectConfirm({ userId, jobId });
+        res.status(204).send();
+    }
+
     async getUsage(req, res) {
         const userId = req.auth.uid;
         const [usage, dailyLimit] = await Promise.all([

--- a/functions/models/ai/AiJob.js
+++ b/functions/models/ai/AiJob.js
@@ -68,16 +68,20 @@ class AiJob {
     static isTerminal(status) {
         return status === AiJob.STATUS.DONE ||
                status === AiJob.STATUS.CONFIRM ||
-               status === AiJob.STATUS.FAILED;
+               status === AiJob.STATUS.FAILED ||
+               status === AiJob.STATUS.REJECTED;
     }
 }
 
+// REJECTED: confirm 대기(CONFIRM) job 을 사용자가 미동의(거부)로 종결시킨 상태 (#243).
+//           confirm 2차 호출(processConfirmCommand) 의 거부 짝 — 데이터 mutation 없음.
 AiJob.STATUS = Object.freeze({
     PENDING: 'PENDING',
     RUNNING: 'RUNNING',
     DONE: 'DONE',
     CONFIRM: 'CONFIRM',
-    FAILED: 'FAILED'
+    FAILED: 'FAILED',
+    REJECTED: 'REJECTED'
 });
 
 // 'command': 자연어 명령 (1차) — Agent Loop run() 진입

--- a/functions/repositories/ai/jobRepository.js
+++ b/functions/repositories/ai/jobRepository.js
@@ -86,6 +86,28 @@ class JobRepository {
             return true;
         });
     }
+
+    /**
+     * CONFIRM → REJECTED 상태 전이 (#243). transaction 으로 원자적 수행.
+     * 현재 status 가 CONFIRM 이 아니면 false 반환 — 멱등 no-op.
+     * result 는 건드리지 않는다 (거부된 confirm action 을 히스토리로 보존).
+     *
+     * @param {string} jobId
+     * @returns {boolean} CONFIRM 에서 전이가 실제로 일어났는지 여부
+     */
+    async rejectConfirm(jobId) {
+        const docRef = collectionRef.doc(jobId);
+        return db.runTransaction(async (tx) => {
+            const snapshot = await tx.get(docRef);
+            if (!snapshot.exists) return false;
+            if (snapshot.data().status !== AiJob.STATUS.CONFIRM) return false;
+            tx.update(docRef, {
+                status: AiJob.STATUS.REJECTED,
+                updatedAt: FieldValue.serverTimestamp()
+            });
+            return true;
+        });
+    }
 }
 
 module.exports = JobRepository;

--- a/functions/routes/ai/aiRoutes.js
+++ b/functions/routes/ai/aiRoutes.js
@@ -15,6 +15,7 @@ const controller = new AiController(jobService, aiUsageService);
 const router = express.Router();
 router.post('/command', (req, res) => controller.postCommand(req, res));
 router.post('/command/confirm', (req, res) => controller.postCommandConfirm(req, res));
+router.post('/command/reject', (req, res) => controller.postCommandReject(req, res));
 router.get('/jobs/:id', (req, res) => controller.getJob(req, res));
 router.get('/usage', (req, res) => controller.getUsage(req, res));
 

--- a/functions/services/ai/jobService.js
+++ b/functions/services/ai/jobService.js
@@ -178,6 +178,34 @@ class JobService {
     async completeWith(jobId, result) {
         return this.jobRepository.completeWith(jobId, result);
     }
+
+    /**
+     * #243 — confirm 대기(CONFIRM) job 을 사용자 미동의(거부)로 종결.
+     *
+     * confirm 2차 호출(createConfirmJob)의 거부 짝. 데이터 mutation·토큰 검증 없이
+     * 1차 command job 의 status 만 CONFIRM → REJECTED 로 전이(CAS). 새 job 을 만들지
+     * 않고 기존 job 을 종결 — `result`(거부된 action 포함)는 그대로 보존해 무엇을
+     * 거부했는지 히스토리로 남긴다.
+     *
+     * - job 미존재 → NotFound
+     * - job.userId !== userId → 403 (타인 job 거부 차단)
+     *
+     * 멱등성: CONFIRM 이 아닌 상태(이미 REJECTED / DONE / FAILED 등)면 전이 없이 false.
+     * 클라가 fire-and-forget 으로 호출하므로 중복·경합 호출도 throw 없이 안전.
+     *
+     * @param {{ userId: string, jobId: string }} params
+     * @returns {Promise<boolean>} CONFIRM → REJECTED 전이가 실제로 일어났는지 여부
+     */
+    async rejectConfirm({ userId, jobId }) {
+        const job = await this.jobRepository.load(jobId);
+        if (!job) {
+            throw new Errors.NotFound('job not found');
+        }
+        if (job.userId !== userId) {
+            throw new Errors.Base(403, 'Forbidden', 'forbidden');
+        }
+        return this.jobRepository.rejectConfirm(jobId);
+    }
 }
 
 module.exports = JobService;

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -325,6 +325,71 @@ describe('AiController', () => {
     });
 
 
+    // MARK: - postCommandReject
+
+    describe('postCommandReject', () => {
+
+        function makeRejectReq({ uid = 'user-1', deviceId = 'device-1', jobId = 'job-123' } = {}) {
+            return {
+                auth: { uid },
+                header: (name) => {
+                    if (name === 'device_id') return deviceId;
+                    return null;
+                },
+                body: { job_id: jobId }
+            };
+        }
+
+        it('정상 — 204 (본문 없음), rejectConfirm 에 userId + jobId 전달', async () => {
+            const req = makeRejectReq();
+            const res = makeRes();
+
+            await controller.postCommandReject(req, res);
+
+            assert.equal(res.statusCode, 204);
+            assert.deepEqual(stubService.lastRejectConfirmArgs, { userId: 'user-1', jobId: 'job-123' });
+        });
+
+        it('이미 종결돼 전이가 안 일어나도(rejectConfirm=false) 204 — fire-and-forget 멱등', async () => {
+            stubService.rejectConfirmResult = false;
+            const req = makeRejectReq();
+            const res = makeRes();
+
+            await controller.postCommandReject(req, res);
+
+            assert.equal(res.statusCode, 204);
+        });
+
+        it('device_id 헤더 누락 → 400', async () => {
+            const req = makeRejectReq({ deviceId: null });
+            await assert.rejects(() => controller.postCommandReject(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('job_id 누락 → 400', async () => {
+            const req = makeRejectReq();
+            delete req.body.job_id;
+            await assert.rejects(() => controller.postCommandReject(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('job_id 빈 문자열 → 400', async () => {
+            const req = makeRejectReq({ jobId: '' });
+            await assert.rejects(() => controller.postCommandReject(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('job_id 가 비문자열 → 400', async () => {
+            const req = makeRejectReq();
+            req.body.job_id = 123;
+            await assert.rejects(() => controller.postCommandReject(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('서비스가 NotFound/403 throw → 그대로 전파', async () => {
+            stubService.shouldFail = true;
+            const req = makeRejectReq();
+            await assert.rejects(() => controller.postCommandReject(req, makeRes()));
+        });
+    });
+
+
     // MARK: - getJob
 
     describe('getJob', () => {

--- a/functions/test/doubles/stubAiJobRepository.js
+++ b/functions/test/doubles/stubAiJobRepository.js
@@ -24,6 +24,7 @@ class StubAiJobRepository {
         // recorders
         this.lastPutPayload = null;       // { jobId, data }
         this.lastTransitionAttempt = null; // jobId (most recent call)
+        this.lastRejectAttempt = null;     // jobId (most recent rejectConfirm call)
     }
 
     /**
@@ -96,6 +97,26 @@ class StubAiJobRepository {
         }
         data.status = result.type;   // 'DONE' | 'CONFIRM' | 'FAILED'
         data.result = result;
+        return true;
+    }
+
+    /**
+     * CONFIRM → REJECTED 상태 전이 (Compare-And-Swap 시뮬레이션, #243).
+     * 현재 status 가 CONFIRM 이면 REJECTED 로 갱신하고 true 반환.
+     * 아니면 false (이미 REJECTED 거나 다른 상태 — 멱등 no-op).
+     *
+     * lastRejectAttempt 에 jobId 를 기록한다.
+     *
+     * @param {string} jobId
+     * @returns {Promise<boolean>}
+     */
+    async rejectConfirm(jobId) {
+        this.lastRejectAttempt = jobId;
+        const data = this._store.get(jobId);
+        if (!data || data.status !== AiJob.STATUS.CONFIRM) {
+            return false;
+        }
+        data.status = AiJob.STATUS.REJECTED;
         return true;
     }
 }

--- a/functions/test/doubles/stubAiJobService.js
+++ b/functions/test/doubles/stubAiJobService.js
@@ -9,6 +9,8 @@ class StubAiJobService {
         this.shouldFail = false;
         this.lastCreateJobArgs = null;
         this.lastCreateConfirmJobArgs = null;
+        this.lastRejectConfirmArgs = null;
+        this.rejectConfirmResult = true;
         this._jobs = {};
         this._nextJobId = 'job-123';
     }
@@ -27,6 +29,12 @@ class StubAiJobService {
         if (this.shouldFail) throw { message: 'service failed' };
         this.lastCreateConfirmJobArgs = { userId, deviceId, parentJobId, timezone, lang, confirmPayload };
         return this._nextJobId;
+    }
+
+    async rejectConfirm({ userId, jobId }) {
+        if (this.shouldFail) throw { message: 'service failed' };
+        this.lastRejectConfirmArgs = { userId, jobId };
+        return this.rejectConfirmResult;
     }
 
     async loadJob(jobId) {

--- a/functions/test/e2e/ai-reject.e2e.js
+++ b/functions/test/e2e/ai-reject.e2e.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const assert = require('assert');
+
+const { authedClient } = require('./helpers/request');
+const { signUserToken, openClient, defaultMcpPat } = require('./helpers/openClient');
+const { TEST_USER_UID } = require('./seeds/commonData');
+
+// 1차 [stub:CONFIRM:<id>] → CONFIRM → reject endpoint → REJECTED 흐름 검증 (#243).
+// confirm 미동의(거부) 짝. 실제 데이터 mutation 이 없어야 하므로 시드한 todo 가
+// reject 이후에도 살아있음을 openAPI GET 200 으로 확인.
+
+async function pollJob(client, jobId, { timeoutMs = 8000, intervalMs = 100 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const res = await client.get(`/v1/ai/jobs/${jobId}`);
+        if (res.status === 200 && ['DONE', 'CONFIRM', 'FAILED', 'REJECTED'].includes(res.data.status)) {
+            return res.data;
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error(`pollJob timeout (${timeoutMs}ms) — jobId: ${jobId}`);
+}
+
+describe('aiFrontAPI confirm 미동의(거부)', function () {
+
+    let client;
+    let openCli;
+
+    before(function () {
+        client = authedClient();
+        const userToken = signUserToken({
+            sub: TEST_USER_UID,
+            scope: ['read:calendar', 'write:calendar']
+        });
+        openCli = openClient({ pat: defaultMcpPat(), userToken });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    describe('POST /v1/ai/command/reject — body validation', function () {
+
+        it('job_id 누락 → 400', async function () {
+            const res = await client.post(
+                '/v1/ai/command/reject',
+                {},
+                { headers: { device_id: 'e2e-device-reject' } }
+            );
+            assert.strictEqual(res.status, 400);
+        });
+
+        it('device_id 헤더 누락 → 400', async function () {
+            const res = await client.post(
+                '/v1/ai/command/reject',
+                { job_id: 'whatever' }
+            );
+            assert.strictEqual(res.status, 400);
+        });
+
+        it('존재하지 않는 job_id → 404', async function () {
+            const res = await client.post(
+                '/v1/ai/command/reject',
+                { job_id: 'no-such-job' },
+                { headers: { device_id: 'e2e-device-reject' } }
+            );
+            assert.strictEqual(res.status, 404);
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    describe('골든 흐름 — 1차 CONFIRM → reject → REJECTED + 멱등 + mutation 없음', function () {
+
+        let createdTodoId;
+        let parentJobId;
+
+        it('todo 시드 → 1차 [stub:CONFIRM:<id>] → CONFIRM 대기', async function () {
+            this.timeout(15000);
+
+            const createRes = await openCli.post('/v2/open/todos/', {
+                name: 'AI reject e2e todo',
+                event_time: { time_type: 'at', timestamp: Math.floor(Date.now() / 1000) + 3600 }
+            });
+            assert.strictEqual(createRes.status, 201);
+            createdTodoId = createRes.data.uuid;
+
+            const cmdRes = await client.post(
+                '/v1/ai/command',
+                {
+                    command_text: `[stub:CONFIRM:${createdTodoId}] 이거 삭제해`,
+                    timezone: 'Asia/Seoul'
+                },
+                { headers: { device_id: 'e2e-device-reject' } }
+            );
+            assert.strictEqual(cmdRes.status, 202);
+            parentJobId = cmdRes.data.job_id;
+
+            const job1 = await pollJob(client, parentJobId);
+            assert.strictEqual(job1.status, 'CONFIRM');
+        });
+
+        it('reject 호출 → 204 → job 이 REJECTED 로 종결', async function () {
+            this.timeout(15000);
+
+            const rejectRes = await client.post(
+                '/v1/ai/command/reject',
+                { job_id: parentJobId },
+                { headers: { device_id: 'e2e-device-reject' } }
+            );
+            assert.strictEqual(rejectRes.status, 204);
+
+            const job = (await client.get(`/v1/ai/jobs/${parentJobId}`)).data;
+            assert.strictEqual(job.status, 'REJECTED');
+            // 거부된 action 이 result 에 보존됨 (무엇을 거부했는지 추적)
+            assert.ok(job.result && job.result.action, 'CONFIRM result.action 보존');
+        });
+
+        it('중복 reject 호출 → 여전히 204, 상태 REJECTED 유지 (멱등)', async function () {
+            this.timeout(15000);
+
+            const rejectAgain = await client.post(
+                '/v1/ai/command/reject',
+                { job_id: parentJobId },
+                { headers: { device_id: 'e2e-device-reject' } }
+            );
+            assert.strictEqual(rejectAgain.status, 204);
+
+            const job = (await client.get(`/v1/ai/jobs/${parentJobId}`)).data;
+            assert.strictEqual(job.status, 'REJECTED');
+        });
+
+        it('데이터 mutation 없음 — 시드한 todo 가 살아있음 (openAPI GET 200)', async function () {
+            this.timeout(15000);
+
+            const checkRes = await openCli.get(`/v2/open/todos/${createdTodoId}`);
+            assert.strictEqual(checkRes.status, 200, 'reject 는 삭제하지 않음');
+        });
+    });
+});

--- a/functions/test/models/ai/AiJob.test.js
+++ b/functions/test/models/ai/AiJob.test.js
@@ -5,12 +5,13 @@ const AiJob = require('../../../models/ai/AiJob');
 describe('AiJob', () => {
 
     describe('STATUS enum', () => {
-        it('5개 상태 상수가 모두 존재함', () => {
+        it('6개 상태 상수가 모두 존재함', () => {
             assert.strictEqual(AiJob.STATUS.PENDING, 'PENDING');
             assert.strictEqual(AiJob.STATUS.RUNNING, 'RUNNING');
             assert.strictEqual(AiJob.STATUS.DONE, 'DONE');
             assert.strictEqual(AiJob.STATUS.CONFIRM, 'CONFIRM');
             assert.strictEqual(AiJob.STATUS.FAILED, 'FAILED');
+            assert.strictEqual(AiJob.STATUS.REJECTED, 'REJECTED');
         });
     });
 
@@ -32,6 +33,10 @@ describe('AiJob', () => {
 
         it('FAILED 는 terminal', () => {
             assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.FAILED), true);
+        });
+
+        it('REJECTED 는 terminal', () => {
+            assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.REJECTED), true);
         });
 
         it('PENDING 은 terminal 아님', () => {

--- a/functions/test/services/ai/jobService.test.js
+++ b/functions/test/services/ai/jobService.test.js
@@ -421,4 +421,76 @@ describe('JobService', () => {
             assert.strictEqual(success, false);
         });
     });
+
+    // ------------------------------------------------------------------ //
+    // rejectConfirm (#243)
+    // ------------------------------------------------------------------ //
+
+    describe('rejectConfirm', () => {
+
+        // 1차 command job 을 CONFIRM 상태까지 진행시켜 jobId 반환.
+        async function setupConfirmJob(userId = 'u') {
+            const jobId = await service.createJob({
+                userId, deviceId: 'd', commandText: '할일 지워줘'
+            });
+            await service.transitionToRunning(jobId);
+            await service.completeWith(
+                jobId,
+                AiJobResult.confirm('지울까요?', { tool: 'delete_todo', args: { todo_id: 't1' }, confirmToken: 'tk' })
+            );
+            return jobId;
+        }
+
+        it('CONFIRM 대기 job → REJECTED 로 전이하고 true 반환', async () => {
+            const jobId = await setupConfirmJob('u');
+
+            const result = await service.rejectConfirm({ userId: 'u', jobId });
+            assert.strictEqual(result, true);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.REJECTED);
+        });
+
+        it('이미 REJECTED 인 job 재호출 → throw 없이 false (멱등)', async () => {
+            const jobId = await setupConfirmJob('u');
+            await service.rejectConfirm({ userId: 'u', jobId });
+
+            const result = await service.rejectConfirm({ userId: 'u', jobId });
+            assert.strictEqual(result, false);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.REJECTED);
+        });
+
+        it('CONFIRM 이 아닌 job(DONE) → 전이 없이 false (no-op, 상태 보존)', async () => {
+            const jobId = await service.createJob({ userId: 'u', deviceId: 'd', commandText: 'cmd' });
+            await service.transitionToRunning(jobId);
+            await service.completeWith(jobId, AiJobResult.done('완료'));
+
+            const result = await service.rejectConfirm({ userId: 'u', jobId });
+            assert.strictEqual(result, false);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.DONE);
+        });
+
+        it('존재하지 않는 jobId → NotFound', async () => {
+            await assert.rejects(
+                () => service.rejectConfirm({ userId: 'u', jobId: 'no-such-job' }),
+                (err) => err.status === 404
+            );
+        });
+
+        it('다른 user 의 job → 403 (전이 시도조차 안 함)', async () => {
+            const jobId = await setupConfirmJob('owner');
+
+            await assert.rejects(
+                () => service.rejectConfirm({ userId: 'intruder', jobId }),
+                (err) => err.status === 403
+            );
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.CONFIRM, '거부 실패 — CONFIRM 유지');
+        });
+    });
 });


### PR DESCRIPTION
## 배경

AI 자연어 입력 플로우에서 서버가 `result=confirm`으로 사용자 확인을 요청하는 케이스가 있다. 사용자가 **동의**하면 클라가 `/v1/ai/command/confirm`(confirmToken 포함)을 호출해 작업이 진행되지만, **미동의(거부)** 를 선택했을 때 이를 서버에 통지할 경로가 없었다. 그 결과 거부된 job 이 `CONFIRM` 상태로 남아 사용량 정산에서 거부 사실을 추적할 수 없었다.

closes #243

## 접근

confirm 2차 호출의 **거부 짝**을 추가한다. 새 job 을 만드는 대신 **1차 command job(`CONFIRM` 대기)을 `REJECTED`로 종결**시킨다 — 이슈가 "해당 confirm job 을 거부 상태로 종료"를 명시하기 때문. 데이터 mutation·confirmToken 검증 없이 status 만 전이하고, `result`(거부된 action) 는 보존해 무엇을 거부했는지 히스토리로 남긴다.

- **`AiJob.STATUS.REJECTED`** (terminal) 추가 + `isTerminal()` 인식 → `getJob`/polling 종료 조건 동작
- **`JobRepository.rejectConfirm`** — transaction CAS 로 `CONFIRM` 일 때만 `REJECTED` 전이. 그 외 상태(이미 REJECTED / DONE / FAILED)면 no-op → **fire-and-forget 중복 호출 멱등**
- **`JobService.rejectConfirm`** — 소유권 검증(미존재 404 / 타인 403) 후 위임
- **`POST /v1/ai/command/reject`** `{ job_id }` — 클라가 미동의 버튼에서 fire-and-forget 호출. 전이 성공/no-op 무관하게 항상 `204`

`job_id` 는 confirm path 의 `parent_job_id` 와 같은 대상(1차 command job).

## 검증 (TDD)

- 유닛: 모델 6 / 서비스 5 / 컨트롤러 7 케이스 신규 (전체 1228 passing)
- E2E `ai-reject.e2e`: 골든 흐름(`CONFIRM` → reject `204` → `REJECTED`) + 중복 reject 멱등 + 시드 todo 생존(openAPI GET 200)으로 **mutation 없음** 확인 + body/header/404 검증

## 남은 과제

- 클라(sudopark/TodoCalendar#629)가 `REJECTED` status 핸들링하는지 확인 필요
- `FEATURE_AI` 게이트(#245) 하에 있어 프로덕션은 여전히 dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)