### PR TITLE
[#250] 진행 중 AI 작업 중지 — POST /v1/ai/command/cancel

### DIFF
--- a/docs/spec/aiFront.md
+++ b/docs/spec/aiFront.md
@@ -45,7 +45,7 @@
 | 객체 | 위치 | 책임 |
 |---|---|---|
 | `AiController` | `controllers/ai/aiController.js` | HTTP body / header 검증, `jobId` 즉시 반환 (202) |
-| `JobService` | `services/ai/jobService.js` | job doc create, state CAS (PENDING→RUNNING→종결, CONFIRM→REJECTED 거부) |
+| `JobService` | `services/ai/jobService.js` | job doc create, state CAS (PENDING→RUNNING→종결, CONFIRM→REJECTED 거부, PENDING/RUNNING 중지 #250) |
 | `JobRepository` | `repositories/ai/jobRepository.js` | Firestore `ai_jobs` 컬렉션 IO (transaction 기반 CAS) |
 | `agentLoopTrigger` | `triggers/ai/agentLoopTrigger.js` | `ai_jobs/{jobId}` onCreate trigger (composition root) |
 | `AgentLoopHandler` | `triggers/ai/agentLoopHandler.js` | 전이 가드, usage record, FCM 발송, 에러 sanitize |
@@ -65,6 +65,7 @@
 | POST | `/v1/ai/command` | `{ command_text, timezone }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
 | POST | `/v1/ai/command/confirm` | `{ parent_job_id, tool, args, confirm_token, timezone? }` | `Authorization`, `device_id`, `Accept-Language?` | `202 { job_id }` |
 | POST | `/v1/ai/command/reject` | `{ job_id }` | `Authorization`, `device_id` | `204 No Content` |
+| POST | `/v1/ai/command/cancel` | `{ job_id }` | `Authorization`, `device_id` | `202 Accepted` |
 | GET | `/v1/ai/jobs/:id` | — | `Authorization` | `200 AiJob.toJSON()` |
 | GET | `/v1/ai/usage` | — | `Authorization` | `200 AiUsage.toJSON() + { daily_limit }` (오늘 사용량 + 일일 한도) |
 
@@ -74,12 +75,13 @@
 - 누락 / invalid → 400.
 - `POST /v1/ai/command` 은 일일 토큰 한도 (`daily_limit`) 초과 시 controller 가 agent loop 진입 전 차단 → `202 { job_id }` 그대로 + Firestore 의 해당 job 은 즉시 `FAILED` (`errorCode: DailyLimitExceeded`). `/confirm` 은 한도 적용 X (#157).
 - `POST /v1/ai/command/reject` 는 confirm 대기 (`CONFIRM`) 1차 job 을 사용자 미동의 (거부) 로 종결 (#243). body 의 `job_id` 는 confirm path 의 `parent_job_id` 와 같은 대상 (1차 command job). 해당 job 을 `CONFIRM → REJECTED` 로 전이만 하고 **데이터 mutation·confirmToken 검증·trigger·FCM 없음**. 클라가 **fire-and-forget** 으로 호출 — 응답 안 기다리고 즉시 미동의 UI 로 전환. **멱등**: 이미 종결 (`REJECTED`/`DONE`/`FAILED`) 된 job 중복 호출도 `204`. 소유권 불일치 403 / 미존재 404. (전이 성공/no-op 여부와 무관하게 항상 `204` — 클라는 본문·상태코드 분기 불필요.)
+- `POST /v1/ai/command/cancel` 은 **진행 중**인 작업을 사용자가 중지 (#250). reject 와 동선이 다른 별개 액션 — confirm 거부가 아니라 "지금 돌아가는 거 중지". 대상 상태에 따라 분기: `PENDING` → 즉시 `CANCELED` (trigger 의 `PENDING→RUNNING` CAS 가 실패해 agent loop 진입 차단), `RUNNING` → `cancelRequested` flag 만 set 하고 loop 가 turn 사이 이를 읽어 협조적으로 `CANCELED` 종결 (진행 중인 Claude 호출/tool 한 건은 못 끊고 turn 사이에만 멈춤; 중지 시점까지의 부분 mutation 은 `result` 에 보존, 롤백 없음). `CONFIRM`/terminal → no-op. 클라가 **fire-and-forget** 으로 호출하고 `GET /jobs/:id` 로 최종 상태 재폴링하므로 전이/no-op 무관하게 `202`. 소유권 불일치 403 / 미존재 404.
 
 ## Firestore Collections
 
-- **`ai_jobs/{jobId}`** — 단일 job. status: `PENDING` → `RUNNING` → `{DONE | CONFIRM | FAILED}`, 그리고 `CONFIRM` → `REJECTED` (사용자 미동의, #243).
+- **`ai_jobs/{jobId}`** — 단일 job. status: `PENDING` → `RUNNING` → `{DONE | CONFIRM | FAILED}`, `CONFIRM` → `REJECTED` (사용자 미동의, #243), `PENDING`/`RUNNING` → `CANCELED` (사용자 중지, #250).
   필드: `userId`, `deviceId`, `commandText`, `timezone`, `lang` (`ko`|`en`), `mode` (`command`|`confirm`), `confirmPayload`,
-  `status`, `result` (`AiJobResult` plain object), `createdAt`, `updatedAt`, `expireAt` (24h).
+  `status`, `result` (`AiJobResult` plain object), `cancelRequested` (RUNNING 중지 요청 flag, #250), `createdAt`, `updatedAt`, `expireAt` (24h).
 - **`aiUsage/{userId}/dailyUsage/{YYYY-MM-DD}`** — UTC 기준 일별 토큰 누적.
   필드: `inputTokens`, `outputTokens`, `lastUpdatedAt`.
 
@@ -240,6 +242,43 @@ reject 와 trigger 의 race 는 안전하다 — handler 는 `RUNNING → 종결
 
 ---
 
+## 시퀀스: CANCEL 흐름 (진행 중 작업 중지, #250)
+
+진행 중인 작업을 사용자가 중지. cross-instance (cancel HTTP vs trigger) 라 즉시 abort 불가 — 상태에 따라 다르게 처리한다.
+
+- **PENDING 중지** — trigger 가 아직 `PENDING→RUNNING` CAS 를 선점하기 전. cancel 이 먼저 `PENDING→CANCELED` 로 전이하면, 뒤이어 발화한 trigger 의 `transitionToRunning` CAS 가 status≠PENDING 으로 false → agent loop 진입 자체가 차단된다 (mutation 0).
+- **RUNNING 중지** — loop 가 이미 돌고 있음. cancel 은 `cancelRequested` flag 만 set 하고, loop 가 **매 turn top 에서** 이 flag 를 읽어 다음 Claude 호출 전에 `CANCELED` 로 협조적 종결. 진행 중인 Claude 호출/tool 한 건은 못 끊고 **turn 사이에만** 멈춘다. 중지 시점까지의 부분 mutation 은 `result.mutations` 에 보존 (롤백 없음).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App
+    participant Ctrl as AiController
+    participant JobSvc as JobService
+    participant FS as Firestore ai_jobs
+    participant Hand as AgentLoopHandler
+    participant Loop as AgentLoopService
+    App->>Ctrl: POST /v1/ai/command/cancel with job_id, device_id
+    Ctrl->>JobSvc: cancel with userId, jobId
+    JobSvc->>FS: load jobId
+    Note over JobSvc: 미존재 404, job.userId 불일치 403
+    JobSvc->>FS: tx — PENDING to CANCELED, or RUNNING set cancelRequested, else no-op
+    JobSvc-->>Ctrl: transitioned boolean
+    Ctrl-->>App: 202 Accepted (fire-and-forget)
+    Note over App: GET /jobs/:id 로 최종 상태 재폴링
+    opt RUNNING 이었던 경우
+        Loop->>JobSvc: isCancelRequested(jobId) — 매 turn top
+        JobSvc->>FS: read cancelRequested
+        Loop->>Hand: AiJobResult.canceled (부분 mutation 첨부)
+        Hand->>FS: completeWith RUNNING to CANCELED
+        Hand->>App: FCM (CANCELED)
+    end
+```
+
+cancel 과 trigger 의 race 도 안전하다 — PENDING 중지는 trigger 의 `PENDING→RUNNING` 과 같은 source 를 다투지만 CAS 라 한쪽만 이긴다 (cancel 이 이기면 loop 미진입, trigger 가 이기면 RUNNING 경로로 넘어가 flag 기반 협조 종결). handler 의 `RUNNING→CANCELED` 종결은 `completeWith` CAS 가 보장.
+
+---
+
 ## 시퀀스: GET /v1/ai/usage
 
 ```mermaid
@@ -296,11 +335,12 @@ Content-Type: application/json
 
 ```
 PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
-                                       ├─▶ CONFIRM ──(POST /command/reject)──▶ REJECTED
-                                       └─▶ FAILED
+   │                          │        ├─▶ CONFIRM ──(POST /command/reject)──▶ REJECTED
+   │                          │        └─▶ FAILED
+   └──(POST /command/cancel)──┴─▶ CANCELED   ◀──(POST /command/cancel: RUNNING 협조 종결)
 ```
 
-`status` 가 terminal (`DONE` / `CONFIRM` / `FAILED` / `REJECTED`) 이면 `result` 필드에 `AiJobResult` 가 박혀 있다. `REJECTED` 는 거부된 `CONFIRM` 의 `result` (= `type: CONFIRM`, `action` 포함) 를 **그대로 보존**한다 — 무엇을 거부했는지 추적용. 따라서 **상태 판단은 `status` 필드 기준** (`result.type` 아님).
+`status` 가 terminal (`DONE` / `CONFIRM` / `FAILED` / `REJECTED` / `CANCELED`) 이면 `result` 필드에 `AiJobResult` 가 박혀 있다. `REJECTED` 는 거부된 `CONFIRM` 의 `result` (= `type: CONFIRM`, `action` 포함) 를 **그대로 보존**한다 — 무엇을 거부했는지 추적용. `CANCELED` 는 `result.type: CANCELED` + 중지 시점까지의 부분 `mutations` (단, PENDING 중지면 `result` 없이 status 만 `CANCELED`). 따라서 **상태 판단은 `status` 필드 기준** (`result.type` 아님).
 
 ### `AiJobResult` 응답 형태
 
@@ -342,6 +382,15 @@ PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
 }
 ```
 
+**CANCELED** — 사용자 중지 (#250). 오류가 아니라 의도된 중지라 `errorCode` 없음. PENDING 중지면 `result` 자체가 없을 수 있음 (status 만 `CANCELED`):
+```json
+{
+  "type": "CANCELED",
+  "text": "요청을 중지했어요.",
+  "mutations": [{ "dataType": "todo", "op": "created" }]
+}
+```
+
 ### 클라 처리 패턴
 
 | `type` | 클라가 할 일 |
@@ -349,6 +398,7 @@ PENDING ──(trigger 발화)──▶ RUNNING ──┬─▶ DONE
 | `DONE` | `text` 사용자에게 표시 (toast / chat 등). **`mutations` 보고 영향받은 도메인 list/cache invalidate**. |
 | `CONFIRM` | `text` 로 confirm UI 표시. **승인 시** `action` 통째로 2차 호출 body 에 박아 `POST /v1/ai/command/confirm` 호출 (`action.parentJobId` 는 body 의 `parent_job_id` 자리로). **거부 시** `action.parentJobId` 를 `job_id` 로 담아 `POST /v1/ai/command/reject` fire-and-forget 호출 (아래 "거부 호출" 참고). 1차 응답에 `mutations` 가 박혀 있을 수 있음 (이전 turn 의 변경) → list reload. |
 | `FAILED` | `reason` 사용자에게 표시. **`errorCode` 보고 분류 / 다른 UX 분기**. `mutations` 도 박혀 있을 수 있음 (부분 mutation) → reload. |
+| `CANCELED` | 중지 완료 UI. **`mutations` 가 있으면** 중지 시점까지 일어난 부분 변경 → 해당 도메인 reload + "일부 작업은 반영됐어요" 안내 가능. PENDING 중지면 `mutations` 없음. |
 
 ### 2차 호출 — CONFIRM 확인 후
 
@@ -397,6 +447,28 @@ Content-Type: application/json
 - **`device_id` 헤더 필수** — 빠지면 `400` 이고 거부 처리가 안 돼 job 이 `CONFIRM` 으로 남는다. fire-and-forget 이라 클라가 `400` 을 못 보니 반드시 포함.
 - 처리 후 해당 job 의 `status` 가 `REJECTED` 로 바뀐다. 히스토리·재진입 등으로 다시 조회하면 `status: REJECTED` + 거부한 `action` 이 보존된 `result` 가 보인다.
 
+### 중지 호출 — 진행 중 작업 중지 시 (#250)
+
+사용자가 진행 중인 작업의 **중지 (취소)** 를 누르면 호출. reject (confirm 거부) 와 동선이 다른 별개 액션 — `RUNNING`/`PENDING` 인 job 을 대상으로 한다 (보통 1차 command jobId).
+
+```http
+POST /v1/ai/command/cancel
+Authorization: Bearer <Firebase ID token>
+device_id: <device id>
+Content-Type: application/json
+
+{
+  "job_id": "<중지할 job 의 jobId>"
+}
+```
+
+응답: `202 Accepted`.
+
+- **fire-and-forget** — 응답을 기다리지 말고 즉시 중지 UI 로 전환. 최종 상태는 `GET /jobs/:id` (또는 Firestore listen) 로 `CANCELED` 확인. 서버가 멱등 처리라 중복 호출·재탭 모두 안전.
+- **`device_id` 헤더 필수** — 빠지면 `400`. fire-and-forget 이라 클라가 `400` 을 못 보니 반드시 포함.
+- **즉시 중지 아님** — `RUNNING` 이면 진행 중인 Claude 호출/tool 한 건은 못 끊고 turn 사이에만 멈춘다. 그래서 중지 요청 후에도 짧게는 작업이 더 진행될 수 있고, **중지 시점까지 일어난 변경은 `result.mutations` 에 남는다** (롤백 없음) → 그 도메인 reload + "일부 반영됨" 안내 가능.
+- 이미 `CONFIRM`/terminal 인 job 에 호출하면 no-op (상태 그대로) — 그래도 `202`.
+
 도메인 별 reload 결정에 사용. `dataType` × `op` 매핑:
 
 | `dataType` | 영향받는 컬렉션 |
@@ -438,7 +510,7 @@ Content-Type: application/json
 ```
 
 - `notification.{title,body}` — 1차 응답의 `result.notification` (있으면) 또는 lang 별 fallback.
-- `data.status` — `DONE` / `CONFIRM` / `FAILED` 중 하나. 클라가 tap 시 → `ai_jobs/{jobId}` doc 으로 결과 fetch.
+- `data.status` — `DONE` / `CONFIRM` / `FAILED` / `CANCELED` 중 하나. 클라가 tap 시 → `ai_jobs/{jobId}` doc 으로 결과 fetch. (`CANCELED` 는 RUNNING 협조 종결 시에만 발송 — PENDING 중지는 loop 미진입이라 FCM 없음.)
 - 페이로드에 민감 정보 없음 — text / args / token 등 일체 미포함.
 
 ### `GET /v1/ai/usage` — 오늘 사용량 조회

--- a/functions/controllers/ai/aiController.js
+++ b/functions/controllers/ai/aiController.js
@@ -129,6 +129,27 @@ class AiController {
         res.status(204).send();
     }
 
+    async postCommandCancel(req, res) {
+        const deviceId = req.header('device_id');
+        if (!deviceId) {
+            throw new Errors.BadRequest('device_id header is required');
+        }
+
+        // cancel path body:
+        //  - job_id: 중지할 진행 중(PENDING/RUNNING) job 의 jobId. reject 와 동선이 다른
+        //    별개 액션 — confirm 거부가 아니라 "지금 돌아가는 거 중지".
+        const jobId = req.body.job_id;
+        if (!jobId || typeof jobId !== 'string') {
+            throw new Errors.BadRequest('job_id is required');
+        }
+
+        const userId = req.auth.uid;
+        // 클라가 fire-and-forget 으로 호출. RUNNING 은 협조적으로 비동기 종결되고
+        // 클라는 GET /jobs/:id 로 최종 상태를 재폴링하므로 202 Accepted (전이/no-op 무관).
+        await this.jobService.cancel({ userId, jobId });
+        res.status(202).send();
+    }
+
     async getUsage(req, res) {
         const userId = req.auth.uid;
         const [usage, dailyLimit] = await Promise.all([

--- a/functions/models/ai/AiJob.js
+++ b/functions/models/ai/AiJob.js
@@ -69,19 +69,25 @@ class AiJob {
         return status === AiJob.STATUS.DONE ||
                status === AiJob.STATUS.CONFIRM ||
                status === AiJob.STATUS.FAILED ||
-               status === AiJob.STATUS.REJECTED;
+               status === AiJob.STATUS.REJECTED ||
+               status === AiJob.STATUS.CANCELED;
     }
 }
 
 // REJECTED: confirm 대기(CONFIRM) job 을 사용자가 미동의(거부)로 종결시킨 상태 (#243).
 //           confirm 2차 호출(processConfirmCommand) 의 거부 짝 — 데이터 mutation 없음.
+// CANCELED: 진행 중인 작업을 사용자가 중지시킨 상태 (#250). PENDING 이면 loop 진입 전
+//           즉시 종결, RUNNING 이면 loop 가 턴 사이 cancelRequested 를 보고 협조적 종결.
+//           REJECTED(confirm 거부)와 동선이 다른 별개 상태 — 중지 시점까지 일어난
+//           부분 mutation 은 result 에 보존(롤백 X).
 AiJob.STATUS = Object.freeze({
     PENDING: 'PENDING',
     RUNNING: 'RUNNING',
     DONE: 'DONE',
     CONFIRM: 'CONFIRM',
     FAILED: 'FAILED',
-    REJECTED: 'REJECTED'
+    REJECTED: 'REJECTED',
+    CANCELED: 'CANCELED'
 });
 
 // 'command': 자연어 명령 (1차) — Agent Loop run() 진입

--- a/functions/models/ai/AiJobResult.js
+++ b/functions/models/ai/AiJobResult.js
@@ -70,6 +70,26 @@ const AiJobResult = {
     },
 
     /**
+     * #250 — 진행 중인 작업이 사용자 중지로 종결될 때의 결과.
+     * mutations 에 중지 시점까지 일어난 부분 mutation 을 실어 클라가 "일부 반영됨" 을
+     * 표시할 수 있게 한다 (롤백 없음). errorCode 없음 — 오류가 아니라 사용자 의도.
+     *
+     * @param {string} text  사용자 노출 텍스트 (lang-aware)
+     * @param {{ title: string, body: string } | null | undefined} notification
+     * @param {Array<{dataType: string, op: string}> | undefined} mutations
+     * @returns {object}
+     */
+    canceled(text, notification, mutations) {
+        const n = sanitizeNotification(notification);
+        return {
+            type: 'CANCELED',
+            text,
+            ...(n ? { notification: n } : {}),
+            mutations: mutations ?? []
+        };
+    },
+
+    /**
      * result 에 실제로 사용 가능한 notification 이 있는지 판별.
      * title 과 body 가 모두 non-empty string 이어야 true.
      * trigger 가 push notification fallback 분기에 사용.

--- a/functions/repositories/ai/jobRepository.js
+++ b/functions/repositories/ai/jobRepository.js
@@ -108,6 +108,54 @@ class JobRepository {
             return true;
         });
     }
+
+    /**
+     * 사용자 중지 (#250). transaction 으로 현재 status 를 읽어 atomic 분기.
+     * - PENDING → CANCELED 즉시 전이. 이후 onCreate trigger 의 transitionToRunning CAS
+     *   가 status !== PENDING 으로 false → agent loop 진입 차단.
+     * - RUNNING → status 는 유지하고 cancelRequested 만 true 로 set. loop 가 턴 사이
+     *   isCancelRequested 로 읽어 협조적으로 CANCELED 종결 (completeWith).
+     * - 그 외(CONFIRM/terminal) → no-op false (멱등).
+     *
+     * @param {string} jobId
+     * @returns {boolean} 전이 또는 flag set 이 실제로 일어났는지 여부
+     */
+    async cancel(jobId) {
+        const docRef = collectionRef.doc(jobId);
+        return db.runTransaction(async (tx) => {
+            const snapshot = await tx.get(docRef);
+            if (!snapshot.exists) return false;
+            const status = snapshot.data().status;
+            if (status === AiJob.STATUS.PENDING) {
+                tx.update(docRef, {
+                    status: AiJob.STATUS.CANCELED,
+                    updatedAt: FieldValue.serverTimestamp()
+                });
+                return true;
+            }
+            if (status === AiJob.STATUS.RUNNING) {
+                tx.update(docRef, {
+                    cancelRequested: true,
+                    updatedAt: FieldValue.serverTimestamp()
+                });
+                return true;
+            }
+            return false;
+        });
+    }
+
+    /**
+     * cancelRequested flag 조회 (#250). RUNNING loop 의 협조적 cancel 체크포인트가 매 턴
+     * 호출 — 가벼운 단일 doc read. 없는 doc / 미설정이면 false.
+     *
+     * @param {string} jobId
+     * @returns {boolean}
+     */
+    async isCancelRequested(jobId) {
+        const snapshot = await collectionRef.doc(jobId).get();
+        if (!snapshot.exists) return false;
+        return snapshot.data().cancelRequested === true;
+    }
 }
 
 module.exports = JobRepository;

--- a/functions/routes/ai/aiRoutes.js
+++ b/functions/routes/ai/aiRoutes.js
@@ -16,6 +16,7 @@ const router = express.Router();
 router.post('/command', (req, res) => controller.postCommand(req, res));
 router.post('/command/confirm', (req, res) => controller.postCommandConfirm(req, res));
 router.post('/command/reject', (req, res) => controller.postCommandReject(req, res));
+router.post('/command/cancel', (req, res) => controller.postCommandCancel(req, res));
 router.get('/jobs/:id', (req, res) => controller.getJob(req, res));
 router.get('/usage', (req, res) => controller.getUsage(req, res));
 

--- a/functions/services/ai/agentLoopService.js
+++ b/functions/services/ai/agentLoopService.js
@@ -91,7 +91,8 @@ const MESSAGES = Object.freeze({
         confirmArgsMismatch: '확인 정보가 일치하지 않아요. 처음부터 다시 시도해 주세요.',
         confirmDone: '요청하신 작업을 완료했어요.',
         dailyLimitExceeded: '오늘 사용 가능한 한도를 모두 사용했어요. 내일 다시 시도해 주세요.',
-        timeout: '응답이 너무 오래 걸려 처리를 중단했어요. 잠시 후 다시 시도해 주세요.'
+        timeout: '응답이 너무 오래 걸려 처리를 중단했어요. 잠시 후 다시 시도해 주세요.',
+        canceled: '요청을 중지했어요.'
     }),
     en: Object.freeze({
         internalError: 'Something went wrong. Please try again.',
@@ -103,7 +104,8 @@ const MESSAGES = Object.freeze({
         confirmArgsMismatch: "Confirmation details don't match. Please start over.",
         confirmDone: 'Done',
         dailyLimitExceeded: "You've reached today's usage limit. Please try again tomorrow.",
-        timeout: 'The request took too long and was canceled. Please try again later.'
+        timeout: 'The request took too long and was canceled. Please try again later.',
+        canceled: 'The request was canceled.'
     })
 });
 
@@ -275,8 +277,14 @@ class AgentLoopService {
      *          throw 경로는 catch 안 함 → caller 가 0/0 으로 처리 (acceptable loss).
      *
      * jobId 는 CONFIRM 종결 시 result.action.parentJobId 로 박는 용도 (#238).
+     *
+     * cancelChecker (#250) — 매 turn top 에서 await 호출하는 협조적 cancel 체크포인트.
+     * true 면 다음 Claude 호출 전에 CANCELED 로 종결한다 (turn 사이에만 멈춤 — 진행
+     * 중인 Claude 호출/tool 한 건은 못 끊음). 미주입이면 기존 흐름 그대로. handler 가
+     * `() => jobService.isCancelRequested(jobId)` 로 주입 — agentLoopService 는 job
+     * 저장소를 모름 (dependency inversion).
      */
-    async run(commandText, { userId, timezone, lang, jobId }) {
+    async run(commandText, { userId, timezone, lang, jobId, cancelChecker }) {
         const auth = { userId, scopes: this.scopes };
         const messages = [{ role: 'user', content: commandText }];
         const resolvedLang = lang ?? 'en';
@@ -289,6 +297,7 @@ class AgentLoopService {
             return { result, usage: { inputTokens: tokens.input, outputTokens: tokens.output } };
         };
         const timeoutResult = () => AiJobResult.failed(_msg(resolvedLang, 'timeout'), undefined, undefined, AiErrorCode.Timeout);
+        const canceledResult = () => AiJobResult.canceled(_msg(resolvedLang, 'canceled'));
 
         const ac = new AbortController();
         const budgetTimer = setTimeout(() => ac.abort(), this.budgetMs);
@@ -300,6 +309,8 @@ class AgentLoopService {
 
             for (let iter = 0; iter < this.loopCap; iter++) {
                 if (ac.signal.aborted) return finish(timeoutResult());
+                // 사용자 중지 — 다음 Claude 호출 전에 종결. 누적 mutations 는 finish 가 첨부.
+                if (cancelChecker && await cancelChecker()) return finish(canceledResult());
 
                 _markLastMessageForCache(messages);
                 let resp;

--- a/functions/services/ai/jobService.js
+++ b/functions/services/ai/jobService.js
@@ -206,6 +206,49 @@ class JobService {
         }
         return this.jobRepository.rejectConfirm(jobId);
     }
+
+    /**
+     * #250 — 진행 중인 작업을 사용자가 중지. rejectConfirm(confirm 거부)과 동선이 다른
+     * 별개 액션 — 대상은 아직 진행 중인 PENDING/RUNNING job.
+     *
+     * 상태별 처리는 repository.cancel 이 atomic 하게 분기:
+     * - PENDING → CANCELED 즉시 전이 (trigger 의 transitionToRunning CAS 가 false 가 돼
+     *   agent loop 진입 차단).
+     * - RUNNING → cancelRequested flag 만 set. status 는 직접 건드리지 않고, loop 가 턴
+     *   사이 isCancelRequested 를 보고 협조적으로 CANCELED 로 종결 (중지 시점까지의 부분
+     *   mutation 은 result 에 보존).
+     * - CONFIRM / terminal → no-op false.
+     *
+     * - job 미존재 → NotFound
+     * - job.userId !== userId → 403 (타인 job 중지 차단)
+     *
+     * 멱등성: 이미 CANCELED / terminal 이면 전이 없이 false. 클라가 fire-and-forget 으로
+     * 호출하므로 중복·경합 호출도 throw 없이 안전.
+     *
+     * @param {{ userId: string, jobId: string }} params
+     * @returns {Promise<boolean>} 전이 또는 cancelRequested set 이 실제로 일어났는지 여부
+     */
+    async cancel({ userId, jobId }) {
+        const job = await this.jobRepository.load(jobId);
+        if (!job) {
+            throw new Errors.NotFound('job not found');
+        }
+        if (job.userId !== userId) {
+            throw new Errors.Base(403, 'Forbidden', 'forbidden');
+        }
+        return this.jobRepository.cancel(jobId);
+    }
+
+    /**
+     * #250 — RUNNING job 에 cancelRequested flag 가 세워졌는지 조회.
+     * agent loop 의 협조적 cancel 체크포인트(턴 사이)가 호출.
+     *
+     * @param {string} jobId
+     * @returns {Promise<boolean>}
+     */
+    async isCancelRequested(jobId) {
+        return this.jobRepository.isCancelRequested(jobId);
+    }
 }
 
 module.exports = JobService;

--- a/functions/test/controllers/ai/aiController.test.js
+++ b/functions/test/controllers/ai/aiController.test.js
@@ -390,6 +390,71 @@ describe('AiController', () => {
     });
 
 
+    // MARK: - postCommandCancel (#250)
+
+    describe('postCommandCancel', () => {
+
+        function makeCancelReq({ uid = 'user-1', deviceId = 'device-1', jobId = 'job-123' } = {}) {
+            return {
+                auth: { uid },
+                header: (name) => {
+                    if (name === 'device_id') return deviceId;
+                    return null;
+                },
+                body: { job_id: jobId }
+            };
+        }
+
+        it('정상 — 202 (본문 없음), cancel 에 userId + jobId 전달', async () => {
+            const req = makeCancelReq();
+            const res = makeRes();
+
+            await controller.postCommandCancel(req, res);
+
+            assert.equal(res.statusCode, 202);
+            assert.deepEqual(stubService.lastCancelArgs, { userId: 'user-1', jobId: 'job-123' });
+        });
+
+        it('전이가 안 일어나도(cancel=false, 이미 종결/CONFIRM) 202 — fire-and-forget 멱등', async () => {
+            stubService.cancelResult = false;
+            const req = makeCancelReq();
+            const res = makeRes();
+
+            await controller.postCommandCancel(req, res);
+
+            assert.equal(res.statusCode, 202);
+        });
+
+        it('device_id 헤더 누락 → 400', async () => {
+            const req = makeCancelReq({ deviceId: null });
+            await assert.rejects(() => controller.postCommandCancel(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('job_id 누락 → 400', async () => {
+            const req = makeCancelReq();
+            delete req.body.job_id;
+            await assert.rejects(() => controller.postCommandCancel(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('job_id 빈 문자열 → 400', async () => {
+            const req = makeCancelReq({ jobId: '' });
+            await assert.rejects(() => controller.postCommandCancel(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('job_id 가 비문자열 → 400', async () => {
+            const req = makeCancelReq();
+            req.body.job_id = 123;
+            await assert.rejects(() => controller.postCommandCancel(req, makeRes()), Errors.BadRequest);
+        });
+
+        it('서비스가 NotFound/403 throw → 그대로 전파', async () => {
+            stubService.shouldFail = true;
+            const req = makeCancelReq();
+            await assert.rejects(() => controller.postCommandCancel(req, makeRes()));
+        });
+    });
+
+
     // MARK: - getJob
 
     describe('getJob', () => {

--- a/functions/test/doubles/stubAiJobRepository.js
+++ b/functions/test/doubles/stubAiJobRepository.js
@@ -25,6 +25,7 @@ class StubAiJobRepository {
         this.lastPutPayload = null;       // { jobId, data }
         this.lastTransitionAttempt = null; // jobId (most recent call)
         this.lastRejectAttempt = null;     // jobId (most recent rejectConfirm call)
+        this.lastCancelAttempt = null;     // jobId (most recent cancel call)
     }
 
     /**
@@ -118,6 +119,43 @@ class StubAiJobRepository {
         }
         data.status = AiJob.STATUS.REJECTED;
         return true;
+    }
+
+    /**
+     * 사용자 중지 (#250, Compare-And-Swap 시뮬레이션).
+     * - PENDING → CANCELED 즉시 전이 (loop 진입 전 종결).
+     * - RUNNING → cancelRequested flag 만 set (loop 가 협조적으로 종결).
+     * - 그 외(CONFIRM/terminal) → no-op false.
+     *
+     * lastCancelAttempt 에 jobId 를 기록한다.
+     *
+     * @param {string} jobId
+     * @returns {Promise<boolean>} 전이 또는 flag set 이 실제로 일어났는지 여부
+     */
+    async cancel(jobId) {
+        this.lastCancelAttempt = jobId;
+        const data = this._store.get(jobId);
+        if (!data) return false;
+        if (data.status === AiJob.STATUS.PENDING) {
+            data.status = AiJob.STATUS.CANCELED;
+            return true;
+        }
+        if (data.status === AiJob.STATUS.RUNNING) {
+            data.cancelRequested = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * cancelRequested flag 조회 (#250). RUNNING loop 의 협조적 cancel 체크포인트가 사용.
+     *
+     * @param {string} jobId
+     * @returns {Promise<boolean>}
+     */
+    async isCancelRequested(jobId) {
+        const data = this._store.get(jobId);
+        return !!(data && data.cancelRequested === true);
     }
 }
 

--- a/functions/test/doubles/stubAiJobService.js
+++ b/functions/test/doubles/stubAiJobService.js
@@ -11,6 +11,8 @@ class StubAiJobService {
         this.lastCreateConfirmJobArgs = null;
         this.lastRejectConfirmArgs = null;
         this.rejectConfirmResult = true;
+        this.lastCancelArgs = null;
+        this.cancelResult = true;
         this._jobs = {};
         this._nextJobId = 'job-123';
     }
@@ -35,6 +37,12 @@ class StubAiJobService {
         if (this.shouldFail) throw { message: 'service failed' };
         this.lastRejectConfirmArgs = { userId, jobId };
         return this.rejectConfirmResult;
+    }
+
+    async cancel({ userId, jobId }) {
+        if (this.shouldFail) throw { message: 'service failed' };
+        this.lastCancelArgs = { userId, jobId };
+        return this.cancelResult;
     }
 
     async loadJob(jobId) {

--- a/functions/test/e2e/ai-cancel.e2e.js
+++ b/functions/test/e2e/ai-cancel.e2e.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const assert = require('assert');
+
+const { authedClient } = require('./helpers/request');
+
+// 진행 중 작업 중지 (#250). reject 와 별개 엔드포인트.
+//
+// RUNNING 협조 중지의 mid-loop 타이밍은 stub anthropic 이 즉답이라 emulator 에서
+// deterministic 하게 못 잡는다 (협조 로직은 단위 테스트가 커버). 여기서는 라우트
+// 배선·검증·소유권·terminal no-op 멱등만 deterministic 하게 검증.
+
+async function pollJob(client, jobId, { timeoutMs = 8000, intervalMs = 100 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const res = await client.get(`/v1/ai/jobs/${jobId}`);
+        if (res.status === 200 && ['DONE', 'CONFIRM', 'FAILED', 'REJECTED', 'CANCELED'].includes(res.data.status)) {
+            return res.data;
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error(`pollJob timeout (${timeoutMs}ms) — jobId: ${jobId}`);
+}
+
+describe('aiFrontAPI cancel (진행 중 작업 중지)', function () {
+
+    let client;
+
+    before(function () {
+        client = authedClient();
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    describe('POST /v1/ai/command/cancel — body validation', function () {
+
+        it('job_id 누락 → 400', async function () {
+            const res = await client.post(
+                '/v1/ai/command/cancel',
+                {},
+                { headers: { device_id: 'e2e-device-cancel' } }
+            );
+            assert.strictEqual(res.status, 400);
+        });
+
+        it('device_id 헤더 누락 → 400', async function () {
+            const res = await client.post(
+                '/v1/ai/command/cancel',
+                { job_id: 'whatever' }
+            );
+            assert.strictEqual(res.status, 400);
+        });
+
+        it('존재하지 않는 job_id → 404', async function () {
+            const res = await client.post(
+                '/v1/ai/command/cancel',
+                { job_id: 'no-such-job' },
+                { headers: { device_id: 'e2e-device-cancel' } }
+            );
+            assert.strictEqual(res.status, 404);
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    describe('terminal no-op — 이미 DONE 인 job 중지는 202 + 상태 보존 (멱등)', function () {
+
+        let jobId;
+
+        it('명령 → DONE 종결까지 대기', async function () {
+            this.timeout(15000);
+
+            const cmdRes = await client.post(
+                '/v1/ai/command',
+                { command_text: '오늘 할일 보여줘', timezone: 'Asia/Seoul' },
+                { headers: { device_id: 'e2e-device-cancel' } }
+            );
+            assert.strictEqual(cmdRes.status, 202);
+            jobId = cmdRes.data.job_id;
+
+            const job = await pollJob(client, jobId);
+            assert.strictEqual(job.status, 'DONE');
+        });
+
+        it('cancel 호출 → 202, 상태는 DONE 그대로 (no-op)', async function () {
+            this.timeout(15000);
+
+            const cancelRes = await client.post(
+                '/v1/ai/command/cancel',
+                { job_id: jobId },
+                { headers: { device_id: 'e2e-device-cancel' } }
+            );
+            assert.strictEqual(cancelRes.status, 202);
+
+            const job = (await client.get(`/v1/ai/jobs/${jobId}`)).data;
+            assert.strictEqual(job.status, 'DONE', 'terminal job 은 중지로 안 바뀜');
+        });
+
+        it('중복 cancel → 여전히 202, DONE 유지 (멱등)', async function () {
+            this.timeout(15000);
+
+            const again = await client.post(
+                '/v1/ai/command/cancel',
+                { job_id: jobId },
+                { headers: { device_id: 'e2e-device-cancel' } }
+            );
+            assert.strictEqual(again.status, 202);
+
+            const job = (await client.get(`/v1/ai/jobs/${jobId}`)).data;
+            assert.strictEqual(job.status, 'DONE');
+        });
+    });
+});

--- a/functions/test/models/ai/AiJob.test.js
+++ b/functions/test/models/ai/AiJob.test.js
@@ -5,13 +5,14 @@ const AiJob = require('../../../models/ai/AiJob');
 describe('AiJob', () => {
 
     describe('STATUS enum', () => {
-        it('6개 상태 상수가 모두 존재함', () => {
+        it('7개 상태 상수가 모두 존재함', () => {
             assert.strictEqual(AiJob.STATUS.PENDING, 'PENDING');
             assert.strictEqual(AiJob.STATUS.RUNNING, 'RUNNING');
             assert.strictEqual(AiJob.STATUS.DONE, 'DONE');
             assert.strictEqual(AiJob.STATUS.CONFIRM, 'CONFIRM');
             assert.strictEqual(AiJob.STATUS.FAILED, 'FAILED');
             assert.strictEqual(AiJob.STATUS.REJECTED, 'REJECTED');
+            assert.strictEqual(AiJob.STATUS.CANCELED, 'CANCELED');
         });
     });
 
@@ -37,6 +38,10 @@ describe('AiJob', () => {
 
         it('REJECTED 는 terminal', () => {
             assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.REJECTED), true);
+        });
+
+        it('CANCELED 는 terminal', () => {
+            assert.strictEqual(AiJob.isTerminal(AiJob.STATUS.CANCELED), true);
         });
 
         it('PENDING 은 terminal 아님', () => {

--- a/functions/test/models/ai/AiJobResult.test.js
+++ b/functions/test/models/ai/AiJobResult.test.js
@@ -19,6 +19,11 @@ describe('AiJobResult', () => {
             const result = AiJobResult.failed('reason');
             assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
         });
+
+        it('canceled() 이 plain object 를 반환', () => {
+            const result = AiJobResult.canceled('중지됨');
+            assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+        });
     });
 
     describe('done()', () => {
@@ -85,6 +90,38 @@ describe('AiJobResult', () => {
         it('notification null 이면 포함 안 됨', () => {
             const result = AiJobResult.failed('오류', null);
             assert.strictEqual(result.notification, undefined);
+        });
+    });
+
+    describe('canceled()', () => {
+        it('notification 없이 생성 — type CANCELED', () => {
+            const result = AiJobResult.canceled('요청을 중지했어요.');
+            assert.strictEqual(result.type, 'CANCELED');
+            assert.strictEqual(result.text, '요청을 중지했어요.');
+            assert.strictEqual(result.notification, undefined);
+        });
+
+        it('notification 있으면 포함', () => {
+            const notification = { title: '중지됨', body: '요청을 중지했어요' };
+            const result = AiJobResult.canceled('중지', notification);
+            assert.strictEqual(result.type, 'CANCELED');
+            assert.deepStrictEqual(result.notification, notification);
+        });
+
+        it('notification null 이면 포함 안 됨', () => {
+            const result = AiJobResult.canceled('중지', null);
+            assert.strictEqual(result.notification, undefined);
+        });
+
+        it('mutations 전달 시 그대로 노출 (중지 시점까지 일어난 부분 mutation)', () => {
+            const m = [{ dataType: 'todo', op: 'created' }];
+            const result = AiJobResult.canceled('중지', null, m);
+            assert.deepStrictEqual(result.mutations, m);
+        });
+
+        it('mutations 미지정 시 빈 array', () => {
+            const result = AiJobResult.canceled('중지');
+            assert.deepStrictEqual(result.mutations, []);
         });
     });
 

--- a/functions/test/services/ai/agentLoopService.test.js
+++ b/functions/test/services/ai/agentLoopService.test.js
@@ -763,6 +763,66 @@ describe('AgentLoopService', () => {
         });
     });
 
+    // ─── 협조적 cancel (#250) ──────────────────────────────────────────────────
+    //
+    // context.cancelChecker — 매 turn top 에서 await 호출. true 면 다음 Claude 호출
+    // 전에 CANCELED 로 종결. 진행 중인 호출/tool 은 못 끊고 turn 사이에만 멈춘다.
+    // 중지 시점까지의 mutations 는 finish 가 첨부.
+
+    describe('cancel 협조적 중지 (#250)', () => {
+
+        it('cancelChecker 가 첫 체크에서 true — Claude 호출 없이 CANCELED 종결 (ko 메시지)', async () => {
+            const { service, anthropic } = makeService();
+            anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '완료' }));
+
+            const { result } = await service.run('회의 추가', {
+                userId: 'u1', timezone: 'Asia/Seoul', lang: 'ko',
+                cancelChecker: async () => true
+            });
+
+            assert.strictEqual(result.type, 'CANCELED');
+            assert.strictEqual(result.text, '요청을 중지했어요.');
+            assert.strictEqual(anthropic.allCreateMessageArgs.length, 0, 'Claude 호출 0회');
+            assert.deepStrictEqual(result.mutations, []);
+        });
+
+        it('한 turn mutation 후 cancel — 다음 turn 전 CANCELED + 부분 mutation 보존', async () => {
+            const { service, anthropic, registry } = makeService();
+            registry.registerExecute('create_todo', { uuid: 't1' });
+            anthropic.enqueue(makeToolUseResponse('create_todo', { name: '회의' }));
+            anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '완료' })); // 소비되면 안 됨
+
+            let checks = 0;
+            const { result } = await service.run('회의 추가', {
+                userId: 'u1', timezone: 'Asia/Seoul',
+                cancelChecker: async () => (checks++ >= 1) // 1st turn false, 2nd turn true
+            });
+
+            assert.strictEqual(result.type, 'CANCELED');
+            assert.deepStrictEqual(result.mutations, [{ dataType: 'todo', op: 'created' }]);
+            assert.strictEqual(anthropic.allCreateMessageArgs.length, 1, '두 번째 turn 은 Claude 호출 안 함');
+        });
+
+        it('cancelChecker 미주입 — 기존 흐름 그대로 (정상 DONE)', async () => {
+            const { service, anthropic } = makeService();
+            anthropic.enqueue(makeToolUseResponse('finalize', { type: 'DONE', text: '완료' }));
+
+            const { result } = await service.run('할일 보여줘', { userId: 'u1', timezone: 'Asia/Seoul' });
+
+            assert.strictEqual(result.type, 'DONE');
+        });
+
+        it('lang=en — 영어 중지 메시지', async () => {
+            const { service } = makeService();
+            const { result } = await service.run('add todo', {
+                userId: 'u1', timezone: 'Asia/Seoul', lang: 'en',
+                cancelChecker: async () => true
+            });
+            assert.strictEqual(result.type, 'CANCELED');
+            assert.strictEqual(result.text, 'The request was canceled.');
+        });
+    });
+
     // ─── runConfirm (CONFIRM 2차 호출) ─────────────────────────────────────────
 
     describe('runConfirm', () => {

--- a/functions/test/services/ai/jobService.test.js
+++ b/functions/test/services/ai/jobService.test.js
@@ -493,4 +493,116 @@ describe('JobService', () => {
             assert.strictEqual(job.status, AiJob.STATUS.CONFIRM, '거부 실패 — CONFIRM 유지');
         });
     });
+
+    // ------------------------------------------------------------------ //
+    // cancel (#250)
+    // ------------------------------------------------------------------ //
+
+    describe('cancel', () => {
+
+        async function setupPendingJob(userId = 'u') {
+            return service.createJob({ userId, deviceId: 'd', commandText: '내일 일정 추가' });
+        }
+
+        async function setupRunningJob(userId = 'u') {
+            const jobId = await setupPendingJob(userId);
+            await service.transitionToRunning(jobId);
+            return jobId;
+        }
+
+        it('PENDING job → 즉시 CANCELED 로 전이하고 true 반환 (loop 진입 전 종결)', async () => {
+            const jobId = await setupPendingJob('u');
+
+            const result = await service.cancel({ userId: 'u', jobId });
+            assert.strictEqual(result, true);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.CANCELED);
+        });
+
+        it('RUNNING job → status 는 RUNNING 유지, cancelRequested 만 set + true 반환', async () => {
+            const jobId = await setupRunningJob('u');
+
+            const result = await service.cancel({ userId: 'u', jobId });
+            assert.strictEqual(result, true);
+
+            // 직접 종결시키지 않는다 — loop 가 협조적으로 CANCELED 로 종결.
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.RUNNING);
+            assert.strictEqual(await service.isCancelRequested(jobId), true);
+        });
+
+        it('CONFIRM 대기 job → no-op false (cancel 대상 아님, reject 가 처리)', async () => {
+            const jobId = await setupRunningJob('u');
+            await service.completeWith(jobId, AiJobResult.confirm('지울까요?', { tool: 'delete_todo', args: {}, confirmToken: 'tk' }));
+
+            const result = await service.cancel({ userId: 'u', jobId });
+            assert.strictEqual(result, false);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.CONFIRM, 'CONFIRM 유지');
+        });
+
+        it('terminal(DONE) job → no-op false (상태 보존)', async () => {
+            const jobId = await setupRunningJob('u');
+            await service.completeWith(jobId, AiJobResult.done('완료'));
+
+            const result = await service.cancel({ userId: 'u', jobId });
+            assert.strictEqual(result, false);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.DONE);
+        });
+
+        it('이미 CANCELED 인 job 재호출 → throw 없이 false (멱등)', async () => {
+            const jobId = await setupPendingJob('u');
+            await service.cancel({ userId: 'u', jobId });
+
+            const result = await service.cancel({ userId: 'u', jobId });
+            assert.strictEqual(result, false);
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.CANCELED);
+        });
+
+        it('존재하지 않는 jobId → NotFound', async () => {
+            await assert.rejects(
+                () => service.cancel({ userId: 'u', jobId: 'no-such-job' }),
+                (err) => err.status === 404
+            );
+        });
+
+        it('다른 user 의 job → 403 (전이 시도조차 안 함)', async () => {
+            const jobId = await setupRunningJob('owner');
+
+            await assert.rejects(
+                () => service.cancel({ userId: 'intruder', jobId }),
+                (err) => err.status === 403
+            );
+
+            const job = await service.loadJob(jobId);
+            assert.strictEqual(job.status, AiJob.STATUS.RUNNING, '중지 실패 — RUNNING 유지');
+            assert.strictEqual(await service.isCancelRequested(jobId), false);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // isCancelRequested (#250) — agent loop 의 협조적 cancel 체크포인트가 사용
+    // ------------------------------------------------------------------ //
+
+    describe('isCancelRequested', () => {
+
+        it('cancelRequested 가 set 되지 않은 job → false', async () => {
+            const jobId = await service.createJob({ userId: 'u', deviceId: 'd', commandText: 'cmd' });
+            await service.transitionToRunning(jobId);
+            assert.strictEqual(await service.isCancelRequested(jobId), false);
+        });
+
+        it('RUNNING 중 cancel 호출로 flag 가 set 되면 → true', async () => {
+            const jobId = await service.createJob({ userId: 'u', deviceId: 'd', commandText: 'cmd' });
+            await service.transitionToRunning(jobId);
+            await service.cancel({ userId: 'u', jobId });
+            assert.strictEqual(await service.isCancelRequested(jobId), true);
+        });
+    });
 });

--- a/functions/test/triggers/ai/agentLoopTrigger.test.js
+++ b/functions/test/triggers/ai/agentLoopTrigger.test.js
@@ -158,10 +158,33 @@ describe('AgentLoopHandler', () => {
         assert.strictEqual(payload.data.status, 'DONE');
 
         // handler 가 agentLoopService.run 에 commandText 와 {userId, timezone, lang, jobId} 을 정확히 전달하는지 검증 (재발 방지)
-        assert.deepStrictEqual(agentLoopService.lastRunArgs, {
-            commandText: BASE_JOB_DATA.commandText,
-            opts: { userId: BASE_JOB_DATA.userId, timezone: BASE_JOB_DATA.timezone, lang: BASE_JOB_DATA.lang, jobId: 'job-1' }
-        });
+        const { commandText, opts } = agentLoopService.lastRunArgs;
+        assert.strictEqual(commandText, BASE_JOB_DATA.commandText);
+        assert.strictEqual(opts.userId, BASE_JOB_DATA.userId);
+        assert.strictEqual(opts.timezone, BASE_JOB_DATA.timezone);
+        assert.strictEqual(opts.lang, BASE_JOB_DATA.lang);
+        assert.strictEqual(opts.jobId, 'job-1');
+        // #250 — 협조적 cancel 체크포인트 주입
+        assert.strictEqual(typeof opts.cancelChecker, 'function');
+    });
+
+    it('command dispatch — cancelChecker 가 jobService.isCancelRequested(jobId) 에 연결됨 (#250)', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo, makeAiUsageService());
+        const agentLoopService = makeAgentLoopService(AiJobResult.done('done'));
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        const checker = agentLoopService.lastRunArgs.opts.cancelChecker;
+        // flag 안 세워진 상태 → false
+        assert.strictEqual(await checker(), false);
+        // 올바른 jobId('job-1')에 바인딩됐는지 — 그 doc 에 flag set 하면 true 로 바뀜
+        repo._store.get('job-1').cancelRequested = true;
+        assert.strictEqual(await checker(), true);
     });
 
     it('정상 발화 — result.notification 있으면 그 값으로 FCM 발송', async () => {
@@ -266,6 +289,22 @@ describe('AgentLoopHandler', () => {
         assert.strictEqual(messaging.sendCalled, 1);
         assert.strictEqual(messaging.lastSendPayload.notification.title, FALLBACK_NOTIFICATION.ko.FAILED.title);
         assert.strictEqual(messaging.lastSendPayload.data.status, 'FAILED');
+    });
+
+    it('result.type 이 CANCELED 일 때 FCM 에 fallback CANCELED 카피 사용 (#250)', async () => {
+        const repo = seededRepo();
+        const jobService = new JobService(repo, makeAiUsageService());
+        const agentLoopService = makeAgentLoopService(AiJobResult.canceled('stub canceled')); // no notification
+        const messaging = makeMessaging();
+        const userRepo = makeUserRepository(BASE_DEVICE);
+        const { logger } = captureLogger();
+
+        const handler = makeHandler({ jobService, agentLoopService, userRepository: userRepo, messaging, logger });
+        await handler.handle(makeEvent('job-1', BASE_JOB_DATA));
+
+        assert.strictEqual(messaging.sendCalled, 1);
+        assert.strictEqual(messaging.lastSendPayload.notification.title, FALLBACK_NOTIFICATION.ko.CANCELED.title);
+        assert.strictEqual(messaging.lastSendPayload.data.status, 'CANCELED');
     });
 
     it('result.notification 의 title 이 빈 문자열이면 hasNotification false → fallback 사용', async () => {

--- a/functions/triggers/ai/agentLoopHandler.js
+++ b/functions/triggers/ai/agentLoopHandler.js
@@ -36,12 +36,14 @@ const FALLBACK_NOTIFICATION = Object.freeze({
     ko: Object.freeze({
         DONE: Object.freeze({ title: 'AI 작업이 완료됐어요', body: '탭해서 결과를 확인해 주세요' }),
         CONFIRM: Object.freeze({ title: '확인이 필요해요', body: '작업 전 확인이 필요해요' }),
-        FAILED: Object.freeze({ title: '처리에 실패했어요', body: '탭해서 자세히 확인해 주세요' })
+        FAILED: Object.freeze({ title: '처리에 실패했어요', body: '탭해서 자세히 확인해 주세요' }),
+        CANCELED: Object.freeze({ title: '요청을 중지했어요', body: '탭해서 결과를 확인해 주세요' })
     }),
     en: Object.freeze({
         DONE: Object.freeze({ title: 'AI command completed', body: 'Tap to view the result' }),
         CONFIRM: Object.freeze({ title: 'Confirmation required', body: 'Please confirm before proceeding' }),
-        FAILED: Object.freeze({ title: 'AI command failed', body: 'Tap to view the result' })
+        FAILED: Object.freeze({ title: 'AI command failed', body: 'Tap to view the result' }),
+        CANCELED: Object.freeze({ title: 'Request canceled', body: 'Tap to view the result' })
     })
 });
 
@@ -134,7 +136,10 @@ class AgentLoopHandler {
             userId: job.userId,
             timezone: job.timezone,
             lang: job.lang,
-            jobId: job.jobId
+            jobId: job.jobId,
+            // #250 — 협조적 cancel 체크포인트. loop 가 매 turn isCancelRequested 로 읽어
+            // 사용자 중지 시 CANCELED 로 종결. runConfirm(2차)은 단일 실행이라 미주입.
+            cancelChecker: () => this.jobService.isCancelRequested(job.jobId)
         });
     }
 


### PR DESCRIPTION
## 문제

진행 중인 AI 작업을 사용자가 중지할 수단이 없었다. 기존 timeout/cap 은 폭주 방지일 뿐 유저 의도의 중단이 아니고, `reject`(#243)는 confirm 거부 전용이라 동선이 다르다. → `reject` 와 별개로 `cancel` 추가 (흡수 X).

## 접근

진입점은 위임만, 상태 분기는 `jobService.cancel` 에 응집. 상태머신에 `CANCELED` terminal 상태를 추가하고 대상 상태에 따라 처리:

- `PENDING` → 즉시 `CANCELED`. trigger 의 `transitionToRunning` CAS 가 실패해 agent loop 진입 차단.
- `RUNNING` → `cancelRequested` flag 만 set. loop 가 매 turn top 에서 이를 읽어 협조적으로 `CANCELED` 종결. cross-instance 라 즉시 abort 는 불가 — 진행 중인 Claude 호출/tool 한 건은 못 끊고 **turn 사이에만** 멈춘다. 중지 시점까지의 부분 mutation 은 `result` 에 보존 (롤백 없음).
- `CONFIRM`/terminal → no-op.

`agentLoopService` 는 job 저장소를 모르게 유지 — handler 가 `cancelChecker` thunk 로 주입 (dependency inversion).

## 커밋 (레이어별 응집)

1. `cb2dc0c` — cancel 상태머신 (`CANCELED` + `AiJobResult.canceled` + `jobService.cancel`/`isCancelRequested` + repo CAS)
2. `edcdb92` — RUNNING agent loop 협조적 중지 (turn 사이 cancel 체크포인트 + handler 주입 + FCM fallback)
3. `39c52bf` — HTTP 엔드포인트 `POST /v1/ai/command/cancel` (202, fire-and-forget)
4. `e046bbd` — aiFront 스펙 반영 + e2e 검증

## 검증

- unit 1257 passing / 0 failing
- e2e `ai-cancel.e2e.js` 6/6 — 라우트 배선·body 검증(400)·미존재(404)·terminal no-op 멱등(202+상태 보존)

## 남은 과제

- **RUNNING mid-loop 협조 중지는 e2e 미검증** — stub anthropic 즉답이라 emulator 에서 mid-loop 타이밍을 deterministic 하게 못 잡음. 협조 로직 자체는 단위 테스트로 커버.
- iOS/웹 클라 "중지" 버튼 연동 (후속)

관련: #154 (agent loop), #243 (reject), #245 (FEATURE_AI dark)

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
